### PR TITLE
feat: add context option to justbash struct for custom commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,36 @@ bash = JustBash.new(commands: %{"greet" => MyApp.Commands.Greet})
 result.stdout  #=> "Hello, world!\n"
 ```
 
+#### Custom command context
+
+Pass caller data into custom commands with the `:context` option. It is stored on the `JustBash`
+struct as `context` (default `%{}`) and is readable inside any custom command as `bash.context`.
+Builtins and the interpreter ignore it.
+
+```elixir
+defmodule MyApp.Commands.Whoami do
+  @behaviour JustBash.Commands.Command
+
+  @impl true
+  def names, do: ["whoami_ctx"]
+
+  @impl true
+  def execute(bash, _args, _stdin) do
+    user = Map.get(bash.context, :user, "anonymous")
+    {%{stdout: "#{user}\n", stderr: "", exit_code: 0}, bash}
+  end
+end
+
+bash =
+  JustBash.new(
+    context: %{user: "alice"},
+    commands: %{"whoami_ctx" => MyApp.Commands.Whoami}
+  )
+
+{result, _bash} = JustBash.exec(bash, "whoami_ctx")
+result.stdout  #=> "alice\n"
+```
+
 Important caveats:
 
 - Custom commands run arbitrary Elixir code in the host BEAM process

--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -86,6 +86,7 @@ defmodule JustBash do
             cwd: "/home/user",
             functions: %{},
             commands: %{},
+            context: %{},
             exit_code: 0,
             last_exit_code: 0,
             network: %{enabled: false, allow_list: [], allow_insecure: false},
@@ -123,6 +124,7 @@ defmodule JustBash do
           cwd: String.t(),
           functions: map(),
           commands: %{String.t() => module()},
+          context: map(),
           exit_code: non_neg_integer(),
           last_exit_code: non_neg_integer(),
           network: network_config(),
@@ -151,6 +153,9 @@ defmodule JustBash do
     Custom commands override regular builtins but are overridden by shell functions. Protected
     stateful builtins such as `cd` and `export` cannot be overridden.
     Dispatch order: shell functions > custom commands > builtins.
+  - `:context` - Optional map of caller data for custom commands. Stored on the `JustBash` struct
+    as `context` and readable inside any custom command as `bash.context`. Defaults to `%{}`.
+    Not used by builtins or the interpreter; only host-defined custom commands should read it.
   - `:network` - Network configuration map with:
     - `:enabled` - Whether network access is allowed (default: false)
     - `:allow_list` - Allowed hosts/patterns. Use `:all` to allow all hosts, or a list of
@@ -181,6 +186,9 @@ defmodule JustBash do
 
       # Custom HTTP client for testing:
       bash = JustBash.new(network: %{enabled: true}, http_client: MyTestHttpClient)
+
+      # Pass data to custom commands via bash.context:
+      bash = JustBash.new(context: %{user_id: 42}, commands: %{"my_cmd" => MyCommand})
   """
   @spec new(keyword()) :: t()
   def new(opts \\ []) do
@@ -194,6 +202,7 @@ defmodule JustBash do
     max_call_depth = Keyword.get(opts, :max_call_depth, 1_000)
     limits = opts |> Keyword.get(:limits, :default) |> Limit.new()
     jq_module_paths = Keyword.get(opts, :jq_module_paths, [])
+    context = opts |> Keyword.get(:context, %{}) |> validate_context!()
 
     default_env = %{
       "HOME" => cwd,
@@ -213,6 +222,7 @@ defmodule JustBash do
       cwd: cwd,
       functions: %{},
       commands: commands,
+      context: context,
       exit_code: 0,
       last_exit_code: 0,
       network: Map.merge(%{enabled: false, allow_list: [], allow_insecure: false}, network),
@@ -223,6 +233,12 @@ defmodule JustBash do
       jq_module_paths: jq_module_paths,
       interpreter: State.new()
     }
+  end
+
+  defp validate_context!(context) when is_map(context), do: context
+
+  defp validate_context!(other) do
+    raise ArgumentError, "expected :context to be a map, got: #{inspect(other)}"
   end
 
   defp normalize_commands!(commands) when is_map(commands) do

--- a/test/custom_commands_test.exs
+++ b/test/custom_commands_test.exs
@@ -186,6 +186,18 @@ defmodule JustBash.CustomCommandsTest do
     end
   end
 
+  defmodule ContextDumper do
+    @behaviour JustBash.Commands.Command
+
+    @impl true
+    def names, do: ["ctxdump"]
+
+    @impl true
+    def execute(bash, _args, _stdin) do
+      {%{stdout: inspect(bash.context) <> "\n", stderr: "", exit_code: 0}, bash}
+    end
+  end
+
   defmodule Counter do
     @doc "A command that reads a file, increments the number in it, and writes it back"
     @behaviour JustBash.Commands.Command
@@ -264,6 +276,29 @@ defmodule JustBash.CustomCommandsTest do
       assert result.exit_code == 1
       assert result.stderr =~ "throwy"
       assert result.stderr =~ "throw"
+    end
+  end
+
+  describe "custom command context" do
+    test "custom command receives bash.context from JustBash.new" do
+      ctx = %{"api_key" => "secret", greeting: "hello"}
+
+      bash =
+        JustBash.new(
+          context: ctx,
+          commands: %{"ctxdump" => ContextDumper}
+        )
+
+      {result, _} = JustBash.exec(bash, "ctxdump")
+      assert String.trim(result.stdout) == inspect(ctx)
+      assert result.exit_code == 0
+    end
+
+    test "custom command sees default empty context when :context omitted" do
+      bash = JustBash.new(commands: %{"ctxdump" => ContextDumper})
+      {result, _} = JustBash.exec(bash, "ctxdump")
+      assert String.trim(result.stdout) == inspect(%{})
+      assert result.exit_code == 0
     end
   end
 

--- a/test/just_bash_test.exs
+++ b/test/just_bash_test.exs
@@ -110,6 +110,24 @@ defmodule JustBashTest do
     end
   end
 
+  describe "new/1 :context option" do
+    test "defaults context to an empty map" do
+      bash = JustBash.new()
+      assert bash.context == %{}
+    end
+
+    test "sets context from option" do
+      bash = JustBash.new(context: %{"api_key" => "secret", :tenant => 1})
+      assert bash.context == %{"api_key" => "secret", :tenant => 1}
+    end
+
+    test "raises when context is not a map" do
+      assert_raise ArgumentError, ~r/expected :context to be a map/, fn ->
+        JustBash.new(context: :not_a_map)
+      end
+    end
+  end
+
   describe "exec/2" do
     test "executes echo command" do
       bash = JustBash.new()


### PR DESCRIPTION
## Summary

Introduces a new `context` option to the `JustBash` struct so that custom context can be injected and passed down to custom commands in a convenient way. 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing
Describe how this was tested:
- [x] Added new tests
- [x] All existing tests pass
- [x] Tested manually

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG.md (for non-trivial changes)
