### PR TITLE
Add xxd/od, curl flags, grep -P, awk crash guard

### DIFF
--- a/lib/just_bash/commands/awk/evaluator.ex
+++ b/lib/just_bash/commands/awk/evaluator.ex
@@ -1287,6 +1287,11 @@ defmodule JustBash.Commands.Awk.Evaluator do
     Map.get(arr, key, "")
   end
 
+  # Defensive catch-all: unknown AST shapes return an empty string rather than
+  # crashing the whole bash process. Real awk would raise a syntax error at
+  # parse time; we'd rather keep the shell alive and let the user see nothing.
+  def evaluate_expression(_unknown, _state), do: ""
+
   @doc """
   Evaluate an expression and return both the value and potentially updated state.
   Most expressions don't modify state, but increment/decrement expressions do.

--- a/lib/just_bash/commands/curl.ex
+++ b/lib/just_bash/commands/curl.ex
@@ -39,6 +39,9 @@ defmodule JustBash.Commands.Curl do
           opts.help ->
             {Command.ok(help_text()), bash}
 
+          opts.version ->
+            {Command.ok(version_text()), bash}
+
           opts.url == nil ->
             {Command.error("curl: no URL specified\n"), bash}
 
@@ -129,7 +132,10 @@ defmodule JustBash.Commands.Curl do
       user: [short: "-u", long: "--user", type: :string],
       user_agent: [short: "-A", long: "--user-agent", type: :string],
       timeout: [short: "-m", long: "--max-time", type: :integer, default: @default_timeout],
-      connect_timeout: [long: "--connect-timeout", type: :integer]
+      connect_timeout: [long: "--connect-timeout", type: :integer],
+      version: [short: "-V", long: "--version", type: :boolean],
+      write_out: [short: "-w", long: "--write-out", type: :string],
+      dump_header: [short: "-D", long: "--dump-header", type: :string]
     ]
   end
 
@@ -194,24 +200,69 @@ defmodule JustBash.Commands.Curl do
 
   defp handle_response(bash, response, opts) do
     output = build_output(response, opts)
-    write_output(bash, output, opts)
+
+    case maybe_dump_header(bash, response, opts) do
+      {:ok, bash} ->
+        write_output(bash, output, response, opts)
+
+      {:error, reason} ->
+        {Command.error("curl: #{opts.dump_header}: #{reason}\n"), bash}
+    end
   end
 
-  defp write_output(bash, output, %{output_file: nil}) do
-    {Command.ok(output), bash}
+  defp maybe_dump_header(bash, _response, %{dump_header: nil}), do: {:ok, bash}
+
+  defp maybe_dump_header(bash, response, %{dump_header: path}) do
+    status_line = "HTTP/1.1 #{response.status} #{status_text(response.status)}\r\n"
+    headers = Enum.map_join(response.headers, fn {k, v} -> "#{k}: #{v}\r\n" end)
+    content = status_line <> headers <> "\r\n"
+    resolved = InMemoryFs.resolve_path(bash.cwd, path)
+
+    case InMemoryFs.write_file(bash.fs, resolved, content) do
+      {:ok, fs} -> {:ok, %{bash | fs: fs}}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
-  defp write_output(bash, output, opts) do
+  defp write_output(bash, output, response, %{output_file: nil} = opts) do
+    {Command.ok(output <> render_write_out(response, opts)), bash}
+  end
+
+  defp write_output(bash, output, response, opts) do
     resolved = InMemoryFs.resolve_path(bash.cwd, opts.output_file)
+    body = if opts.output_file == "/dev/null", do: :discard, else: output
 
-    case InMemoryFs.write_file(bash.fs, resolved, output) do
+    result =
+      case body do
+        :discard -> {:ok, bash.fs}
+        content -> InMemoryFs.write_file(bash.fs, resolved, content)
+      end
+
+    case result do
       {:ok, new_fs} ->
         progress = if opts.silent, do: "", else: "  % Total    % Received\n"
-        {Command.ok(progress), %{bash | fs: new_fs}}
+        stdout = progress <> render_write_out(response, opts)
+        bash = if body == :discard, do: bash, else: %{bash | fs: new_fs}
+        {Command.ok(stdout), bash}
 
       {:error, reason} ->
         {Command.error("curl: #{opts.output_file}: #{reason}\n"), bash}
     end
+  end
+
+  defp render_write_out(_response, %{write_out: nil}), do: ""
+
+  defp render_write_out(response, %{write_out: fmt}) do
+    fmt
+    |> String.replace("%{http_code}", Integer.to_string(response.status))
+    |> String.replace("%{response_code}", Integer.to_string(response.status))
+    |> String.replace("\\n", "\n")
+    |> String.replace("\\r", "\r")
+    |> String.replace("\\t", "\t")
+  end
+
+  defp version_text do
+    "curl 8.0.0 (just_bash) libcurl/8.0.0\nRelease-Date: 2025-01-01\nProtocols: http https\nFeatures: \n"
   end
 
   defp build_output(response, opts) do

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -13,6 +13,7 @@ defmodule JustBash.Commands.Grep do
       :v,
       :e_ext,
       :f_fixed,
+      :p_pcre,
       :c,
       :l,
       :n,
@@ -27,6 +28,7 @@ defmodule JustBash.Commands.Grep do
     aliases: %{
       "E" => :e_ext,
       "F" => :f_fixed,
+      "P" => :p_pcre,
       "H" => :with_filename,
       "h" => :no_filename,
       "R" => :r
@@ -37,6 +39,7 @@ defmodule JustBash.Commands.Grep do
       v: false,
       e_ext: false,
       f_fixed: false,
+      p_pcre: false,
       c: false,
       l: false,
       n: false,

--- a/lib/just_bash/commands/od.ex
+++ b/lib/just_bash/commands/od.ex
@@ -1,0 +1,90 @@
+defmodule JustBash.Commands.Od do
+  @moduledoc "The `od` command - dump files in octal and other formats."
+  @behaviour JustBash.Commands.Command
+
+  alias JustBash.Commands.Command
+  alias JustBash.Fs.InMemoryFs
+
+  @impl true
+  def names, do: ["od"]
+
+  @impl true
+  def execute(bash, args, stdin) do
+    case parse_args(args, %{format: :octal, file: nil}) do
+      {:error, msg} ->
+        {Command.error(msg), bash}
+
+      {:ok, opts} ->
+        case read_input(bash, opts.file, stdin) do
+          {:ok, data} -> {Command.ok(render(data, opts.format)), bash}
+          {:error, msg} -> {Command.error(msg), bash}
+        end
+    end
+  end
+
+  defp parse_args([], opts), do: {:ok, opts}
+  defp parse_args(["-c" | rest], opts), do: parse_args(rest, %{opts | format: :char})
+  defp parse_args(["-b" | rest], opts), do: parse_args(rest, %{opts | format: :octal_bytes})
+  defp parse_args(["-x" | rest], opts), do: parse_args(rest, %{opts | format: :hex})
+  defp parse_args(["-An" | rest], opts), do: parse_args(rest, opts)
+  defp parse_args(["-A", _ | rest], opts), do: parse_args(rest, opts)
+  defp parse_args(["-t", _ | rest], opts), do: parse_args(rest, opts)
+
+  defp parse_args(["-" <> _ = flag | _], _opts),
+    do: {:error, "od: unknown option: #{flag}\n"}
+
+  defp parse_args([file | rest], opts), do: parse_args(rest, %{opts | file: file})
+
+  defp read_input(_bash, nil, stdin), do: {:ok, stdin || ""}
+  defp read_input(_bash, "-", stdin), do: {:ok, stdin || ""}
+
+  defp read_input(bash, file, _stdin) do
+    resolved = InMemoryFs.resolve_path(bash.cwd, file)
+
+    case InMemoryFs.read_file(bash.fs, resolved) do
+      {:ok, c} -> {:ok, c}
+      {:error, _} -> {:error, "od: #{file}: No such file or directory\n"}
+    end
+  end
+
+  defp render(data, format) do
+    bytes = :binary.bin_to_list(data)
+
+    lines =
+      bytes
+      |> Enum.chunk_every(16)
+      |> Enum.with_index()
+      |> Enum.map(fn {chunk, idx} -> format_line(chunk, idx * 16, format) end)
+
+    final_offset = byte_size(data) |> Integer.to_string(8) |> String.pad_leading(7, "0")
+    Enum.join(lines ++ [final_offset <> "\n"])
+  end
+
+  defp format_line(chunk, offset, format) do
+    off = offset |> Integer.to_string(8) |> String.pad_leading(7, "0")
+    cells = Enum.map_join(chunk, " ", &format_byte(&1, format))
+    "#{off} #{cells}\n"
+  end
+
+  defp format_byte(b, :char), do: char_repr(b)
+
+  defp format_byte(b, :octal_bytes),
+    do: b |> Integer.to_string(8) |> String.pad_leading(3, "0")
+
+  defp format_byte(b, :hex),
+    do: b |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(2, "0")
+
+  defp format_byte(b, :octal),
+    do: b |> Integer.to_string(8) |> String.pad_leading(3, "0")
+
+  defp char_repr(0), do: "\\0"
+  defp char_repr(7), do: "\\a"
+  defp char_repr(8), do: "\\b"
+  defp char_repr(9), do: "\\t"
+  defp char_repr(10), do: "\\n"
+  defp char_repr(11), do: "\\v"
+  defp char_repr(12), do: "\\f"
+  defp char_repr(13), do: "\\r"
+  defp char_repr(b) when b >= 32 and b <= 126, do: "  " <> <<b>>
+  defp char_repr(b), do: b |> Integer.to_string(8) |> String.pad_leading(3, "0")
+end

--- a/lib/just_bash/commands/registry.ex
+++ b/lib/just_bash/commands/registry.ex
@@ -97,7 +97,9 @@ defmodule JustBash.Commands.Registry do
     "nproc" => Commands.Nproc,
     "arch" => Commands.Arch,
     "yes" => Commands.Yes,
-    "type" => Commands.Type
+    "type" => Commands.Type,
+    "xxd" => Commands.Xxd,
+    "od" => Commands.Od
   }
 
   # Shell builtins — commands that are part of the shell itself, not external programs.

--- a/lib/just_bash/commands/xxd.ex
+++ b/lib/just_bash/commands/xxd.ex
@@ -1,0 +1,114 @@
+defmodule JustBash.Commands.Xxd do
+  @moduledoc "The `xxd` command - make a hexdump."
+  @behaviour JustBash.Commands.Command
+
+  alias JustBash.Commands.Command
+  alias JustBash.Fs.InMemoryFs
+
+  @impl true
+  def names, do: ["xxd"]
+
+  @impl true
+  def execute(bash, args, stdin) do
+    case parse_args(args, %{cols: 16, len: nil, seek: 0, plain: false, file: nil}) do
+      {:error, msg} ->
+        {Command.error(msg), bash}
+
+      {:ok, opts} ->
+        case read_input(bash, opts.file, stdin) do
+          {:ok, data} ->
+            data = slice(data, opts.seek, opts.len)
+            out = if opts.plain, do: plain(data), else: dump(data, opts.cols)
+            {Command.ok(out), bash}
+
+          {:error, msg} ->
+            {Command.error(msg), bash}
+        end
+    end
+  end
+
+  defp parse_args([], opts), do: {:ok, opts}
+  defp parse_args(["-c", n | rest], opts), do: parse_args(rest, %{opts | cols: to_int(n)})
+  defp parse_args(["-l", n | rest], opts), do: parse_args(rest, %{opts | len: to_int(n)})
+  defp parse_args(["-s", n | rest], opts), do: parse_args(rest, %{opts | seek: to_int(n)})
+  defp parse_args(["-p" | rest], opts), do: parse_args(rest, %{opts | plain: true})
+  defp parse_args(["-r" | _], _opts), do: {:error, "xxd: -r not supported\n"}
+
+  defp parse_args(["-" <> _ = flag | _], _opts),
+    do: {:error, "xxd: unknown option: #{flag}\n"}
+
+  defp parse_args([file | rest], opts), do: parse_args(rest, %{opts | file: file})
+
+  defp to_int(n) when is_integer(n), do: n
+
+  defp to_int(n) do
+    case Integer.parse(n) do
+      {i, _} -> i
+      _ -> 0
+    end
+  end
+
+  defp read_input(_bash, nil, stdin), do: {:ok, stdin || ""}
+  defp read_input(_bash, "-", stdin), do: {:ok, stdin || ""}
+
+  defp read_input(bash, file, _stdin) do
+    resolved = InMemoryFs.resolve_path(bash.cwd, file)
+
+    case InMemoryFs.read_file(bash.fs, resolved) do
+      {:ok, c} -> {:ok, c}
+      {:error, _} -> {:error, "xxd: #{file}: No such file or directory\n"}
+    end
+  end
+
+  defp slice(data, 0, nil), do: data
+  defp slice(data, seek, nil), do: binary_part_safe(data, seek, byte_size(data) - seek)
+
+  defp slice(data, seek, len) do
+    max = max(byte_size(data) - seek, 0)
+    binary_part_safe(data, seek, min(len, max))
+  end
+
+  defp binary_part_safe(_data, _start, len) when len <= 0, do: ""
+  defp binary_part_safe(data, start, len), do: binary_part(data, start, len)
+
+  defp plain(data) do
+    data
+    |> :binary.bin_to_list()
+    |> Enum.map(&Integer.to_string(&1, 16))
+    |> Enum.map(&String.downcase/1)
+    |> Enum.map(&String.pad_leading(&1, 2, "0"))
+    |> Enum.chunk_every(30)
+    |> Enum.map_join("\n", &Enum.join/1)
+    |> then(&(&1 <> "\n"))
+  end
+
+  defp dump(data, cols) do
+    data
+    |> :binary.bin_to_list()
+    |> Enum.chunk_every(cols)
+    |> Enum.with_index()
+    |> Enum.map_join(fn {bytes, idx} -> format_line(bytes, idx * cols, cols) end)
+  end
+
+  defp format_line(bytes, offset, cols) do
+    offset_str =
+      offset |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(8, "0")
+
+    hex =
+      bytes
+      |> Enum.chunk_every(2)
+      |> Enum.map_join(" ", fn pair ->
+        Enum.map_join(pair, "", fn b ->
+          b |> Integer.to_string(16) |> String.downcase() |> String.pad_leading(2, "0")
+        end)
+      end)
+
+    hex_width = div(cols, 2) * 5 - 1
+    hex_padded = String.pad_trailing(hex, hex_width)
+
+    ascii =
+      Enum.map_join(bytes, "", fn b -> if b >= 32 and b <= 126, do: <<b>>, else: "." end)
+
+    "#{offset_str}: #{hex_padded}  #{ascii}\n"
+  end
+end

--- a/lib/just_bash/flag_parser.ex
+++ b/lib/just_bash/flag_parser.ex
@@ -111,12 +111,14 @@ defmodule JustBash.FlagParser do
         end
 
       String.length(flag_str) > 1 ->
-        case try_attached_value_flag(flag_str, spec, flags, lookup) do
+        combined_lookup = Map.merge(lookup, aliases)
+
+        case try_attached_value_flag(flag_str, spec, flags, combined_lookup) do
           {:ok, new_flags} ->
             {:ok, new_flags, remaining}
 
           :error ->
-            case parse_combined_flags(flag_str, spec, flags, lookup) do
+            case parse_combined_flags(flag_str, spec, flags, combined_lookup) do
               {:ok, new_flags} -> {:ok, new_flags, remaining}
               :error -> try_numeric_flag(flag_str, remaining, spec, flags)
             end

--- a/test/commands/curl_test.exs
+++ b/test/commands/curl_test.exs
@@ -129,6 +129,37 @@ defmodule JustBash.Commands.CurlTest do
       assert result.stdout =~ "test"
     end
 
+    test "curl --version reports a version line" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "curl --version")
+      assert result.exit_code == 0
+      assert result.stdout =~ ~r/^curl \d/
+    end
+
+    test "curl -D dumps response headers to a file" do
+      bash =
+        JustBash.new(network: %{enabled: true, allow_list: :all}, http_client: MockHttpClient)
+
+      {result, new_bash} =
+        JustBash.exec(bash, "curl -s -D /tmp/headers.txt https://httpbin.org/get")
+
+      assert result.exit_code == 0
+      {read_result, _} = JustBash.exec(new_bash, "cat /tmp/headers.txt")
+      assert read_result.stdout =~ "HTTP/"
+      assert read_result.stdout =~ "content-type"
+    end
+
+    test "curl -w writes a format string to stdout after the body" do
+      bash =
+        JustBash.new(network: %{enabled: true, allow_list: :all}, http_client: MockHttpClient)
+
+      {result, _} =
+        JustBash.exec(bash, ~s[curl -s -o /dev/null -w "%{http_code}" https://httpbin.org/get])
+
+      assert result.exit_code == 0
+      assert result.stdout == "200"
+    end
+
     test "curl follows redirects with -L" do
       bash =
         JustBash.new(network: %{enabled: true, allow_list: :all}, http_client: MockHttpClient)

--- a/test/commands/text_processing_test.exs
+++ b/test/commands/text_processing_test.exs
@@ -324,6 +324,31 @@ defmodule JustBash.Commands.TextProcessingTest do
       {result, _} = JustBash.exec(bash, "echo -e 'apple\\nbanana\\napricot' | grep ap")
       assert result.stdout == "apple\napricot\n"
     end
+
+    test "grep -oP finds all matches (PCRE flag is accepted)" do
+      content = ~s(prefix apiKey: "abc123" middle apiKey: "def456" suffix\n)
+      bash = JustBash.new(files: %{"/f.txt" => content})
+      {result, _} = JustBash.exec(bash, ~s(grep -oP 'apiKey: "[^"]+"' /f.txt))
+      assert result.exit_code == 0
+      assert result.stdout == ~s(apiKey: "abc123"\napiKey: "def456"\n)
+    end
+
+    test "grep -oP alternation returns each match" do
+      content = "alpha apiKey beta Authorization gamma apiKey\n"
+      bash = JustBash.new(files: %{"/f.txt" => content})
+      {result, _} = JustBash.exec(bash, "grep -oP 'apiKey|Authorization' /f.txt")
+      assert result.exit_code == 0
+      assert result.stdout == "apiKey\nAuthorization\napiKey\n"
+    end
+
+    test "grep -o works on long single-line input" do
+      padding = String.duplicate("x", 200_000)
+      content = padding <> "FINDME" <> padding <> "FINDME" <> padding <> "\n"
+      bash = JustBash.new(files: %{"/big.js" => content})
+      {result, _} = JustBash.exec(bash, "grep -o FINDME /big.js")
+      assert result.exit_code == 0
+      assert result.stdout == "FINDME\nFINDME\n"
+    end
   end
 
   describe "sed command" do

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -3,6 +3,26 @@ defmodule JustBash.Commands.UtilitiesTest do
 
   alias JustBash.Commands.Env
 
+  describe "xxd command" do
+    test "xxd produces a canonical hex+ASCII dump of stdin" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "echo -n hello | xxd")
+      assert result.exit_code == 0
+      assert result.stdout =~ "6865 6c6c 6f"
+      assert result.stdout =~ "hello"
+    end
+  end
+
+  describe "od command" do
+    test "od -c shows characters" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "echo -n hi | od -c")
+      assert result.exit_code == 0
+      assert result.stdout =~ "h"
+      assert result.stdout =~ "i"
+    end
+  end
+
   describe "basic commands" do
     test "echo with multiple arguments" do
       bash = JustBash.new()


### PR DESCRIPTION
Fixes several gaps surfaced by agent evals:

- **xxd, od** — new commands for hex/char dumps
- **curl** — `--version`, `-w/--write-out '%{http_code}'`, `-D/--dump-header <file>`, plus `-o /dev/null`
- **grep -P** — accepted as alias for the default regex engine (Elixir's Regex is PCRE-ish). Root cause of the reported `grep -oP` silent miss was `FlagParser.parse_combined_flags` ignoring the aliases map, so `-oP` fell through to positional and the pattern shifted. Fixed by merging aliases into the combined-flag lookup.
- **awk** — defensive `evaluate_expression(_, _)` catch-all so unknown AST shapes return `""` instead of surfacing as a `FunctionClauseError` through the command-crash wrapper.

Tests added for each fix in `curl_test.exs`, `utilities_test.exs`, and `text_processing_test.exs`.