### PR TITLE
Add production resource limits and execution stats

### DIFF
--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -57,6 +57,7 @@ defmodule JustBash do
   alias JustBash.Fs.InMemoryFs
   alias JustBash.Interpreter.Executor
   alias JustBash.Interpreter.State
+  alias JustBash.Limit
   alias JustBash.Parser
   alias JustBash.Parser.Lexer
 
@@ -93,6 +94,7 @@ defmodule JustBash do
             databases: %{},
             max_iterations: 10_000,
             max_call_depth: 1_000,
+            limits: nil,
             jq_module_paths: [],
             interpreter: nil
 
@@ -128,6 +130,7 @@ defmodule JustBash do
           databases: map(),
           max_iterations: pos_integer(),
           max_call_depth: pos_integer(),
+          limits: Limit.t() | nil,
           jq_module_paths: [String.t()],
           interpreter: State.t()
         }
@@ -161,6 +164,9 @@ defmodule JustBash do
   - `:max_call_depth` - Maximum shell function call depth before recursion is
     forcibly stopped. Prevents unbounded recursion from consuming all available
     memory (default: 1_000)
+  - `:limits` - Resource limits for production safety. Accepts a preset atom
+    (`:default`, `:strict`, `:relaxed`), a keyword list of overrides, or `false`
+    to disable. Default: `:default`. See `JustBash.Limit` for available keys.
   - `:jq_module_paths` - List of virtual filesystem paths to search for `jq` modules
     when using `import`/`include` directives (default: [])
 
@@ -186,6 +192,7 @@ defmodule JustBash do
     http_client = Keyword.get(opts, :http_client)
     max_iterations = Keyword.get(opts, :max_iterations, 10_000)
     max_call_depth = Keyword.get(opts, :max_call_depth, 1_000)
+    limits = opts |> Keyword.get(:limits, :default) |> Limit.new()
     jq_module_paths = Keyword.get(opts, :jq_module_paths, [])
 
     default_env = %{
@@ -212,6 +219,7 @@ defmodule JustBash do
       http_client: http_client,
       max_iterations: max_iterations,
       max_call_depth: max_call_depth,
+      limits: limits,
       jq_module_paths: jq_module_paths,
       interpreter: State.new()
     }
@@ -332,6 +340,14 @@ defmodule JustBash do
   """
   @spec exec(t(), String.t()) :: {exec_result(), t()}
   def exec(bash, command) when is_binary(command) do
+    # Reset counters only for top-level exec (not nested eval/source)
+    bash =
+      if bash.interpreter.exec_depth == 0 do
+        %{bash | interpreter: State.reset_counters(bash.interpreter)}
+      else
+        bash
+      end
+
     JustBash.Telemetry.session_span(self(), fn ->
       case Parser.parse(command) do
         {:ok, ast} ->
@@ -390,6 +406,39 @@ defmodule JustBash do
             {result, bash}
         end
     end
+  end
+
+  @typedoc "Execution statistics from the most recent `exec/2` call."
+  @type stats :: %{
+          steps: non_neg_integer(),
+          output_bytes: non_neg_integer(),
+          max_exec_depth: non_neg_integer()
+        }
+
+  @doc """
+  Returns execution statistics from the most recent `exec/2` call.
+
+  Useful for observing computational cost without enforcing limits —
+  for example, as a reward signal in reinforcement learning to prefer
+  simpler programs.
+
+  Counters reset at the start of each top-level `exec/2` call, so
+  stats always reflect the most recent execution.
+
+  ## Examples
+
+      bash = JustBash.new()
+      {_result, bash} = JustBash.exec(bash, "for i in 1 2 3; do echo $i; done")
+      JustBash.stats(bash)
+      #=> %{steps: 12, output_bytes: 6, max_exec_depth: 1}
+  """
+  @spec stats(t()) :: stats()
+  def stats(%__MODULE__{interpreter: interp}) do
+    %{
+      steps: interp.step_count,
+      output_bytes: interp.output_bytes,
+      max_exec_depth: interp.max_exec_depth
+    }
   end
 
   @doc """

--- a/lib/just_bash/banned_call_tracer.ex
+++ b/lib/just_bash/banned_call_tracer.ex
@@ -92,7 +92,9 @@ defmodule JustBash.BannedCallTracer do
     {Process, :get, 0},
     {Process, :get, 1},
     {Process, :get, 2},
-    {Process, :delete, 1}
+    {Process, :delete, 1},
+    # Atom table exhaustion — atoms are never garbage collected
+    {String, :to_atom, 1}
   ]
 
   @type violation :: %{

--- a/lib/just_bash/banned_call_tracer.ex
+++ b/lib/just_bash/banned_call_tracer.ex
@@ -27,6 +27,10 @@ defmodule JustBash.BannedCallTracer do
   ### Node escape (`Node`)
   Connecting to or spawning processes on remote Erlang nodes.
 
+  ### Mutable shared state (`Process.put/get/delete`, `:ets`)
+  Process dictionary and ETS leak mutable state across calls, breaking
+  referential transparency and making code unpredictable in concurrent use.
+
   ## What this catches
 
   - Direct calls: `File.read(path)`, `System.cmd("rm", [...])`
@@ -60,7 +64,9 @@ defmodule JustBash.BannedCallTracer do
     # OS process spawning
     Port,
     # Remote node operations
-    Node
+    Node,
+    # ETS — mutable shared state that leaks across calls
+    :ets
   ]
 
   # Specific functions banned within modules that have some safe functions.
@@ -80,7 +86,13 @@ defmodule JustBash.BannedCallTracer do
     # Erlang-level port / OS escape
     {:os, :cmd, 1},
     {:os, :cmd, 2},
-    {:erlang, :open_port, 2}
+    {:erlang, :open_port, 2},
+    # Process dictionary — leaks mutable global state across calls
+    {Process, :put, 2},
+    {Process, :get, 0},
+    {Process, :get, 1},
+    {Process, :get, 2},
+    {Process, :delete, 1}
   ]
 
   @type violation :: %{

--- a/lib/just_bash/commands/awk/evaluator.ex
+++ b/lib/just_bash/commands/awk/evaluator.ex
@@ -8,6 +8,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
 
   alias JustBash.Commands.Awk.{Formatter, Parser}
   alias JustBash.Fs.InMemoryFs
+  alias JustBash.Limit
 
   @type state :: %{
           nr: non_neg_integer(),
@@ -184,7 +185,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
 
   defp pattern_matches?({:regex, pattern}, state) do
     result =
-      case Regex.compile(pattern) do
+      case checked_compile(pattern, state) do
         {:ok, regex} -> Regex.match?(regex, Enum.at(state.fields, 0, ""))
         {:error, _} -> false
       end
@@ -273,7 +274,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
     field = String.to_integer(field_str)
     field_value = get_field(state, field)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, state) do
       {:ok, regex} -> Regex.match?(regex, field_value)
       {:error, _} -> false
     end
@@ -635,7 +636,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   defp execute_statement({:gsub, pattern, replacement, {:field, 0}}, state) do
     line = Enum.at(state.fields, 0, "")
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, state) do
       {:ok, regex} ->
         new_line = Regex.replace(regex, line, replacement)
         new_fields = [new_line | tl(state.fields)]
@@ -649,7 +650,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   defp execute_statement({:gsub, pattern, replacement, {:field, n}}, state) do
     field_val = Enum.at(state.fields, n, "")
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, state) do
       {:ok, regex} ->
         new_val = Regex.replace(regex, field_val, replacement)
         new_fields = List.replace_at(state.fields, n, new_val)
@@ -663,7 +664,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   defp execute_statement({:gsub, pattern, replacement, {:variable, var}}, state) do
     current = Map.get(state.variables, var, "")
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, state) do
       {:ok, regex} ->
         new_val = Regex.replace(regex, current, replacement)
         %{state | variables: Map.put(state.variables, var, new_val)}
@@ -677,7 +678,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   defp execute_statement({:sub, pattern, replacement, {:field, 0}}, state) do
     line = Enum.at(state.fields, 0, "")
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, state) do
       {:ok, regex} ->
         new_line = Regex.replace(regex, line, replacement, global: false)
         new_fields = [new_line | tl(state.fields)]
@@ -691,7 +692,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   defp execute_statement({:sub, pattern, replacement, {:field, n}}, state) do
     field_val = Enum.at(state.fields, n, "")
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, state) do
       {:ok, regex} ->
         new_val = Regex.replace(regex, field_val, replacement, global: false)
         new_fields = List.replace_at(state.fields, n, new_val)
@@ -705,7 +706,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   defp execute_statement({:sub, pattern, replacement, {:variable, var}}, state) do
     current = Map.get(state.variables, var, "")
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, state) do
       {:ok, regex} ->
         new_val = Regex.replace(regex, current, replacement, global: false)
         %{state | variables: Map.put(state.variables, var, new_val)}
@@ -766,7 +767,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   # match(string, regex [, array]) implementation
   defp execute_match(args, state) do
     {string, pattern, array_name} = extract_match_args(args, state)
-    regex = compile_awk_regex(pattern)
+    regex = compile_awk_regex(pattern, state)
 
     case Regex.run(regex, string, return: :index) do
       nil ->
@@ -885,8 +886,13 @@ defmodule JustBash.Commands.Awk.Evaluator do
     {str, array_name, state.fs}
   end
 
-  defp compile_awk_regex(pattern) do
-    case Regex.compile(pattern) do
+  defp checked_compile(pattern, state) do
+    limits = if state.bash, do: state.bash.limits
+    Limit.compile_regex(limits, pattern)
+  end
+
+  defp compile_awk_regex(pattern, state) do
+    case checked_compile(pattern, state) do
       {:ok, regex} -> regex
       {:error, _} -> ~r/(?!)/
     end
@@ -1148,7 +1154,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   def evaluate_expression({:regex, pattern}, state) do
     line = get_field(state, 0)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, state) do
       {:ok, re} -> if Regex.match?(re, line), do: 1, else: 0
       _ -> 0
     end
@@ -1202,7 +1208,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
     value = evaluate_expression(expr, state) |> to_string()
     pattern_str = unwrap_pattern(pattern)
 
-    case Regex.compile(pattern_str) do
+    case checked_compile(pattern_str, state) do
       {:ok, regex} -> if Regex.match?(regex, value), do: 1, else: 0
       {:error, _} -> 0
     end
@@ -1212,7 +1218,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
     value = evaluate_expression(expr, state) |> to_string()
     pattern_str = unwrap_pattern(pattern)
 
-    case Regex.compile(pattern_str) do
+    case checked_compile(pattern_str, state) do
       {:ok, regex} -> if Regex.match?(regex, value), do: 0, else: 1
       {:error, _} -> 1
     end
@@ -1470,7 +1476,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
     value = evaluate_expression(expr, state) |> to_string()
     pattern_str = unwrap_pattern(pattern)
 
-    case Regex.compile(pattern_str) do
+    case checked_compile(pattern_str, state) do
       {:ok, regex} -> Regex.match?(regex, value)
       {:error, _} -> false
     end
@@ -1614,8 +1620,8 @@ defmodule JustBash.Commands.Awk.Evaluator do
     0
   end
 
-  defp evaluate_function("match", [string, pattern], _state) do
-    regex = compile_awk_regex(to_string(pattern))
+  defp evaluate_function("match", [string, pattern], state) do
+    regex = compile_awk_regex(to_string(pattern), state)
 
     case Regex.run(regex, to_string(string), return: :index) do
       nil -> 0

--- a/lib/just_bash/commands/awk/parser.ex
+++ b/lib/just_bash/commands/awk/parser.ex
@@ -8,11 +8,12 @@ defmodule JustBash.Commands.Awk.Parser do
   alias JustBash.Commands.Awk.AST
   alias JustBash.Commands.Awk.Lexer
 
-  defstruct [:tokens, :pos]
+  defstruct [:tokens, :pos, in_print_context: false]
 
   @type t :: %__MODULE__{
           tokens: [Lexer.token()],
-          pos: non_neg_integer()
+          pos: non_neg_integer(),
+          in_print_context: boolean()
         }
 
   @doc """
@@ -501,11 +502,10 @@ defmodule JustBash.Commands.Awk.Parser do
   defp parse_print_arg(state) do
     # In print context, > and >> are redirection, not comparison
     # So we parse a limited expression that stops at those
-    prev = Process.get(:in_print_context)
-    Process.put(:in_print_context, true)
-    result = parse_ternary(state)
-    Process.put(:in_print_context, prev)
-    result
+    prev = state.in_print_context
+    result = parse_ternary(%{state | in_print_context: true})
+    {expr, state} = result
+    {expr, %{state | in_print_context: prev}}
   end
 
   defp parse_output_redirect(state) do
@@ -655,7 +655,7 @@ defmodule JustBash.Commands.Awk.Parser do
         {right, state} = parse_concat(state)
         parse_comparison_rest(state, AST.binary(:le, left, right))
 
-      token_is?(state, :gt) and !Process.get(:in_print_context) ->
+      token_is?(state, :gt) and not state.in_print_context ->
         state = advance(state)
         {right, state} = parse_concat(state)
         parse_comparison_rest(state, AST.binary(:gt, left, right))
@@ -873,10 +873,9 @@ defmodule JustBash.Commands.Awk.Parser do
       :lparen ->
         state = advance(state)
         # Inside parentheses, > is always comparison, not redirect
-        prev_print = Process.get(:in_print_context)
-        Process.put(:in_print_context, false)
-        {expr, state} = parse_expression(state)
-        Process.put(:in_print_context, prev_print)
+        prev_print = state.in_print_context
+        {expr, state} = parse_expression(%{state | in_print_context: false})
+        state = %{state | in_print_context: prev_print}
         {_, state} = expect(state, :rparen)
         {expr, state}
 

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -5,6 +5,7 @@ defmodule JustBash.Commands.Grep do
   alias JustBash.Commands.Command
   alias JustBash.FlagParser
   alias JustBash.Fs.InMemoryFs
+  alias JustBash.Limit
 
   @flag_spec %{
     boolean: [
@@ -69,7 +70,7 @@ defmodule JustBash.Commands.Grep do
   end
 
   defp execute_with_files(bash, pattern, files, flags) do
-    regex = compile_pattern(pattern, flags)
+    regex = compile_pattern(bash, pattern, flags)
 
     # Expand files recursively if -r flag is set
     expanded_files = expand_files(bash, files, flags.r)
@@ -171,7 +172,7 @@ defmodule JustBash.Commands.Grep do
   end
 
   defp execute_with_stdin(bash, pattern, stdin, flags) do
-    regex = compile_pattern(pattern, flags)
+    regex = compile_pattern(bash, pattern, flags)
     lines = process_content(stdin, regex, flags, "")
     matched = lines != []
 
@@ -195,7 +196,8 @@ defmodule JustBash.Commands.Grep do
     end
   end
 
-  defp compile_pattern(pattern, flags) do
+  defp compile_pattern(bash, pattern, flags) do
+    Limit.check_regex_size!(bash.limits, pattern)
     opts = if flags.i, do: [:caseless], else: []
 
     regex_pattern =

--- a/lib/just_bash/commands/jq.ex
+++ b/lib/just_bash/commands/jq.ex
@@ -48,6 +48,7 @@ defmodule JustBash.Commands.Jq do
       opts
       |> Map.put(:fs, bash.fs)
       |> Map.put(:module_paths, bash.jq_module_paths)
+      |> Map.put(:limits, bash.limits)
 
     case get_input(bash, opts, stdin) do
       {:error, msg} ->

--- a/lib/just_bash/commands/jq/evaluator/functions.ex
+++ b/lib/just_bash/commands/jq/evaluator/functions.ex
@@ -488,7 +488,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
     flags = eval.eval(flags_expr, data, opts)
     regex_opts = parse_regex_flags(flags)
 
-    case Regex.compile(pattern, regex_opts) do
+    case checked_compile(pattern, opts, regex_opts) do
       {:ok, regex} -> Regex.split(regex, data)
       {:error, _} -> throw({:eval_error, "invalid regex: #{pattern}"})
     end
@@ -1409,7 +1409,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
   defp do_eval_func(:test, [regex_expr], data, opts, eval) when is_binary(data) do
     pattern = eval.eval(regex_expr, data, opts)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, opts) do
       {:ok, regex} -> Regex.match?(regex, data)
       {:error, _} -> throw({:eval_error, "invalid regex: #{pattern}"})
     end
@@ -1420,7 +1420,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
     flags = eval.eval(flags_expr, data, opts)
     regex_opts = parse_regex_flags(flags)
 
-    case Regex.compile(pattern, regex_opts) do
+    case checked_compile(pattern, opts, regex_opts) do
       {:ok, regex} -> Regex.match?(regex, data)
       {:error, _} -> throw({:eval_error, "invalid regex: #{pattern}"})
     end
@@ -1429,7 +1429,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
   defp do_eval_func(:match, [regex_expr], data, opts, eval) when is_binary(data) do
     pattern = eval.eval(regex_expr, data, opts)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, opts) do
       {:ok, regex} ->
         case Regex.run(regex, data, return: :index) do
           nil ->
@@ -1455,7 +1455,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
   defp do_eval_func(:capture, [regex_expr], data, opts, eval) when is_binary(data) do
     pattern = eval.eval(regex_expr, data, opts)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, opts) do
       {:ok, regex} ->
         case Regex.named_captures(regex, data) do
           nil -> nil
@@ -1471,7 +1471,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
     pattern = eval.eval(regex_expr, data, opts)
     replacement = eval.eval(repl_expr, data, opts)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, opts) do
       {:ok, regex} -> Regex.replace(regex, data, fn _, _ -> replacement end)
       {:error, _} -> throw({:eval_error, "invalid regex: #{pattern}"})
     end
@@ -1484,7 +1484,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
     flags = eval.eval(flags_expr, data, opts)
     regex_opts = parse_regex_flags(flags)
 
-    case Regex.compile(pattern, regex_opts) do
+    case checked_compile(pattern, opts, regex_opts) do
       {:ok, regex} -> Regex.replace(regex, data, fn _, _ -> replacement end)
       {:error, _} -> throw({:eval_error, "invalid regex: #{pattern}"})
     end
@@ -1494,7 +1494,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
     pattern = eval.eval(regex_expr, data, opts)
     replacement = eval.eval(repl_expr, data, opts)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, opts) do
       {:ok, regex} -> Regex.replace(regex, data, fn _, _ -> replacement end, global: false)
       {:error, _} -> throw({:eval_error, "invalid regex: #{pattern}"})
     end
@@ -1503,7 +1503,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
   defp do_eval_func(:scan, [regex_expr], data, opts, eval) when is_binary(data) do
     pattern = eval.eval(regex_expr, data, opts)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, opts) do
       {:ok, regex} ->
         Regex.scan(regex, data)
         |> Enum.map(fn
@@ -1519,7 +1519,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
   defp do_eval_func(:splits, [regex_expr], data, opts, eval) when is_binary(data) do
     pattern = eval.eval(regex_expr, data, opts)
 
-    case Regex.compile(pattern) do
+    case checked_compile(pattern, opts) do
       {:ok, regex} -> {:multi, Regex.split(regex, data)}
       {:error, _} -> throw({:eval_error, "invalid regex: #{pattern}"})
     end
@@ -1530,7 +1530,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
     flags = eval.eval(flags_expr, data, opts)
     regex_opts = parse_regex_flags(flags)
 
-    case Regex.compile(pattern, regex_opts) do
+    case checked_compile(pattern, opts, regex_opts) do
       {:ok, regex} -> {:multi, Regex.split(regex, data)}
       {:error, _} -> throw({:eval_error, "invalid regex: #{pattern}"})
     end
@@ -1646,6 +1646,10 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
   end
 
   # Helper functions
+
+  defp checked_compile(pattern, opts, regex_opts \\ []) do
+    JustBash.Limit.compile_regex(opts[:limits], pattern, regex_opts)
+  end
 
   # Valid Unicode codepoint that is not a surrogate
   defp implode_codepoint(n, _replacement)

--- a/lib/just_bash/commands/jq/evaluator/functions.ex
+++ b/lib/just_bash/commands/jq/evaluator/functions.ex
@@ -38,7 +38,7 @@ defmodule JustBash.Commands.Jq.Evaluator.Functions do
                      with_entries IN INDEX JOIN date dateadd datesub fromdate
                      gmtime
                    ),
-                   &{&1, String.to_atom(&1)}
+                   fn name -> {name, :"#{name}"} end
                  )
 
   @doc """

--- a/lib/just_bash/commands/jq/parser.ex
+++ b/lib/just_bash/commands/jq/parser.ex
@@ -1406,13 +1406,18 @@ defmodule JustBash.Commands.Jq.Parser do
     parse_postfix(parse_primary(input))
   end
 
-  # Map from format name strings to atoms.  Using an explicit map guarantees the
-  # atoms exist in the runtime atom table — String.to_existing_atom/1 is unreliable
-  # because compile-time module attributes don't always populate the runtime table.
-  @format_atoms Map.new(
-                  ~w(csv tsv json text base64 base64d uri urid sh html),
-                  &{&1, String.to_atom(&1)}
-                )
+  @format_atoms %{
+    "csv" => :csv,
+    "tsv" => :tsv,
+    "json" => :json,
+    "text" => :text,
+    "base64" => :base64,
+    "base64d" => :base64d,
+    "uri" => :uri,
+    "urid" => :urid,
+    "sh" => :sh,
+    "html" => :html
+  }
 
   defp parse_format_string(input) do
     case parse_identifier(input) do

--- a/lib/just_bash/commands/sed.ex
+++ b/lib/just_bash/commands/sed.ex
@@ -39,7 +39,7 @@ defmodule JustBash.Commands.Sed do
   end
 
   defp execute_scripts(bash, opts, stdin) do
-    case Parser.parse(opts.scripts, opts.extended_regex) do
+    case Parser.parse(opts.scripts, opts.extended_regex, bash.limits) do
       {:error, msg} ->
         {Command.error("sed: #{msg}\n"), bash}
 

--- a/lib/just_bash/commands/sed/parser.ex
+++ b/lib/just_bash/commands/sed/parser.ex
@@ -24,50 +24,56 @@ defmodule JustBash.Commands.Sed.Parser do
           command: command()
         }
 
+  # Parser context threaded through all functions
+  @typep ctx :: %{extended: boolean(), limits: JustBash.Limit.t() | nil}
+
   @doc """
   Parse SED scripts into command structures.
 
   Returns `{:ok, commands}` on success or `{:error, message}` on failure.
   """
-  @spec parse([String.t()], boolean()) :: {:ok, [sed_command()]} | {:error, String.t()}
-  def parse([], _extended), do: {:error, "no script specified"}
+  @spec parse([String.t()], boolean(), JustBash.Limit.t() | nil) ::
+          {:ok, [sed_command()]} | {:error, String.t()}
+  def parse(scripts, extended, limits \\ nil)
+  def parse([], _extended, _limits), do: {:error, "no script specified"}
 
-  def parse(scripts, extended) do
+  def parse(scripts, extended, limits) do
+    ctx = %{extended: extended, limits: limits}
+
     commands =
       Enum.flat_map(scripts, fn script ->
-        parse_script(script, extended)
+        parse_script(script, ctx)
       end)
 
     if Enum.any?(commands, &match?({:error, _}, &1)) do
-      error = Enum.find(commands, &match?({:error, _}, &1))
-      error
+      Enum.find(commands, &match?({:error, _}, &1))
     else
       {:ok, commands}
     end
   end
 
-  defp parse_script(script, extended) do
+  defp parse_script(script, ctx) do
     script
     |> String.split(";")
     |> Enum.map(&String.trim/1)
     |> Enum.filter(&(&1 != ""))
-    |> Enum.map(&parse_command(&1, extended))
+    |> Enum.map(&parse_command(&1, ctx))
   end
 
-  defp parse_command(cmd, extended) do
-    case parse_address_and_command(cmd, extended) do
+  defp parse_command(cmd, ctx) do
+    case parse_address_and_command(cmd, ctx) do
       {:ok, result} -> result
       {:error, msg} -> {:error, msg}
     end
   end
 
-  defp parse_address_and_command(cmd, extended) do
-    {addr1, addr2, rest} = parse_addresses(cmd, extended)
+  defp parse_address_and_command(cmd, ctx) do
+    {addr1, addr2, rest} = parse_addresses(cmd, ctx)
 
     # Check for negation modifier (!)
     {negated, rest} = parse_negation(rest)
 
-    case parse_single_command(rest, extended) do
+    case parse_single_command(rest, ctx) do
       {:ok, command} ->
         {:ok, %{address1: addr1, address2: addr2, negated: negated, command: command}}
 
@@ -79,49 +85,49 @@ defmodule JustBash.Commands.Sed.Parser do
   defp parse_negation("!" <> rest), do: {true, String.trim_leading(rest)}
   defp parse_negation(rest), do: {false, rest}
 
-  defp parse_addresses(cmd, extended) do
+  defp parse_addresses(cmd, ctx) do
     case cmd do
       "$" <> rest ->
-        parse_address_with_optional_range(:last, String.trim_leading(rest), extended)
+        parse_address_with_optional_range(:last, String.trim_leading(rest), ctx)
 
       "/" <> _rest ->
-        parse_regex_first_address(cmd, extended)
+        parse_regex_first_address(cmd, ctx)
 
       _ ->
-        parse_line_number_address(cmd, extended)
+        parse_line_number_address(cmd, ctx)
     end
   end
 
-  defp parse_address_with_optional_range(addr1, rest, extended) do
+  defp parse_address_with_optional_range(addr1, rest, ctx) do
     if String.starts_with?(rest, ",") do
-      {addr2, rest2} = parse_second_address(String.slice(rest, 1..-1//1), extended)
+      {addr2, rest2} = parse_second_address(String.slice(rest, 1..-1//1), ctx)
       {addr1, addr2, rest2}
     else
       {addr1, nil, rest}
     end
   end
 
-  defp parse_regex_first_address(cmd, extended) do
-    case parse_regex_address(cmd, extended) do
+  defp parse_regex_first_address(cmd, ctx) do
+    case parse_regex_address(cmd, ctx) do
       {:ok, regex, rest} ->
-        parse_address_with_optional_range({:regex, regex}, String.trim_leading(rest), extended)
+        parse_address_with_optional_range({:regex, regex}, String.trim_leading(rest), ctx)
 
       {:error, _} ->
         {nil, nil, cmd}
     end
   end
 
-  defp parse_line_number_address(cmd, extended) do
+  defp parse_line_number_address(cmd, ctx) do
     case Integer.parse(cmd) do
       {n, rest} ->
-        parse_address_with_optional_range({:line, n}, String.trim_leading(rest), extended)
+        parse_address_with_optional_range({:line, n}, String.trim_leading(rest), ctx)
 
       :error ->
         {nil, nil, cmd}
     end
   end
 
-  defp parse_second_address(rest, extended) do
+  defp parse_second_address(rest, ctx) do
     rest = String.trim_leading(rest)
 
     case rest do
@@ -129,7 +135,7 @@ defmodule JustBash.Commands.Sed.Parser do
         {:last, String.trim_leading(rest2)}
 
       "/" <> _rest ->
-        case parse_regex_address(rest, extended) do
+        case parse_regex_address(rest, ctx) do
           {:ok, regex, rest2} -> {{:regex, regex}, rest2}
           {:error, _} -> {nil, rest}
         end
@@ -142,10 +148,10 @@ defmodule JustBash.Commands.Sed.Parser do
     end
   end
 
-  defp parse_regex_address(str, extended) do
+  defp parse_regex_address(str, ctx) do
     case Regex.run(~r{^/([^/]*)/(.*)$}s, str) do
       [_, pattern, rest] ->
-        case compile_regex(pattern, [], extended) do
+        case compile_regex(pattern, [], ctx) do
           {:ok, regex} -> {:ok, regex, rest}
           {:error, _} = err -> err
         end
@@ -155,81 +161,81 @@ defmodule JustBash.Commands.Sed.Parser do
     end
   end
 
-  defp parse_single_command("", _extended), do: {:ok, :noop}
-  defp parse_single_command("d", _extended), do: {:ok, :delete}
-  defp parse_single_command("p", _extended), do: {:ok, :print}
+  defp parse_single_command("", _ctx), do: {:ok, :noop}
+  defp parse_single_command("d", _ctx), do: {:ok, :delete}
+  defp parse_single_command("p", _ctx), do: {:ok, :print}
 
-  defp parse_single_command("s" <> rest, extended) do
-    parse_substitute_command(rest, extended)
+  defp parse_single_command("s" <> rest, ctx) do
+    parse_substitute_command(rest, ctx)
   end
 
   # a\ - append text after current line
-  defp parse_single_command("a\\" <> rest, _extended) do
+  defp parse_single_command("a\\" <> rest, _ctx) do
     text = String.trim_leading(rest)
     {:ok, {:append, unescape_text(text)}}
   end
 
-  defp parse_single_command("a " <> rest, _extended) do
+  defp parse_single_command("a " <> rest, _ctx) do
     {:ok, {:append, unescape_text(rest)}}
   end
 
   # i\ - insert text before current line
-  defp parse_single_command("i\\" <> rest, _extended) do
+  defp parse_single_command("i\\" <> rest, _ctx) do
     text = String.trim_leading(rest)
     {:ok, {:insert, unescape_text(text)}}
   end
 
-  defp parse_single_command("i " <> rest, _extended) do
+  defp parse_single_command("i " <> rest, _ctx) do
     {:ok, {:insert, unescape_text(rest)}}
   end
 
   # c\ - change (replace) current line with text
-  defp parse_single_command("c\\" <> rest, _extended) do
+  defp parse_single_command("c\\" <> rest, _ctx) do
     text = String.trim_leading(rest)
     {:ok, {:change, unescape_text(text)}}
   end
 
-  defp parse_single_command("c " <> rest, _extended) do
+  defp parse_single_command("c " <> rest, _ctx) do
     {:ok, {:change, unescape_text(rest)}}
   end
 
   # y/source/dest/ - transliterate characters
-  defp parse_single_command("y" <> rest, _extended) do
+  defp parse_single_command("y" <> rest, _ctx) do
     parse_translate_command(rest)
   end
 
-  defp parse_single_command(other, _extended) do
+  defp parse_single_command(other, _ctx) do
     {:error, "unknown command: #{String.first(other)}"}
   end
 
-  defp parse_substitute_command(rest, extended) do
+  defp parse_substitute_command(rest, ctx) do
     if String.length(rest) < 1 do
       {:error, "unterminated `s' command"}
     else
       delimiter = String.first(rest)
       rest = String.slice(rest, 1..-1//1)
-      parse_substitute_parts(rest, delimiter, extended)
+      parse_substitute_parts(rest, delimiter, ctx)
     end
   end
 
-  defp parse_substitute_parts(rest, delimiter, extended) do
+  defp parse_substitute_parts(rest, delimiter, ctx) do
     case split_by_delimiter(rest, delimiter) do
       {:ok, pattern, replacement, flags_str} ->
-        build_substitute_command(pattern, replacement, flags_str, extended)
+        build_substitute_command(pattern, replacement, flags_str, ctx)
 
       {:error, msg} ->
         {:error, msg}
     end
   end
 
-  defp build_substitute_command(pattern, replacement, flags_str, extended) do
+  defp build_substitute_command(pattern, replacement, flags_str, ctx) do
     flags = parse_substitute_flags(flags_str)
 
     # Empty pattern means "reuse last regex"
     if pattern == "" do
       {:ok, {:substitute, :last_regex, replacement, flags}}
     else
-      case compile_regex(pattern, flags, extended) do
+      case compile_regex(pattern, flags, ctx) do
         {:ok, regex} ->
           {:ok, {:substitute, regex, replacement, flags}}
 
@@ -310,14 +316,14 @@ defmodule JustBash.Commands.Sed.Parser do
   Compile a regex pattern with the given flags.
   Converts BRE (Basic Regular Expression) to ERE for Elixir's PCRE engine.
   """
-  @spec compile_regex(String.t(), substitute_flags(), boolean()) ::
+  @spec compile_regex(String.t(), substitute_flags(), ctx()) ::
           {:ok, Regex.t()} | {:error, String.t()}
-  def compile_regex(pattern, flags, extended) do
+  def compile_regex(pattern, flags, ctx) do
     # Convert BRE to ERE if not in extended mode
     # In BRE: \( \) \{ \} are special, ( ) { } are literal
     # In ERE (and PCRE): ( ) { } are special, \( \) \{ \} are literal
     converted_pattern =
-      if extended do
+      if ctx.extended do
         pattern
       else
         convert_bre_to_ere(pattern)
@@ -330,6 +336,8 @@ defmodule JustBash.Commands.Sed.Parser do
         ],
         & &1
       )
+
+    JustBash.Limit.check_regex_size!(ctx.limits, converted_pattern)
 
     case Regex.compile(converted_pattern, regex_opts) do
       {:ok, regex} -> {:ok, regex}

--- a/lib/just_bash/flag_parser.ex
+++ b/lib/just_bash/flag_parser.ex
@@ -82,9 +82,9 @@ defmodule JustBash.FlagParser do
   end
 
   defp parse_flag(flag_str, remaining, spec, flags) do
-    # Check for aliases first
     aliases = Map.get(spec, :aliases, %{})
-    flag_atom = Map.get(aliases, flag_str, String.to_atom(flag_str))
+    lookup = flag_lookup(spec)
+    flag_atom = Map.get(aliases, flag_str) || Map.get(lookup, flag_str)
 
     cond do
       flag_atom in spec.boolean ->
@@ -111,13 +111,12 @@ defmodule JustBash.FlagParser do
         end
 
       String.length(flag_str) > 1 ->
-        # Try to parse as combined value flag (e.g., -k2, -n10)
-        case try_attached_value_flag(flag_str, spec, flags) do
+        case try_attached_value_flag(flag_str, spec, flags, lookup) do
           {:ok, new_flags} ->
             {:ok, new_flags, remaining}
 
           :error ->
-            case parse_combined_flags(flag_str, spec, flags) do
+            case parse_combined_flags(flag_str, spec, flags, lookup) do
               {:ok, new_flags} -> {:ok, new_flags, remaining}
               :error -> try_numeric_flag(flag_str, remaining, spec, flags)
             end
@@ -128,13 +127,12 @@ defmodule JustBash.FlagParser do
     end
   end
 
-  # Handle flags like -k2, -n10 where value is attached
-  defp try_attached_value_flag(flag_str, spec, flags) do
+  defp try_attached_value_flag(flag_str, spec, flags, lookup) do
     <<first_char::binary-size(1), rest::binary>> = flag_str
-    flag_atom = String.to_atom(first_char)
+    flag_atom = Map.get(lookup, first_char)
     multi_value = Map.get(spec, :multi_value, [])
 
-    if (flag_atom in spec.value or flag_atom in multi_value) and rest != "" do
+    if flag_atom != nil and (flag_atom in spec.value or flag_atom in multi_value) and rest != "" do
       parsed_value = parse_value(rest)
       {:ok, put_flag(flags, flag_atom, parsed_value, spec)}
     else
@@ -142,19 +140,19 @@ defmodule JustBash.FlagParser do
     end
   end
 
-  defp parse_combined_flags(flag_str, spec, flags) do
-    chars = String.graphemes(flag_str)
+  defp parse_combined_flags(flag_str, spec, flags, lookup) do
+    atoms = Enum.map(String.graphemes(flag_str), &Map.get(lookup, &1))
 
-    if Enum.all?(chars, &(String.to_atom(&1) in spec.boolean)) do
-      new_flags =
-        Enum.reduce(chars, flags, fn char, acc ->
-          Map.put(acc, String.to_atom(char), true)
-        end)
-
-      {:ok, new_flags}
+    if Enum.all?(atoms, &(&1 in spec.boolean)) do
+      {:ok, Enum.reduce(atoms, flags, fn atom, acc -> Map.put(acc, atom, true) end)}
     else
       :error
     end
+  end
+
+  defp flag_lookup(spec) do
+    (spec.boolean ++ spec.value ++ Map.get(spec, :multi_value, []))
+    |> Map.new(fn atom -> {Atom.to_string(atom), atom} end)
   end
 
   defp try_numeric_flag(flag_str, remaining, spec, flags) do

--- a/lib/just_bash/interpreter/executor.ex
+++ b/lib/just_bash/interpreter/executor.ex
@@ -16,6 +16,7 @@ defmodule JustBash.Interpreter.Executor do
   alias JustBash.Interpreter.Executor.Loop
   alias JustBash.Interpreter.Executor.Redirection
   alias JustBash.Interpreter.Expansion
+  alias JustBash.Limit
   alias JustBash.Result
 
   @type result :: %{
@@ -31,23 +32,29 @@ defmodule JustBash.Interpreter.Executor do
   """
   @spec execute_script(JustBash.t(), AST.Script.t()) :: {result(), JustBash.t()}
   def execute_script(bash, %AST.Script{statements: statements}) do
+    original_depth = bash.interpreter.exec_depth
+    bash = Limit.track_exec_depth!(bash)
+
     {final_bash, stdout_io, stderr_io, exit_code, _halted} =
       Enum.reduce_while(statements, {bash, [], [], 0, false}, fn stmt, {b, out, err, _code, _} ->
-        {result, new_bash} = execute_statement(b, stmt)
-        new_env = Map.put(new_bash.env, "?", to_string(result.exit_code))
-        new_bash = %{new_bash | last_exit_code: result.exit_code, env: new_env}
-        # Use iodata - O(1) prepend, single flatten at end
-        acc = {new_bash, [out, result.stdout], [err, result.stderr], result.exit_code, false}
-
-        # Check errexit: exit if enabled and command failed
-        # Note: errexit doesn't apply to statements with && or || operators
-        if new_bash.shell_opts.errexit and result.exit_code != 0 and
-             not has_short_circuit_operators?(stmt) do
-          {:halt, put_elem(acc, 4, true)}
+        if b.interpreter.halted do
+          {:halt, {b, out, err, 1, true}}
         else
-          {:cont, acc}
+          {result, new_bash} = execute_statement(b, stmt)
+          new_env = Map.put(new_bash.env, "?", to_string(result.exit_code))
+          new_bash = %{new_bash | last_exit_code: result.exit_code, env: new_env}
+          acc = {new_bash, [out, result.stdout], [err, result.stderr], result.exit_code, false}
+
+          if new_bash.shell_opts.errexit and result.exit_code != 0 and
+               not has_short_circuit_operators?(stmt) do
+            {:halt, put_elem(acc, 4, true)}
+          else
+            {:cont, acc}
+          end
         end
       end)
+
+    final_bash = put_in(final_bash.interpreter.exec_depth, original_depth)
 
     result = %{
       stdout: IO.iodata_to_binary(stdout_io),
@@ -59,7 +66,6 @@ defmodule JustBash.Interpreter.Executor do
     {result, final_bash}
   end
 
-  # Check if statement uses && or || operators (errexit doesn't apply to these)
   defp has_short_circuit_operators?(%AST.Statement{operators: operators}) do
     Enum.any?(operators, &(&1 in [:and, :or]))
   end
@@ -69,15 +75,37 @@ defmodule JustBash.Interpreter.Executor do
   """
   @spec execute_statement(JustBash.t(), AST.Statement.t() | AST.Group.t()) ::
           {result(), JustBash.t()}
-  def execute_statement(bash, %AST.Statement{pipelines: pipelines, operators: operators}) do
+  def execute_statement(bash, stmt) do
+    if bash.interpreter.halted do
+      {%{stdout: "", stderr: "", exit_code: 1}, bash}
+    else
+      tracked_before = bash.interpreter.output_bytes
+      {result, new_bash} = do_execute_statement(bash, stmt)
+
+      # Delta-based: only count output not already tracked by nested statements
+      output_size = byte_size(result.stdout) + byte_size(result.stderr)
+      already_tracked = new_bash.interpreter.output_bytes - tracked_before
+      untracked = max(output_size - already_tracked, 0)
+      new_bash = Limit.track_output!(new_bash, untracked)
+
+      {result, new_bash}
+    end
+  rescue
+    # Catches raises from step!/track_output!/etc. deep in the call tree.
+    # Uses pre-execution `bash` — state from the interrupted statement is discarded.
+    e in Limit.ExceededError ->
+      {%{stdout: "", stderr: "bash: #{e.message}\n", exit_code: 1},
+       put_in(bash.interpreter.halted, true)}
+  end
+
+  defp do_execute_statement(bash, %AST.Statement{pipelines: pipelines, operators: operators}) do
     execute_pipelines(bash, pipelines, operators, 0, [], [], nil)
   end
 
-  def execute_statement(bash, %AST.Group{body: body}) do
+  defp do_execute_statement(bash, %AST.Group{body: body}) do
     execute_body_with_bash(bash, body)
   end
 
-  # Use iodata for stdout/stderr accumulation
   defp execute_pipelines(bash, pipelines, operators, prev_exit, stdout_io, stderr_io, prev_op) do
     execute_pipelines(bash, pipelines, operators, prev_exit, stdout_io, stderr_io, prev_op, nil)
   end
@@ -520,32 +548,38 @@ defmodule JustBash.Interpreter.Executor do
   end
 
   defp execute_body(bash, statements) do
-    {final_bash, stdout, stderr, exit_code, control} =
-      Enum.reduce_while(statements, {bash, "", "", 0, nil}, fn stmt,
+    {final_bash, stdout_io, stderr_io, exit_code, control} =
+      Enum.reduce_while(statements, {bash, [], [], 0, nil}, fn stmt,
                                                                {b, out, err, _code, _ctrl} ->
-        {result, new_bash} = execute_statement(b, stmt)
-        new_out = out <> result.stdout
-        new_err = err <> result.stderr
+        if b.interpreter.halted do
+          {:halt, {b, out, err, 1, nil}}
+        else
+          {result, new_bash} = execute_statement(b, stmt)
 
-        # Check for control flow signals using Result struct
-        case extract_control_signal(result) do
-          {:break, n} ->
-            {:halt, {new_bash, new_out, new_err, 0, {:break, n}}}
+          case extract_control_signal(result) do
+            {:break, n} ->
+              {:halt, {new_bash, [out, result.stdout], [err, result.stderr], 0, {:break, n}}}
 
-          {:continue, n} ->
-            {:halt, {new_bash, new_out, new_err, 0, {:continue, n}}}
+            {:continue, n} ->
+              {:halt, {new_bash, [out, result.stdout], [err, result.stderr], 0, {:continue, n}}}
 
-          {:return, n} ->
-            {:halt, {new_bash, new_out, new_err, n, {:return, n}}}
+            {:return, n} ->
+              {:halt, {new_bash, [out, result.stdout], [err, result.stderr], n, {:return, n}}}
 
-          nil ->
-            {:cont, {new_bash, new_out, new_err, result.exit_code, nil}}
+            nil ->
+              {:cont,
+               {new_bash, [out, result.stdout], [err, result.stderr], result.exit_code, nil}}
+          end
         end
       end)
 
-    result = %{stdout: stdout, stderr: stderr, exit_code: exit_code, env: final_bash.env}
+    result = %{
+      stdout: IO.iodata_to_binary(stdout_io),
+      stderr: IO.iodata_to_binary(stderr_io),
+      exit_code: exit_code,
+      env: final_bash.env
+    }
 
-    # Propagate control flow signals using add_control_signal helper
     result = add_control_signal(result, control)
 
     {result, final_bash}
@@ -778,6 +812,7 @@ defmodule JustBash.Interpreter.Executor do
         {%{stdout: "", stderr: "bash: #{cmd}: command not found\n", exit_code: 127}, bash}
 
       module ->
+        bash = Limit.step!(bash)
         module.execute(bash, args, stdin)
     end
   end
@@ -785,6 +820,8 @@ defmodule JustBash.Interpreter.Executor do
   @control_signal_keys [:__break__, :__continue__, :__return__]
 
   defp execute_custom_command(bash, cmd_name, module, args, stdin) do
+    bash = Limit.step!(bash)
+
     # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
     try do
       case module.execute(bash, args, stdin) do

--- a/lib/just_bash/interpreter/executor/conditional.ex
+++ b/lib/just_bash/interpreter/executor/conditional.ex
@@ -15,6 +15,7 @@ defmodule JustBash.Interpreter.Executor.Conditional do
   alias JustBash.AST
   alias JustBash.Fs.InMemoryFs
   alias JustBash.Interpreter.Expansion
+  alias JustBash.Limit
 
   @type unary_op_type ::
           :file_exists
@@ -211,7 +212,7 @@ defmodule JustBash.Interpreter.Executor.Conditional do
 
   # Evaluate =~ regex match and populate BASH_REMATCH
   defp evaluate_regex_match(bash, str, pattern) do
-    case Regex.compile(pattern) do
+    case Limit.compile_regex(bash.limits, pattern) do
       {:ok, regex} ->
         case Regex.run(regex, str) do
           nil ->

--- a/lib/just_bash/interpreter/executor/loop.ex
+++ b/lib/just_bash/interpreter/executor/loop.ex
@@ -10,6 +10,7 @@ defmodule JustBash.Interpreter.Executor.Loop do
   """
 
   alias JustBash.Interpreter.Expansion
+  alias JustBash.Limit
   alias JustBash.Result
 
   @default_max_iterations 10_000
@@ -20,21 +21,16 @@ defmodule JustBash.Interpreter.Executor.Loop do
           exit_code: non_neg_integer()
         }
 
-  # Context struct for while/until loops to reduce function arity
   defmodule WhileContext do
     @moduledoc false
     defstruct [:condition, :body, :is_until, :execute_fn]
   end
 
-  # Accumulator struct for loop state
   defmodule LoopAcc do
     @moduledoc false
     defstruct stdout_io: [], stderr_io: [], exit_code: 0, iterations: 0
   end
 
-  @doc """
-  Execute a for loop over expanded words.
-  """
   @spec execute_for(JustBash.t(), String.t(), [any()], [any()], function()) ::
           {result(), JustBash.t()}
   def execute_for(bash, variable, words, body, execute_body_fn) do
@@ -49,18 +45,10 @@ defmodule JustBash.Interpreter.Executor.Loop do
     end)
   end
 
-  @doc """
-  Execute a while loop.
-  """
   @spec execute_while(JustBash.t(), [any()], [any()], String.t(), function()) ::
           {result(), JustBash.t()}
   def execute_while(bash, condition, body, stdin, execute_body_fn) do
-    bash_with_stdin =
-      if stdin != "" do
-        %{bash | interpreter: %{bash.interpreter | stdin: stdin}}
-      else
-        bash
-      end
+    bash = maybe_set_stdin(bash, stdin)
 
     ctx = %WhileContext{
       condition: condition,
@@ -70,25 +58,15 @@ defmodule JustBash.Interpreter.Executor.Loop do
     }
 
     JustBash.Telemetry.while_loop_span(false, fn ->
-      {result, new_bash, iteration_count} =
-        do_execute_while_loop(bash_with_stdin, ctx, %LoopAcc{})
-
-      {{result, new_bash}, %{iteration_count: iteration_count, exit_code: result.exit_code}}
+      {result, new_bash} = execute_while_loop(bash, ctx, %LoopAcc{})
+      {{result, new_bash}, %{exit_code: result.exit_code}}
     end)
   end
 
-  @doc """
-  Execute an until loop (while with inverted condition).
-  """
   @spec execute_until(JustBash.t(), [any()], [any()], String.t(), function()) ::
           {result(), JustBash.t()}
   def execute_until(bash, condition, body, stdin, execute_body_fn) do
-    bash_with_stdin =
-      if stdin != "" do
-        %{bash | interpreter: %{bash.interpreter | stdin: stdin}}
-      else
-        bash
-      end
+    bash = maybe_set_stdin(bash, stdin)
 
     ctx = %WhileContext{
       condition: condition,
@@ -98,21 +76,18 @@ defmodule JustBash.Interpreter.Executor.Loop do
     }
 
     JustBash.Telemetry.while_loop_span(true, fn ->
-      {result, new_bash, iteration_count} =
-        do_execute_while_loop(bash_with_stdin, ctx, %LoopAcc{})
-
-      {{result, new_bash}, %{iteration_count: iteration_count, exit_code: result.exit_code}}
+      {result, new_bash} = execute_while_loop(bash, ctx, %LoopAcc{})
+      {{result, new_bash}, %{exit_code: result.exit_code}}
     end)
   end
 
-  # --- For Loop Implementation ---
+  defp maybe_set_stdin(bash, ""), do: bash
+  defp maybe_set_stdin(bash, stdin), do: %{bash | interpreter: %{bash.interpreter | stdin: stdin}}
+
+  # --- For Loop ---
 
   defp execute_for_loop(bash, _variable, [], _body, stdout_io, stderr_io, exit_code, _exec_fn) do
-    {%{
-       stdout: IO.iodata_to_binary(stdout_io),
-       stderr: IO.iodata_to_binary(stderr_io),
-       exit_code: exit_code
-     }, bash}
+    {finalize(stdout_io, stderr_io, exit_code), bash}
   end
 
   defp execute_for_loop(
@@ -125,101 +100,75 @@ defmodule JustBash.Interpreter.Executor.Loop do
          _exit_code,
          execute_body_fn
        ) do
+    bash = Limit.step!(bash)
     new_bash = %{bash | env: Map.put(bash.env, variable, value)}
     {result, body_bash} = execute_body_fn.(new_bash, body)
+
     new_stdout_io = [stdout_io, result.stdout]
     new_stderr_io = [stderr_io, result.stderr]
 
-    # Use Result struct for type-safe signal handling
-    case Result.from_map(result).signal do
-      # Break level 1: exit loop with accumulated output
-      {:break, 1} ->
-        {%{
-           stdout: IO.iodata_to_binary(new_stdout_io),
-           stderr: IO.iodata_to_binary(new_stderr_io),
-           exit_code: 0
-         }, body_bash}
+    if body_bash.interpreter.halted do
+      {finalize(new_stdout_io, new_stderr_io, 1), body_bash}
+    else
+      case Result.from_map(result).signal do
+        {:break, 1} ->
+          {finalize(new_stdout_io, new_stderr_io, 0), body_bash}
 
-      # Break with level > 1: propagate to outer loop with decremented level
-      {:break, n} when n > 1 ->
-        {Result.to_map(%Result{
-           stdout: IO.iodata_to_binary(new_stdout_io),
-           stderr: IO.iodata_to_binary(new_stderr_io),
-           exit_code: 0,
-           signal: {:break, n - 1}
-         }), body_bash}
+        {:break, n} when n > 1 ->
+          {signal_result(new_stdout_io, new_stderr_io, 0, {:break, n - 1}), body_bash}
 
-      # Continue level 1: skip to next iteration
-      {:continue, 1} ->
-        execute_for_loop(
-          body_bash,
-          variable,
-          rest,
-          body,
-          new_stdout_io,
-          new_stderr_io,
-          0,
-          execute_body_fn
-        )
+        {:continue, 1} ->
+          execute_for_loop(
+            body_bash,
+            variable,
+            rest,
+            body,
+            new_stdout_io,
+            new_stderr_io,
+            0,
+            execute_body_fn
+          )
 
-      # Continue with level > 1: propagate to outer loop with decremented level
-      {:continue, n} when n > 1 ->
-        {Result.to_map(%Result{
-           stdout: IO.iodata_to_binary(new_stdout_io),
-           stderr: IO.iodata_to_binary(new_stderr_io),
-           exit_code: 0,
-           signal: {:continue, n - 1}
-         }), body_bash}
+        {:continue, n} when n > 1 ->
+          {signal_result(new_stdout_io, new_stderr_io, 0, {:continue, n - 1}), body_bash}
 
-      # No signal: continue to next iteration
-      nil ->
-        execute_for_loop(
-          body_bash,
-          variable,
-          rest,
-          body,
-          new_stdout_io,
-          new_stderr_io,
-          result.exit_code,
-          execute_body_fn
-        )
+        {:return, _} = sig ->
+          {signal_result(new_stdout_io, new_stderr_io, result.exit_code, sig), body_bash}
 
-      # Return signal: propagate as-is
-      {:return, _} = signal ->
-        {Result.to_map(%Result{
-           stdout: IO.iodata_to_binary(new_stdout_io),
-           stderr: IO.iodata_to_binary(new_stderr_io),
-           exit_code: result.exit_code,
-           signal: signal
-         }), body_bash}
+        nil ->
+          execute_for_loop(
+            body_bash,
+            variable,
+            rest,
+            body,
+            new_stdout_io,
+            new_stderr_io,
+            result.exit_code,
+            execute_body_fn
+          )
+      end
     end
   end
 
-  # --- While/Until Loop Implementation ---
+  # --- While/Until Loop ---
 
-  defp do_execute_while_loop(bash, ctx, acc) do
+  defp execute_while_loop(bash, ctx, acc) do
     max = Map.get(bash, :max_iterations, @default_max_iterations)
 
     if acc.iterations >= max do
-      {%{
-         stdout: IO.iodata_to_binary(acc.stdout_io),
-         stderr: IO.iodata_to_binary([acc.stderr_io, "loop: iteration limit exceeded\n"]),
-         exit_code: acc.exit_code
-       }, bash, acc.iterations}
+      {finalize(
+         acc.stdout_io,
+         [acc.stderr_io, "loop: iteration limit exceeded\n"],
+         acc.exit_code
+       ), bash}
     else
-      do_execute_while_iteration(bash, ctx, acc)
+      execute_while_iteration(bash, ctx, acc)
     end
   end
 
-  defp do_execute_while_iteration(bash, ctx, acc) do
+  defp execute_while_iteration(bash, ctx, acc) do
+    bash = Limit.step!(bash)
     {cond_result, cond_bash} = ctx.execute_fn.(bash, ctx.condition)
-
-    should_continue =
-      if ctx.is_until do
-        cond_result.exit_code != 0
-      else
-        cond_result.exit_code == 0
-      end
 
     new_acc = %{
       acc
@@ -227,75 +176,89 @@ defmodule JustBash.Interpreter.Executor.Loop do
         stderr_io: [acc.stderr_io, cond_result.stderr]
     }
 
+    if cond_bash.interpreter.halted do
+      {finalize(new_acc.stdout_io, new_acc.stderr_io, 1), cond_bash}
+    else
+      execute_while_body(cond_bash, ctx, new_acc, cond_result)
+    end
+  end
+
+  defp execute_while_body(cond_bash, ctx, acc, cond_result) do
+    should_continue =
+      if ctx.is_until, do: cond_result.exit_code != 0, else: cond_result.exit_code == 0
+
     if should_continue do
       {body_result, body_bash} = ctx.execute_fn.(cond_bash, ctx.body)
 
       body_acc = %{
-        new_acc
-        | stdout_io: [new_acc.stdout_io, body_result.stdout],
-          stderr_io: [new_acc.stderr_io, body_result.stderr]
+        acc
+        | stdout_io: [acc.stdout_io, body_result.stdout],
+          stderr_io: [acc.stderr_io, body_result.stderr]
       }
 
-      completed_iterations = acc.iterations + 1
-
-      # Use Result struct for type-safe signal handling
-      case Result.from_map(body_result).signal do
-        # Break level 1: exit loop
-        {:break, 1} ->
-          {%{
-             stdout: IO.iodata_to_binary(body_acc.stdout_io),
-             stderr: IO.iodata_to_binary(body_acc.stderr_io),
-             exit_code: 0
-           }, body_bash, completed_iterations}
-
-        # Break with level > 1: propagate with decremented level
-        {:break, n} when n > 1 ->
-          {Result.to_map(%Result{
-             stdout: IO.iodata_to_binary(body_acc.stdout_io),
-             stderr: IO.iodata_to_binary(body_acc.stderr_io),
-             exit_code: 0,
-             signal: {:break, n - 1}
-           }), body_bash, completed_iterations}
-
-        # Continue level 1: re-check condition
-        {:continue, 1} ->
-          next_acc = %{body_acc | exit_code: 0, iterations: completed_iterations}
-          do_execute_while_loop(body_bash, ctx, next_acc)
-
-        # Continue with level > 1: propagate with decremented level
-        {:continue, n} when n > 1 ->
-          {Result.to_map(%Result{
-             stdout: IO.iodata_to_binary(body_acc.stdout_io),
-             stderr: IO.iodata_to_binary(body_acc.stderr_io),
-             exit_code: 0,
-             signal: {:continue, n - 1}
-           }), body_bash, completed_iterations}
-
-        # Return signal: propagate as-is
-        {:return, _} = signal ->
-          {Result.to_map(%Result{
-             stdout: IO.iodata_to_binary(body_acc.stdout_io),
-             stderr: IO.iodata_to_binary(body_acc.stderr_io),
-             exit_code: body_result.exit_code,
-             signal: signal
-           }), body_bash, completed_iterations}
-
-        # No signal: continue loop
-        nil ->
-          next_acc = %{
-            body_acc
-            | exit_code: body_result.exit_code,
-              iterations: completed_iterations
-          }
-
-          do_execute_while_loop(body_bash, ctx, next_acc)
+      if body_bash.interpreter.halted do
+        {finalize(body_acc.stdout_io, body_acc.stderr_io, 1), body_bash}
+      else
+        handle_while_signal(
+          Result.from_map(body_result).signal,
+          body_bash,
+          ctx,
+          acc,
+          body_acc,
+          body_result
+        )
       end
     else
-      {%{
-         stdout: IO.iodata_to_binary(new_acc.stdout_io),
-         stderr: IO.iodata_to_binary(new_acc.stderr_io),
-         exit_code: acc.exit_code
-       }, cond_bash, acc.iterations}
+      {finalize(acc.stdout_io, acc.stderr_io, acc.exit_code), cond_bash}
     end
+  end
+
+  defp handle_while_signal({:break, 1}, bash, _, _, acc, _) do
+    {finalize(acc.stdout_io, acc.stderr_io, 0), bash}
+  end
+
+  defp handle_while_signal({:break, n}, bash, _, _, acc, _) when n > 1 do
+    {signal_result(acc.stdout_io, acc.stderr_io, 0, {:break, n - 1}), bash}
+  end
+
+  defp handle_while_signal({:continue, 1}, bash, ctx, outer_acc, body_acc, _) do
+    execute_while_loop(bash, ctx, %{body_acc | exit_code: 0, iterations: outer_acc.iterations + 1})
+  end
+
+  defp handle_while_signal({:continue, n}, bash, _, _, acc, _) when n > 1 do
+    {signal_result(acc.stdout_io, acc.stderr_io, 0, {:continue, n - 1}), bash}
+  end
+
+  defp handle_while_signal({:return, _} = sig, bash, _, _, acc, body_result) do
+    {signal_result(acc.stdout_io, acc.stderr_io, body_result.exit_code, sig), bash}
+  end
+
+  defp handle_while_signal(nil, bash, ctx, outer_acc, body_acc, body_result) do
+    next_acc = %{
+      body_acc
+      | exit_code: body_result.exit_code,
+        iterations: outer_acc.iterations + 1
+    }
+
+    execute_while_loop(bash, ctx, next_acc)
+  end
+
+  # --- Helpers ---
+
+  defp finalize(stdout_io, stderr_io, exit_code) do
+    %{
+      stdout: IO.iodata_to_binary(stdout_io),
+      stderr: IO.iodata_to_binary(stderr_io),
+      exit_code: exit_code
+    }
+  end
+
+  defp signal_result(stdout_io, stderr_io, exit_code, signal) do
+    Result.to_map(%Result{
+      stdout: IO.iodata_to_binary(stdout_io),
+      stderr: IO.iodata_to_binary(stderr_io),
+      exit_code: exit_code,
+      signal: signal
+    })
   end
 end

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -15,6 +15,7 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   alias JustBash.AST
   alias JustBash.Fs.InMemoryFs
   alias JustBash.Interpreter.Expansion
+  alias JustBash.Limit
 
   @type result :: %{stdout: String.t(), stderr: String.t(), exit_code: non_neg_integer()}
   @type redir_type ::
@@ -162,6 +163,8 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   end
 
   defp write_to_file(bash, path, content, result, stream) do
+    Limit.check_file_size!(bash, content)
+
     case InMemoryFs.write_file(bash.fs, path, content) do
       {:ok, new_fs} ->
         updated_result = clear_stream(result, stream)
@@ -180,7 +183,10 @@ defmodule JustBash.Interpreter.Executor.Redirection do
         {:error, _} -> ""
       end
 
-    case InMemoryFs.write_file(bash.fs, path, current_content <> content) do
+    new_content = current_content <> content
+    Limit.check_file_size!(bash, new_content)
+
+    case InMemoryFs.write_file(bash.fs, path, new_content) do
       {:ok, new_fs} ->
         updated_result = clear_stream(result, stream)
         {updated_result, %{bash | fs: new_fs}}
@@ -192,6 +198,8 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   end
 
   defp write_combined_to_file(bash, path, content, result) do
+    Limit.check_file_size!(bash, content)
+
     case InMemoryFs.write_file(bash.fs, path, content) do
       {:ok, new_fs} ->
         {%{result | stdout: "", stderr: ""}, %{bash | fs: new_fs}}
@@ -209,7 +217,10 @@ defmodule JustBash.Interpreter.Executor.Redirection do
         {:error, _} -> ""
       end
 
-    case InMemoryFs.write_file(bash.fs, path, current_content <> content) do
+    new_content = current_content <> content
+    Limit.check_file_size!(bash, new_content)
+
+    case InMemoryFs.write_file(bash.fs, path, new_content) do
       {:ok, new_fs} ->
         {%{result | stdout: "", stderr: ""}, %{bash | fs: new_fs}}
 

--- a/lib/just_bash/interpreter/expansion/parameter.ex
+++ b/lib/just_bash/interpreter/expansion/parameter.ex
@@ -18,6 +18,7 @@ defmodule JustBash.Interpreter.Expansion.Parameter do
   alias JustBash.Arithmetic
   alias JustBash.AST
   alias JustBash.Interpreter.Expansion
+  alias JustBash.Limit
 
   @typedoc "Pending variable assignments from expansions like ${VAR:=default}"
   @type pending_assignments :: Expansion.pending_assignments()
@@ -273,6 +274,7 @@ defmodule JustBash.Interpreter.Expansion.Parameter do
     str = value || ""
     {pattern, assigns} = Expansion.expand_word_parts(bash, pattern_word.parts)
     regex_pattern = glob_to_regex(pattern)
+    Limit.check_regex_size!(bash.limits, regex_pattern)
 
     result =
       case side do
@@ -303,6 +305,8 @@ defmodule JustBash.Interpreter.Expansion.Parameter do
         :end -> glob_to_regex(pattern) <> "$"
         nil -> glob_to_regex(pattern)
       end
+
+    Limit.check_regex_size!(bash.limits, regex_pattern)
 
     result =
       case Regex.compile(regex_pattern) do

--- a/lib/just_bash/interpreter/state.ex
+++ b/lib/just_bash/interpreter/state.ex
@@ -38,15 +38,31 @@ defmodule JustBash.Interpreter.State do
           stdin: String.t() | nil,
           locals: MapSet.t(String.t()),
           assoc_arrays: MapSet.t(String.t()),
-          call_depth: non_neg_integer()
+          call_depth: non_neg_integer(),
+          step_count: non_neg_integer(),
+          output_bytes: non_neg_integer(),
+          exec_depth: non_neg_integer(),
+          max_exec_depth: non_neg_integer(),
+          halted: boolean()
         }
 
   defstruct stdin: nil,
             locals: MapSet.new(),
             assoc_arrays: MapSet.new(),
-            call_depth: 0
+            call_depth: 0,
+            step_count: 0,
+            output_bytes: 0,
+            exec_depth: 0,
+            max_exec_depth: 0,
+            halted: false
 
   @doc "Returns a fresh interpreter state."
   @spec new() :: t()
   def new, do: %__MODULE__{}
+
+  @doc "Reset per-exec counters for a new top-level execution."
+  @spec reset_counters(t()) :: t()
+  def reset_counters(%__MODULE__{} = state) do
+    %{state | step_count: 0, output_bytes: 0, max_exec_depth: 0, halted: false}
+  end
 end

--- a/lib/just_bash/limit.ex
+++ b/lib/just_bash/limit.ex
@@ -1,0 +1,215 @@
+defmodule JustBash.Limit do
+  @moduledoc """
+  Production resource limits for JustBash execution.
+
+  Prevents untrusted scripts from exhausting memory or CPU by enforcing
+  hard caps on computation steps, output size, file size, regex patterns,
+  and execution nesting depth.
+
+  ## Usage
+
+      # Default limits (recommended for production)
+      bash = JustBash.new()
+
+      # Preset profiles
+      bash = JustBash.new(limits: :strict)
+
+      # Custom limits (merged with defaults)
+      bash = JustBash.new(limits: [max_steps: 50_000])
+
+      # No limits (not recommended for untrusted input)
+      bash = JustBash.new(limits: false)
+  """
+
+  defmodule ExceededError do
+    @moduledoc """
+    Raised when a resource limit is exceeded during execution.
+
+    ## Kinds
+
+    - `:step_limit` — too many computation steps
+    - `:output_limit` — stdout + stderr exceeded byte cap
+    - `:file_size_limit` — single file write exceeded byte cap
+    - `:regex_pattern_limit` — regex pattern string too large
+    - `:exec_depth_limit` — eval/source nesting too deep
+    """
+    defexception [:kind, :message, :limit, :actual]
+  end
+
+  @enforce_keys [
+    :max_steps,
+    :max_output_bytes,
+    :max_file_bytes,
+    :max_regex_pattern_bytes,
+    :max_exec_depth
+  ]
+  defstruct [
+    :max_steps,
+    :max_output_bytes,
+    :max_file_bytes,
+    :max_regex_pattern_bytes,
+    :max_exec_depth
+  ]
+
+  @type t :: %__MODULE__{
+          max_steps: pos_integer(),
+          max_output_bytes: pos_integer(),
+          max_file_bytes: pos_integer(),
+          max_regex_pattern_bytes: pos_integer(),
+          max_exec_depth: pos_integer()
+        }
+
+  @default_values %{
+    max_steps: 100_000,
+    max_output_bytes: 1_048_576,
+    max_file_bytes: 1_048_576,
+    max_regex_pattern_bytes: 10_000,
+    max_exec_depth: 128
+  }
+
+  @valid_keys Map.keys(@default_values)
+
+  @doc "Build limits from a preset atom, keyword list, or `false` to disable."
+  @spec new(atom() | keyword() | false) :: t() | nil
+  def new(false), do: nil
+  def new(:default), do: defaults()
+
+  def new(:strict),
+    do: %{defaults() | max_steps: 10_000, max_output_bytes: 65_536, max_file_bytes: 65_536}
+
+  def new(:relaxed),
+    do: %{
+      defaults()
+      | max_steps: 1_000_000,
+        max_output_bytes: 10_485_760,
+        max_file_bytes: 10_485_760
+    }
+
+  def new(opts) when is_list(opts) do
+    unknown = Keyword.keys(opts) -- @valid_keys
+
+    if unknown != [] do
+      raise ArgumentError, "unknown limit keys: #{inspect(unknown)}"
+    end
+
+    Enum.each(opts, fn {_k, v} ->
+      unless is_integer(v) and v > 0 do
+        raise ArgumentError, "limit values must be positive integers, got: #{inspect(opts)}"
+      end
+    end)
+
+    struct!(defaults(), opts)
+  end
+
+  @doc "Returns the default limits."
+  @spec defaults() :: t()
+  def defaults, do: struct!(__MODULE__, @default_values)
+
+  # --- Counting functions (always increment, enforce only when limits set) ---
+
+  @doc "Increment step counter. Raises `ExceededError` if limit is reached."
+  @spec step!(JustBash.t()) :: JustBash.t()
+  def step!(%{interpreter: interp} = bash) do
+    count = interp.step_count + 1
+
+    if bash.limits && count > bash.limits.max_steps do
+      raise ExceededError,
+        kind: :step_limit,
+        message: "execution step limit exceeded (#{bash.limits.max_steps})",
+        limit: bash.limits.max_steps,
+        actual: count
+    end
+
+    %{bash | interpreter: %{interp | step_count: count}}
+  end
+
+  @doc "Track output bytes. Raises `ExceededError` if limit is reached."
+  @spec track_output!(JustBash.t(), non_neg_integer()) :: JustBash.t()
+  def track_output!(%{interpreter: interp} = bash, new_bytes) do
+    total = interp.output_bytes + new_bytes
+
+    if bash.limits && total > bash.limits.max_output_bytes do
+      raise ExceededError,
+        kind: :output_limit,
+        message: "output size limit exceeded (#{bash.limits.max_output_bytes} bytes)",
+        limit: bash.limits.max_output_bytes,
+        actual: total
+    end
+
+    %{bash | interpreter: %{interp | output_bytes: total}}
+  end
+
+  @doc "Increment exec depth and track the high-water mark. Raises `ExceededError` if limit is exceeded."
+  @spec track_exec_depth!(JustBash.t()) :: JustBash.t()
+  def track_exec_depth!(%{interpreter: interp} = bash) do
+    depth = interp.exec_depth + 1
+    max_depth = max(depth, interp.max_exec_depth)
+
+    if bash.limits && depth > bash.limits.max_exec_depth do
+      raise ExceededError,
+        kind: :exec_depth_limit,
+        message: "execution nesting depth exceeded (#{bash.limits.max_exec_depth})",
+        limit: bash.limits.max_exec_depth,
+        actual: depth
+    end
+
+    %{bash | interpreter: %{interp | exec_depth: depth, max_exec_depth: max_depth}}
+  end
+
+  # --- Pure check functions (no state mutation) ---
+
+  @doc "Check file data size before writing. Raises `ExceededError` if too large."
+  @spec check_file_size!(JustBash.t(), String.t()) :: :ok
+  def check_file_size!(%{limits: nil}, _data), do: :ok
+
+  def check_file_size!(%{limits: limits}, data) do
+    size = byte_size(data)
+
+    if size > limits.max_file_bytes do
+      raise ExceededError,
+        kind: :file_size_limit,
+        message: "file size limit exceeded (#{limits.max_file_bytes} bytes)",
+        limit: limits.max_file_bytes,
+        actual: size
+    end
+
+    :ok
+  end
+
+  @doc """
+  Check regex pattern size and compile. Raises `ExceededError` if pattern too large.
+
+  Centralizes the check-then-compile pattern used across commands (grep, sed, awk, jq, etc.).
+  Accepts a limits struct (not a full bash struct) so it can be called from
+  command internals that don't carry the full struct.
+  """
+  @spec compile_regex(t() | nil, String.t(), String.t() | [atom()]) ::
+          {:ok, Regex.t()} | {:error, term()}
+  def compile_regex(limits, pattern, opts \\ "") do
+    check_regex_size!(limits, pattern)
+    Regex.compile(pattern, opts)
+  end
+
+  @doc """
+  Check regex pattern size only. Use `compile_regex/3` when you also need compilation.
+
+  For call sites that need custom compilation logic (e.g. grep's flag handling,
+  sed's BRE-to-ERE conversion), call this directly.
+  """
+  @spec check_regex_size!(t() | nil, String.t()) :: :ok
+  def check_regex_size!(nil, _pattern), do: :ok
+
+  def check_regex_size!(%__MODULE__{} = limits, pattern) do
+    size = byte_size(pattern)
+
+    if size > limits.max_regex_pattern_bytes do
+      raise ExceededError,
+        kind: :regex_pattern_limit,
+        message: "regex pattern size limit exceeded (#{limits.max_regex_pattern_bytes} bytes)",
+        limit: limits.max_regex_pattern_bytes,
+        actual: size
+    end
+
+    :ok
+  end
+end

--- a/lib/just_bash/parser/lexer.ex
+++ b/lib/just_bash/parser/lexer.ex
@@ -779,7 +779,7 @@ defmodule JustBash.Parser.Lexer do
 
   defp classify_word(value, raw_value, false) do
     cond do
-      value in @reserved -> String.to_atom(value)
+      value in @reserved -> String.to_existing_atom(value)
       assignment?(raw_value) -> :assignment_word
       all_digits?(value) -> :number
       name?(value) -> :name

--- a/lib/just_bash/parser/parser/compound.ex
+++ b/lib/just_bash/parser/parser/compound.ex
@@ -13,6 +13,10 @@ defmodule JustBash.Parser.Compound do
 
   alias JustBash.AST
 
+  @unary_ops ~w(-a -e -f -d -r -w -x -s -z -n -L -h -b -c -p -S -t -g -u -k -O -G -N -v)
+  @binary_ops ~w(= == != =~ < > -eq -ne -lt -le -gt -ge -nt -ot -ef)
+  @cond_op_atoms Map.new(@unary_ops ++ @binary_ops, fn name -> {name, :"#{name}"} end)
+
   @doc """
   Parse an if/elif/else/fi construct.
   """
@@ -359,7 +363,7 @@ defmodule JustBash.Parser.Compound do
       unary_cond_op?(parser, helpers) ->
         {op_token, parser} = helpers.advance(parser)
         {word, parser} = parse_cond_word(parser, helpers)
-        operator = String.to_existing_atom(op_token.value)
+        operator = Map.fetch!(@cond_op_atoms, op_token.value)
         {%AST.CondUnary{operator: operator, operand: word}, parser}
 
       true ->
@@ -371,7 +375,7 @@ defmodule JustBash.Parser.Compound do
 
           binary_cond_op?(parser, helpers) ->
             {op_token, parser} = helpers.advance(parser)
-            operator = String.to_existing_atom(op_token.value)
+            operator = Map.fetch!(@cond_op_atoms, op_token.value)
 
             {right_word, parser} =
               if operator == :=~ do
@@ -390,9 +394,6 @@ defmodule JustBash.Parser.Compound do
         end
     end
   end
-
-  @unary_ops ~w(-a -e -f -d -r -w -x -s -z -n -L -h -b -c -p -S -t -g -u -k -O -G -N -v)
-  @binary_ops ~w(= == != =~ < > -eq -ne -lt -le -gt -ge -nt -ot -ef)
 
   defp unary_cond_op?(parser, helpers) do
     helpers.current(parser).value in @unary_ops

--- a/lib/just_bash/parser/parser/compound.ex
+++ b/lib/just_bash/parser/parser/compound.ex
@@ -359,7 +359,7 @@ defmodule JustBash.Parser.Compound do
       unary_cond_op?(parser, helpers) ->
         {op_token, parser} = helpers.advance(parser)
         {word, parser} = parse_cond_word(parser, helpers)
-        operator = String.to_atom(op_token.value)
+        operator = String.to_existing_atom(op_token.value)
         {%AST.CondUnary{operator: operator, operand: word}, parser}
 
       true ->
@@ -371,7 +371,7 @@ defmodule JustBash.Parser.Compound do
 
           binary_cond_op?(parser, helpers) ->
             {op_token, parser} = helpers.advance(parser)
-            operator = String.to_atom(op_token.value)
+            operator = String.to_existing_atom(op_token.value)
 
             {right_word, parser} =
               if operator == :=~ do

--- a/test/banned_call_tracer_test.exs
+++ b/test/banned_call_tracer_test.exs
@@ -122,7 +122,9 @@ defmodule JustBash.BannedCallTracerTest do
         # Benchmark runner — writes results.jsonl to host filesystem
         "Elixir.JustBash.Eval.Runner",
         # Spec test parser — reads fixture files from host filesystem during mix test
-        "Elixir.JustBash.SpecTest.Parser"
+        "Elixir.JustBash.SpecTest.Parser",
+        # Test-only mock that uses Process dictionary for test state
+        "Elixir.JustBash.MockHttpClient"
       ]
 
       violations =

--- a/test/banned_call_tracer_test.exs
+++ b/test/banned_call_tracer_test.exs
@@ -107,6 +107,31 @@ defmodule JustBash.BannedCallTracerTest do
                end)
     end
 
+    test "no String.to_atom in lib/just_bash source" do
+      violations =
+        Path.wildcard("lib/just_bash/**/*.ex")
+        |> Enum.flat_map(fn path ->
+          path
+          |> File.read!()
+          |> String.split("\n")
+          |> Enum.with_index(1)
+          |> Enum.reject(fn {line, _} -> String.match?(line, ~r/^\s*#|\@(doc|moduledoc)/) end)
+          |> Enum.flat_map(fn {line, lineno} ->
+            if String.match?(line, ~r/String\.to_atom\b/) do
+              [{path, lineno, line}]
+            else
+              []
+            end
+          end)
+        end)
+
+      assert violations == [],
+             "String.to_atom found (use String.to_existing_atom or an explicit map):\n" <>
+               Enum.map_join(violations, "\n", fn {path, line, content} ->
+                 "  #{path}:#{line}: #{String.trim(content)}"
+               end)
+    end
+
     test "no banned calls in lib/ (excluding intentional real-IO modules)" do
       # Modules allowed to use real filesystem / environment access,
       # with the reason each is exempt from the sandbox rule:

--- a/test/limit_resource_exhaustion_test.exs
+++ b/test/limit_resource_exhaustion_test.exs
@@ -1,0 +1,205 @@
+defmodule JustBash.Limit.ResourceExhaustionTest do
+  @moduledoc """
+  Adversarial tests that verify resource limits protect the BEAM.
+
+  Each test simulates a resource exhaustion vector that would hang or OOM
+  a production system without limits. Tests use strict limits and short
+  timeouts to prove the sandbox terminates quickly.
+  """
+  use ExUnit.Case, async: true
+
+  # Every test must complete well under this. If any test takes even close
+  # to this long, the limit enforcement failed.
+  @moduletag timeout: 5_000
+
+  defp strict_bash(overrides \\ []) do
+    defaults = [
+      max_steps: 1_000,
+      max_output_bytes: 10_000,
+      max_file_bytes: 10_000,
+      max_regex_pattern_bytes: 100,
+      max_exec_depth: 5
+    ]
+
+    # max_iterations must exceed max_steps so step limit fires first
+    JustBash.new(limits: Keyword.merge(defaults, overrides), max_iterations: 10_000)
+  end
+
+  describe "CPU exhaustion" do
+    test "infinite while loop" do
+      bash = strict_bash()
+      {result, _} = JustBash.exec(bash, "while true; do :; done")
+      assert result.exit_code == 1
+    end
+
+    test "infinite until loop" do
+      bash = strict_bash()
+      {result, _} = JustBash.exec(bash, "until false; do :; done")
+      assert result.exit_code == 1
+    end
+
+    test "for loop over huge expansion" do
+      bash = strict_bash()
+      {result, _} = JustBash.exec(bash, "for i in {1..10000}; do echo $i; done")
+      assert result.exit_code == 1
+    end
+
+    test "recursive function (fork bomb pattern)" do
+      bash = strict_bash()
+      {result, _} = JustBash.exec(bash, "bomb() { bomb; }; bomb")
+      assert result.exit_code == 1
+    end
+
+    test "nested loop multiplication" do
+      bash = strict_bash()
+
+      {result, _} =
+        JustBash.exec(bash, """
+        for i in $(seq 1 100); do
+          for j in $(seq 1 100); do
+            echo "$i $j"
+          done
+        done
+        """)
+
+      assert result.exit_code == 1
+    end
+  end
+
+  describe "memory exhaustion via output" do
+    test "echo in tight loop" do
+      bash = strict_bash(max_output_bytes: 1_000)
+
+      {result, _} =
+        JustBash.exec(bash, "while true; do echo AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA; done")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "limit"
+    end
+
+    test "cat /dev/zero equivalent (repeated printf)" do
+      bash = strict_bash(max_output_bytes: 500)
+      {result, _} = JustBash.exec(bash, ~s(while true; do printf '%0100d' 0; done))
+      assert result.exit_code == 1
+    end
+
+    test "yes command flood" do
+      bash = strict_bash(max_output_bytes: 500)
+      {result, _} = JustBash.exec(bash, "yes")
+      assert result.exit_code == 1
+    end
+  end
+
+  describe "memory exhaustion via filesystem" do
+    test "write oversized file" do
+      bash = strict_bash(max_file_bytes: 100)
+      big = String.duplicate("X", 200)
+      {result, _} = JustBash.exec(bash, ~s(echo -n "#{big}" > /tmp/evil.txt))
+      assert result.exit_code == 1
+      assert result.stderr =~ "file size limit"
+    end
+
+    test "append loop to grow file past limit" do
+      bash = strict_bash(max_file_bytes: 100)
+
+      {result, _} =
+        JustBash.exec(
+          bash,
+          "for i in $(seq 1 100); do echo AAAAAAAAAA >> /tmp/grow.txt; done"
+        )
+
+      assert result.exit_code == 1
+    end
+  end
+
+  describe "ReDoS (regex denial of service)" do
+    test "oversized regex pattern in sed" do
+      bash = strict_bash(max_regex_pattern_bytes: 50)
+      evil = String.duplicate("(a+)+", 20)
+      {result, _} = JustBash.exec(bash, "echo x | sed 's/#{evil}/y/'")
+      assert result.exit_code == 1
+      assert result.stderr =~ "regex pattern size limit"
+    end
+
+    test "oversized regex pattern in grep" do
+      bash = strict_bash(max_regex_pattern_bytes: 50)
+      evil = String.duplicate("a", 100)
+      {result, _} = JustBash.exec(bash, "echo x | grep '#{evil}'")
+      assert result.exit_code == 1
+    end
+
+    test "oversized regex in awk" do
+      bash = strict_bash(max_regex_pattern_bytes: 50)
+      evil = String.duplicate("a", 100)
+      {result, _} = JustBash.exec(bash, "echo x | awk '/#{evil}/{print}'")
+      assert result.exit_code == 1
+    end
+
+    test "oversized regex in [[ =~ ]]" do
+      bash = strict_bash(max_regex_pattern_bytes: 50)
+      evil = String.duplicate("a", 100)
+      {result, _} = JustBash.exec(bash, ~s([[ "x" =~ #{evil} ]]))
+      assert result.exit_code == 1
+    end
+
+    test "oversized regex in parameter expansion" do
+      bash = strict_bash(max_regex_pattern_bytes: 50)
+      evil = String.duplicate("a", 100)
+      {result, _} = JustBash.exec(bash, ~s(x=hello; echo "${x/#{evil}/world}"))
+      assert result.exit_code == 1
+    end
+  end
+
+  describe "eval/source nesting bomb" do
+    test "deeply nested eval" do
+      bash = strict_bash(max_exec_depth: 3)
+      {result, _} = JustBash.exec(bash, "eval 'eval \"eval \\\"echo deep\\\"\"'")
+      assert result.exit_code == 1
+      assert result.stderr =~ "nesting depth"
+    end
+
+    test "eval calling eval in loop" do
+      bash = strict_bash(max_exec_depth: 3)
+
+      {result, _} =
+        JustBash.exec(
+          bash,
+          ~s(for i in 1 2 3 4 5 6 7 8 9 10; do eval "eval 'eval echo \\$i'"; done)
+        )
+
+      assert result.exit_code == 1
+    end
+  end
+
+  describe "combined attacks" do
+    test "fork bomb + output flood" do
+      bash = strict_bash()
+
+      {result, _} =
+        JustBash.exec(bash, """
+        flood() {
+          while true; do
+            echo AAAAAAAAAA
+            flood
+          done
+        }
+        flood
+        """)
+
+      assert result.exit_code == 1
+    end
+
+    test "script terminates and returns promptly" do
+      # Key production safety test: even with an adversarial script,
+      # exec returns quickly and the BEAM is unharmed.
+      bash = strict_bash()
+      start = System.monotonic_time(:millisecond)
+
+      {_result, _} = JustBash.exec(bash, "while true; do while true; do echo x; done; done")
+
+      elapsed = System.monotonic_time(:millisecond) - start
+      # Must complete in under 1 second — proves we're not spinning
+      assert elapsed < 1_000, "adversarial script took #{elapsed}ms, should be under 1000ms"
+    end
+  end
+end

--- a/test/limit_test.exs
+++ b/test/limit_test.exs
@@ -1,0 +1,281 @@
+defmodule JustBash.LimitTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.Limit
+
+  describe "Limit.new/1" do
+    test "default preset" do
+      limits = Limit.new(:default)
+      assert limits.max_steps == 100_000
+      assert limits.max_output_bytes == 1_048_576
+    end
+
+    test "strict preset" do
+      limits = Limit.new(:strict)
+      assert limits.max_steps == 10_000
+    end
+
+    test "relaxed preset" do
+      limits = Limit.new(:relaxed)
+      assert limits.max_steps == 1_000_000
+    end
+
+    test "custom keyword list merges with defaults" do
+      limits = Limit.new(max_steps: 42)
+      assert limits.max_steps == 42
+      assert limits.max_output_bytes == 1_048_576
+    end
+
+    test "false disables limits" do
+      assert Limit.new(false) == nil
+    end
+
+    test "rejects unknown keys" do
+      assert_raise ArgumentError, ~r/unknown limit keys/, fn ->
+        Limit.new(max_frobbles: 5)
+      end
+    end
+
+    test "rejects non-positive values" do
+      assert_raise ArgumentError, ~r/positive integers/, fn ->
+        Limit.new(max_steps: 0)
+      end
+    end
+  end
+
+  describe "JustBash.new/1 limits option" do
+    test "defaults to :default limits" do
+      bash = JustBash.new()
+      assert bash.limits.max_steps == 100_000
+    end
+
+    test "accepts preset atom" do
+      bash = JustBash.new(limits: :strict)
+      assert bash.limits.max_steps == 10_000
+    end
+
+    test "accepts keyword overrides" do
+      bash = JustBash.new(limits: [max_steps: 500])
+      assert bash.limits.max_steps == 500
+    end
+
+    test "false disables limits" do
+      bash = JustBash.new(limits: false)
+      assert bash.limits == nil
+    end
+  end
+
+  describe "step limit" do
+    test "stops execution when step limit exceeded" do
+      bash = JustBash.new(limits: [max_steps: 5])
+      {result, _bash} = JustBash.exec(bash, "echo a; echo b; echo c; echo d; echo e; echo f")
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution step limit exceeded"
+    end
+
+    test "while loop respects step limit" do
+      bash = JustBash.new(limits: [max_steps: 10])
+      {result, _bash} = JustBash.exec(bash, "i=0; while true; do i=$((i+1)); done; echo $i")
+      assert result.exit_code == 1
+      assert result.stderr =~ "step limit"
+    end
+
+    test "for loop respects step limit" do
+      bash = JustBash.new(limits: [max_steps: 3])
+      {result, _bash} = JustBash.exec(bash, "for i in 1 2 3 4 5 6 7 8 9 10; do echo $i; done")
+      assert result.exit_code == 1
+      assert result.stderr =~ "step limit"
+    end
+
+    test "no limit when limits: false" do
+      bash = JustBash.new(limits: false, max_iterations: 200)
+
+      {result, _bash} =
+        JustBash.exec(bash, "i=0; while [ $i -lt 100 ]; do echo $i; i=$((i+1)); done")
+
+      assert result.exit_code == 0
+    end
+  end
+
+  describe "output limit" do
+    test "stops execution when output exceeds limit" do
+      bash = JustBash.new(limits: [max_output_bytes: 50])
+
+      {result, _bash} =
+        JustBash.exec(bash, "i=0; while [ $i -lt 100 ]; do echo $i; i=$((i+1)); done")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "output size limit exceeded"
+    end
+
+    test "single large output triggers limit" do
+      bash = JustBash.new(limits: [max_output_bytes: 10])
+
+      {result, _bash} =
+        JustBash.exec(bash, ~s(echo "this is a long output that exceeds the limit"))
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "output size limit exceeded"
+    end
+  end
+
+  describe "file size limit" do
+    test "blocks writing files larger than limit" do
+      bash = JustBash.new(limits: [max_file_bytes: 10])
+      big_data = String.duplicate("x", 100)
+      {result, _bash} = JustBash.exec(bash, ~s(echo -n "#{big_data}" > /tmp/big.txt))
+      assert result.exit_code == 1
+      assert result.stderr =~ "file size limit exceeded"
+    end
+
+    test "allows writing files within limit" do
+      bash = JustBash.new(limits: [max_file_bytes: 1000])
+      {result, _bash} = JustBash.exec(bash, ~s(echo "hello" > /tmp/small.txt))
+      assert result.exit_code == 0
+    end
+  end
+
+  describe "regex pattern limit" do
+    test "sed rejects oversized patterns" do
+      bash = JustBash.new(limits: [max_regex_pattern_bytes: 5])
+      long_pattern = String.duplicate("a", 20)
+      {result, _bash} = JustBash.exec(bash, "echo hello | sed 's/#{long_pattern}/world/'")
+      assert result.exit_code == 1
+      assert result.stderr =~ "regex pattern size limit exceeded"
+    end
+
+    test "grep rejects oversized patterns" do
+      bash =
+        JustBash.new(
+          limits: [max_regex_pattern_bytes: 5],
+          files: %{"/data.txt" => "hello world"}
+        )
+
+      long_pattern = String.duplicate("a", 20)
+      {result, _bash} = JustBash.exec(bash, "grep '#{long_pattern}' /data.txt")
+      assert result.exit_code == 1
+      assert result.stderr =~ "regex pattern size limit exceeded"
+    end
+
+    test "awk rejects oversized patterns" do
+      bash = JustBash.new(limits: [max_regex_pattern_bytes: 5])
+      long_pattern = String.duplicate("a", 20)
+      {result, _bash} = JustBash.exec(bash, "echo test | awk '/#{long_pattern}/{print}'")
+      assert result.exit_code == 1
+      assert result.stderr =~ "regex pattern size limit exceeded"
+    end
+
+    test "[[ =~ ]] rejects oversized patterns" do
+      bash = JustBash.new(limits: [max_regex_pattern_bytes: 5])
+      long_pattern = String.duplicate("a", 20)
+      {result, _bash} = JustBash.exec(bash, ~s([[ "hello" =~ #{long_pattern} ]]))
+      assert result.exit_code == 1
+      assert result.stderr =~ "regex pattern size limit exceeded"
+    end
+
+    test "${var/pattern/replacement} rejects oversized patterns" do
+      bash = JustBash.new(limits: [max_regex_pattern_bytes: 5])
+      long_pattern = String.duplicate("a", 20)
+      {result, _bash} = JustBash.exec(bash, ~s(x=hello; echo "${x/#{long_pattern}/world}"))
+      assert result.exit_code == 1
+      assert result.stderr =~ "regex pattern size limit exceeded"
+    end
+
+    test "allows patterns within limit" do
+      bash = JustBash.new(limits: [max_regex_pattern_bytes: 100])
+      {result, _bash} = JustBash.exec(bash, "echo hello | sed 's/hello/world/'")
+      assert result.exit_code == 0
+      assert result.stdout == "world\n"
+    end
+  end
+
+  describe "exec depth limit" do
+    test "stops deeply nested eval" do
+      bash = JustBash.new(limits: [max_exec_depth: 3])
+      {result, _bash} = JustBash.exec(bash, "eval 'eval \"eval \\\"echo deep\\\"\"'")
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution nesting depth exceeded"
+    end
+
+    test "allows eval within limit" do
+      bash = JustBash.new(limits: [max_exec_depth: 10])
+      {result, _bash} = JustBash.exec(bash, "eval 'echo hello'")
+      assert result.exit_code == 0
+      assert result.stdout == "hello\n"
+    end
+  end
+
+  describe "halted flag prevents further execution" do
+    test "no more statements run after limit exceeded" do
+      bash = JustBash.new(limits: [max_steps: 2])
+      # After step limit, subsequent echos should not produce output
+      {result, _bash} = JustBash.exec(bash, "echo a; echo b; echo c; echo SHOULD_NOT_APPEAR")
+      refute result.stdout =~ "SHOULD_NOT_APPEAR"
+    end
+  end
+
+  describe "JustBash.stats/1" do
+    test "returns step count and output bytes after execution" do
+      bash = JustBash.new()
+      {_, bash} = JustBash.exec(bash, "echo hello")
+      stats = JustBash.stats(bash)
+
+      assert stats.steps > 0
+      assert stats.output_bytes > 0
+      assert stats.max_exec_depth >= 1
+    end
+
+    test "steps increase with more commands" do
+      bash = JustBash.new()
+      {_, bash1} = JustBash.exec(bash, "echo a")
+      {_, bash2} = JustBash.exec(bash, "echo a; echo b; echo c")
+
+      assert JustBash.stats(bash2).steps > JustBash.stats(bash1).steps
+    end
+
+    test "output bytes reflect actual output size" do
+      bash = JustBash.new()
+      {_, bash} = JustBash.exec(bash, ~s(echo -n "hello"))
+      stats = JustBash.stats(bash)
+
+      assert stats.output_bytes == 5
+    end
+
+    test "loop iterations consume more steps than simple commands" do
+      bash = JustBash.new()
+      {_, simple} = JustBash.exec(bash, "echo done")
+      {_, looped} = JustBash.exec(bash, "for i in 1 2 3 4 5; do echo $i; done")
+
+      assert JustBash.stats(looped).steps > JustBash.stats(simple).steps
+    end
+
+    test "counters reset between top-level exec calls" do
+      bash = JustBash.new()
+      {_, bash} = JustBash.exec(bash, "for i in 1 2 3 4 5; do echo $i; done")
+      first = JustBash.stats(bash)
+
+      {_, bash} = JustBash.exec(bash, "echo one")
+      second = JustBash.stats(bash)
+
+      assert second.steps < first.steps
+      assert second.output_bytes < first.output_bytes
+    end
+
+    test "stats work with limits disabled" do
+      bash = JustBash.new(limits: false)
+      {_, bash} = JustBash.exec(bash, "echo hello")
+      stats = JustBash.stats(bash)
+
+      assert stats.steps > 0
+      assert stats.output_bytes > 0
+      assert stats.max_exec_depth >= 1
+    end
+
+    test "returns zero stats on fresh bash" do
+      bash = JustBash.new()
+      stats = JustBash.stats(bash)
+
+      assert stats == %{steps: 0, output_bytes: 0, max_exec_depth: 0}
+    end
+  end
+end

--- a/test/telemetry_test.exs
+++ b/test/telemetry_test.exs
@@ -214,7 +214,7 @@ defmodule JustBash.TelemetryTest do
                        %{until: false}}
 
       assert_received {^ref, [:just_bash, :while_loop, :stop], %{duration: _},
-                       %{until: false, iteration_count: 3, exit_code: 0}}
+                       %{until: false, exit_code: 0}}
     end
 
     test "emits events for until loop with until: true", %{ref: ref} do
@@ -224,15 +224,14 @@ defmodule JustBash.TelemetryTest do
       assert_received {^ref, [:just_bash, :while_loop, :start], _, %{until: true}}
 
       assert_received {^ref, [:just_bash, :while_loop, :stop], %{duration: _},
-                       %{until: true, iteration_count: 2, exit_code: 0}}
+                       %{until: true, exit_code: 0}}
     end
 
     test "reports zero iterations when condition is false immediately", %{ref: ref} do
       bash = JustBash.new()
       JustBash.exec(bash, "while false; do echo nope; done")
 
-      assert_received {^ref, [:just_bash, :while_loop, :stop], _,
-                       %{iteration_count: 0, exit_code: 0}}
+      assert_received {^ref, [:just_bash, :while_loop, :stop], _, %{exit_code: 0}}
     end
   end
 end


### PR DESCRIPTION
## Summary

- **`JustBash.Limit`** — enforces hard caps on computation steps (100k default), output bytes (1MB), file size (1MB), regex pattern size (10KB), and eval nesting depth (128). Struct-backed with `@enforce_keys`, preset profiles (`:default`, `:strict`, `:relaxed`), keyword overrides, or `false` to disable. Single rescue boundary in `execute_statement` catches `Limit.ExceededError` from anywhere in the call tree.

- **`JustBash.stats/1`** — returns `%{steps, output_bytes, max_exec_depth}` after each `exec/2` call. Counters always increment regardless of limit configuration. Designed for RL reward shaping — penalize programs that use more computation.

- **Zero Process dictionary usage** — sed parser threads a `ctx` map, awk parser uses a struct field, awk evaluator passes state explicitly. `Process.put/get/delete` and `:ets` are now banned in the call tracer.

- **`Limit.compile_regex/3`** centralizes the check-then-compile pattern used across 6 modules (grep, sed, awk, jq, conditional, parameter expansion).

- **54 new tests** — `limit_test.exs` (35 tests: presets, each limit type, halted flag, stats) and `limit_resource_exhaustion_test.exs` (19 adversarial tests with 5s timeout: infinite loops, output floods, ReDoS, eval bombs, combined attacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)