### PR TITLE
feat: add JustBash.CLI for namespaced subcommand tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,101 @@ Important caveats:
 - Shell functions still win over custom commands at execution time
 - Protected stateful builtins such as `cd`, `export`, `trap`, and `return` cannot be overridden
 
+### Namespaced CLIs (`JustBash.CLI`)
+
+When a single tool needs many subcommands — `acme pr review`, `acme product list` — don't
+hand-roll a `case` router, manual `--help`, and ad-hoc error strings in `execute/3`.
+`JustBash.CLI` is a declarative subcommand layer that gives you **routing**, **typed
+argument parsing**, and **auto-generated help, errors, and docs** from a single source of
+truth. A CLI is plain data (a `%JustBash.CLI{}` tree) that registers like any other
+command:
+
+```elixir
+alias JustBash.CLI
+alias JustBash.Commands.Command
+
+cli =
+  CLI.new("acme", doc: "Acme operations toolkit", commands: [
+    CLI.command("pr", doc: "Pull request management", commands: [
+      CLI.command("review",
+        doc: "Review a pull request",
+        flags: [
+          report:  [type: :integer, required: true, doc: "ID of the report to review"],
+          format:  [type: :string, default: "text", values: ~w(text json), doc: "Output format"],
+          verbose: [type: :boolean, short: "-v"]
+        ],
+        run: fn inv ->
+          tag = if inv.flags.verbose, do: "[v] ", else: ""
+          {Command.ok("#{tag}report #{inv.flags.report} as #{inv.flags.format}\n"), inv.bash}
+        end)
+    ])
+  ])
+
+bash = JustBash.new(commands: %{"acme" => cli})
+{result, _} = JustBash.exec(bash, "acme pr review --report 42 --format json")
+result.stdout  #=> "report 42 as json\n"
+```
+
+Each leaf's `:run` handler takes a single `%JustBash.CLI.Invocation{}` (`flags`, `args`,
+`bash`, `stdin`, `path`) and returns `{result, bash}` — the same contract as a plain
+custom command, so handlers keep full access to `bash.fs`, `bash.context`, etc. Use a
+capture (`run: &Acme.PR.review/1`) to keep handler logic in named, testable functions.
+
+Help, `did you mean` suggestions, and usage-bearing errors come for free and are
+consistent across every CLI — which is exactly what an agent needs to recover from a typo
+in one turn:
+
+```text
+$ acme pr review --help
+acme pr review - Review a pull request
+
+Usage: acme pr review --report <int> [--format text|json] [-v]
+
+Options:
+  --report <int>       ID of the report to review (required)
+  --format text|json   Output format (values: text, json) (default: text)
+  -v, --verbose
+
+$ acme pr reviw
+acme: unknown command 'pr reviw'
+Did you mean 'pr review'?
+Run 'acme --help' for available commands.      # exit code 2
+
+$ acme pr review
+acme pr review: missing required flag: --report
+Usage: acme pr review --report <int> [--format text|json] [-v]   # exit code 2
+```
+
+Because the spec is declarative, you can introspect it to generate the tool documentation
+that goes into an agent's system prompt — from the same source as the runtime behavior:
+
+```elixir
+JustBash.CLI.describe(cli)
+#=> %{name: "acme", doc: "...", commands: [%{path: ["pr", "review"], flags: [...], ...}]}
+
+JustBash.CLI.render_docs(cli, format: :markdown)  # a markdown manual
+```
+
+If you prefer a CLI to live as a module alongside your other command modules, `use
+JustBash.CLI` and define `spec/0` (conventional `use`-wiring, not a DSL):
+
+```elixir
+defmodule Acme.CLI do
+  use JustBash.CLI
+
+  @impl true
+  def spec, do: JustBash.CLI.new("acme", doc: "Acme toolkit", commands: [...])
+end
+
+bash = JustBash.new(commands: %{"acme" => Acme.CLI})
+```
+
+For a complete before/after, compare [`eval/commands/kv.ex`](eval/commands/kv.ex) (a
+hand-rolled router with help text duplicated by hand) against
+[`eval/commands/kv_cli.ex`](eval/commands/kv_cli.ex) (the same tool on `JustBash.CLI`,
+where only the storage logic remains). CLI handlers carry the same trust model and crash
+isolation as any custom command — they are host code and are **not** sandboxed.
+
 ### Execute Script Files
 
 ```elixir

--- a/eval/commands/kv_cli.ex
+++ b/eval/commands/kv_cli.ex
@@ -1,0 +1,118 @@
+defmodule JustBash.Eval.Commands.KVCli do
+  @moduledoc """
+  The key-value store from `JustBash.Eval.Commands.KV`, ported to `JustBash.CLI`.
+
+  This is the "after" half of the before/after showcase for the CLI feature. Compare with
+  `JustBash.Eval.Commands.KV`, which hand-rolls a `case` router, manual `--help`/`-h`/`[]`
+  handling, a help string duplicated between `@moduledoc` and a private function, and
+  ad-hoc error formatting.
+
+  Here, routing, argument parsing, `--help` at every level, "did you mean" suggestions,
+  and the usage lines on errors are all generated from the declarative spec below. The
+  handlers only contain storage logic.
+
+  Storage: persisted as JSON at `/.kv_store.json`, identical to the original.
+  """
+
+  use JustBash.CLI
+
+  alias JustBash.CLI
+  alias JustBash.Commands.Command
+  alias JustBash.Fs.InMemoryFs
+
+  @store_path "/.kv_store.json"
+
+  @impl JustBash.CLI
+  def spec do
+    CLI.new("kv",
+      doc: "A key-value store backed by a JSON file in the virtual filesystem",
+      commands: [
+        CLI.command("set",
+          doc: "Store a key-value pair",
+          args: [
+            %{name: :key, required: true, doc: "Key to store under"},
+            %{name: :value, required: true, variadic: true, doc: "Value (may contain spaces)"}
+          ],
+          run: &set/1
+        ),
+        CLI.command("get",
+          doc: "Retrieve a value (exit 1 if not found)",
+          args: [%{name: :key, required: true, doc: "Key to retrieve"}],
+          run: &get/1
+        ),
+        CLI.command("delete",
+          doc: "Remove a key (exit 1 if not found)",
+          args: [%{name: :key, required: true, doc: "Key to remove"}],
+          run: &delete/1
+        ),
+        CLI.command("list", doc: "List all keys, one per line, sorted", run: &list/1),
+        CLI.command("dump", doc: "Dump all key=value pairs, sorted by key", run: &dump/1),
+        CLI.command("count", doc: "Print the number of stored keys", run: &count/1)
+      ]
+    )
+  end
+
+  defp set(inv) do
+    [key | value_parts] = inv.args
+    store = inv.bash.fs |> store_from() |> Map.put(key, Enum.join(value_parts, " "))
+    {Command.ok(""), write_store(inv.bash, store)}
+  end
+
+  defp get(inv) do
+    [key] = inv.args
+
+    case Map.fetch(store_from(inv.bash.fs), key) do
+      {:ok, value} -> {Command.ok("#{value}\n"), inv.bash}
+      :error -> {Command.error("kv: key '#{key}' not found\n", 1), inv.bash}
+    end
+  end
+
+  defp delete(inv) do
+    [key] = inv.args
+    store = store_from(inv.bash.fs)
+
+    if Map.has_key?(store, key) do
+      {Command.ok(""), write_store(inv.bash, Map.delete(store, key))}
+    else
+      {Command.error("kv: key '#{key}' not found\n", 1), inv.bash}
+    end
+  end
+
+  defp list(inv) do
+    keys = inv.bash.fs |> store_from() |> Map.keys() |> Enum.sort()
+    {Command.ok(join_lines(keys)), inv.bash}
+  end
+
+  defp dump(inv) do
+    pairs =
+      inv.bash.fs
+      |> store_from()
+      |> Enum.sort_by(fn {k, _} -> k end)
+      |> Enum.map(fn {k, v} -> "#{k}=#{v}" end)
+
+    {Command.ok(join_lines(pairs)), inv.bash}
+  end
+
+  defp count(inv) do
+    {Command.ok("#{map_size(store_from(inv.bash.fs))}\n"), inv.bash}
+  end
+
+  # --- storage (identical to JustBash.Eval.Commands.KV) ---
+
+  defp store_from(fs) do
+    with {:ok, content} <- InMemoryFs.read_file(fs, @store_path),
+         {:ok, map} when is_map(map) <- Jason.decode(content) do
+      map
+    else
+      _ -> %{}
+    end
+  end
+
+  defp write_store(bash, store) do
+    {:ok, fs} = InMemoryFs.write_file(bash.fs, @store_path, Jason.encode!(store))
+    %{bash | fs: fs}
+  end
+
+  defp join_lines([]), do: ""
+  defp join_lines(lines), do: Enum.join(lines, "\n") <> "\n"
+end

--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -270,8 +270,31 @@ defmodule JustBash do
     raise ArgumentError, "expected :commands to be a map, got: #{inspect(commands)}"
   end
 
-  # Validates the registration and returns the list of names from the module.
+  # Validates the registration and returns the list of names.
   # Called once per registration entry to avoid double-calling names/0.
+  #
+  # A registered value is either a module implementing JustBash.Commands.Command, or a
+  # %JustBash.CLI{} struct (a declarative subcommand tool — see JustBash.CLI).
+  defp validate_command_registration!(name, %JustBash.CLI{} = cli) when is_binary(name) do
+    if name == "" do
+      raise ArgumentError, "custom command name must not be empty"
+    end
+
+    if name in @protected_builtin_names do
+      raise ArgumentError, "custom commands cannot override protected builtin #{inspect(name)}"
+    end
+
+    names = [cli.name | cli.aliases]
+
+    unless name in names do
+      raise ArgumentError,
+            "CLI #{inspect(cli.name)} was registered as #{inspect(name)} but its registered " <>
+              "names are #{inspect(names)} (the CLI name plus :aliases)"
+    end
+
+    names
+  end
+
   defp validate_command_registration!(name, module) when is_binary(name) and is_atom(module) do
     if name == "" do
       raise ArgumentError,

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -44,6 +44,40 @@ defmodule JustBash.CLI do
   `:float`, `:accumulator`), `:short`, `:long` (defaults to `--name`), `:default`,
   `:required`, `:values` (enum), `:transform`, and `:doc` (used in help output).
 
+  Flag specs are validated at build time (`command/2` raises `ArgumentError`):
+
+    * `--help`/`-h` are **reserved** — see "Reserved flags" below.
+    * `:required` and `:default` are mutually exclusive (a required flag errors when omitted,
+      so the default could never apply).
+    * a `:default` must be a member of `:values` when both are given (the enum check only
+      runs on flags the user actually provides, so an out-of-range default would slip past it).
+
+  `:values` is compared against the **coerced** value, so list members must match the flag's
+  `:type` — e.g. `type: :integer, values: [1, 2]` (integers, not `~w(1 2)`). The raw
+  `:values` list is also what `describe/1` and the help text surface to agents.
+
+  ## Reserved flags
+
+  `--help` and `-h` are reserved: the router intercepts them before a leaf ever parses, so a
+  leaf can request help in one turn. A flag spec may not claim either form (including a flag
+  named `:help`, whose derived long is `--help`) — `command/2` raises if it does. Because
+  interception happens first, `--help`/`-h` anywhere before a `--` terminator wins even when
+  it would otherwise be a flag's value (e.g. `acme pr review --format -h` shows help).
+
+  ## `--` handling
+
+  A leading `--` *before* a subcommand is consumed and routing continues (`acme -- pr review`
+  reaches `pr review`), so wrappers that prepend `--` still route. This is intentionally not
+  POSIX `--` semantics — `--` only acts as an options/help terminator once routing reaches a
+  leaf and hands the remaining tokens to the parser.
+
+  ## Positional arguments
+
+  Positionals are a flat list, so `command/2` rejects ambiguous shapes at build time: a
+  required positional may not follow an optional one, and a variadic must be last. A lone
+  `-` (the stdin convention) is treated as a flag by the router and is **not** supported as a
+  positional; pass it after `--` if a leaf needs it as a literal value.
+
   ## Trust model
 
   CLI handlers are ordinary host Elixir code with the same trust model and crash
@@ -108,7 +142,10 @@ defmodule JustBash.CLI do
       @behaviour JustBash.CLI
 
       @impl JustBash.Commands.Command
-      def names, do: [spec().name | spec().aliases]
+      def names do
+        s = spec()
+        [s.name | s.aliases]
+      end
 
       @impl JustBash.Commands.Command
       def execute(bash, args, stdin), do: JustBash.CLI.run(spec(), bash, args, stdin)
@@ -135,6 +172,9 @@ defmodule JustBash.CLI do
   @spec custom_command_description(term(), String.t()) :: String.t()
   def custom_command_description(value, name) do
     if cli?(value) do
+      # `describe/1` flattens to leaves only (groups are recursed into, not listed), so this
+      # counts runnable commands, not tree nodes. If `describe/1`'s shape ever changes, the
+      # "describes a CLI tool" tests in test/cli/shell_integration_test.exs pin this count.
       count = value |> describe() |> Map.fetch!(:commands) |> length()
       "#{name} is a CLI tool (#{count} #{pluralize(count, "command", "commands")})"
     else
@@ -361,8 +401,12 @@ defmodule JustBash.CLI do
   # %CLI{} or a %Command{} group; both expose `name`/`doc`/`commands`.
   defp route(group, [], path), do: {:no_subcommand, group, path, []}
 
-  # A `--` options terminator before a subcommand is consumed; routing continues with the
-  # rest, so `acme -- pr review` reaches `pr review` instead of erroring as a stray flag.
+  # A leading `--` before a subcommand is consumed; routing continues with the rest, so
+  # `acme -- pr review` reaches `pr review` instead of erroring as a stray flag. This is
+  # deliberately NOT POSIX `--` semantics (which would make everything after it positional):
+  # it lets wrappers that prepend `--` still route to subcommands. `--` only acts as an
+  # options/help terminator once routing reaches a leaf and hands the rest to the parser.
+  # See the "`--` handling" note in the moduledoc.
   defp route(group, ["--" | rest], path), do: route(group, rest, path)
 
   defp route(group, ["-" <> _ | _] = remaining, path),
@@ -534,7 +578,9 @@ defmodule JustBash.CLI do
               "command #{inspect(name)} flag #{inspect(flag_name)} spec must be a keyword list, got: #{inspect(spec)}"
       end
 
-      {flag_name, Keyword.put_new(spec, :long, default_long(flag_name))}
+      spec = Keyword.put_new(spec, :long, default_long(flag_name))
+      validate_flag_spec!(name, flag_name, spec)
+      {flag_name, spec}
     end)
   end
 
@@ -543,21 +589,71 @@ defmodule JustBash.CLI do
           "command #{inspect(name)} :flags must be a keyword list of flag specs, got: #{inspect(flags)}"
   end
 
+  # Build-time guards that can't drift into runtime surprises:
+  #   * `--help`/`-h` are intercepted by the router before any leaf parses, so a flag that
+  #     claims them could never receive its value (see the "reserved flags" note in the
+  #     moduledoc).
+  #   * `:required` + `:default` is contradictory — the default can never apply, since a
+  #     required flag errors when omitted.
+  #   * a `:default` outside `:values` would silently bypass the enum check, which only
+  #     runs on provided flags.
+  defp validate_flag_spec!(name, flag_name, spec) do
+    cond do
+      spec[:long] == "--help" or spec[:short] == "-h" ->
+        reserved = if spec[:long] == "--help", do: "--help", else: "-h"
+
+        raise ArgumentError,
+              "command #{inspect(name)} flag #{inspect(flag_name)}: #{reserved} is reserved for help and cannot be used as a flag"
+
+      spec[:required] && Keyword.has_key?(spec, :default) ->
+        raise ArgumentError,
+              "command #{inspect(name)} flag #{inspect(flag_name)} cannot be both :required and have a :default"
+
+      true ->
+        validate_default_in_values!(name, flag_name, spec)
+    end
+  end
+
+  defp validate_default_in_values!(name, flag_name, spec) do
+    with {:ok, default} <- Keyword.fetch(spec, :default),
+         values when is_list(values) <- spec[:values],
+         false <- default in values do
+      raise ArgumentError,
+            "command #{inspect(name)} flag #{inspect(flag_name)}: :default #{inspect(default)} " <>
+              "is not one of :values #{inspect(values)}"
+    else
+      _ -> :ok
+    end
+  end
+
   defp default_long(flag_name) do
     "--" <> String.replace(Atom.to_string(flag_name), "_", "-")
   end
 
   defp validate_args!(name, args) when is_list(args) do
-    {normalized, _seen_variadic} =
-      Enum.map_reduce(args, false, fn arg, variadic_seen? ->
+    {normalized, _acc} =
+      Enum.map_reduce(args, %{variadic?: false, optional?: false}, fn arg, acc ->
         spec = normalize_arg!(name, arg)
 
-        if variadic_seen? do
+        if acc.variadic? do
           raise ArgumentError,
                 "command #{inspect(name)}: a variadic positional argument must be last"
         end
 
-        {spec, spec.variadic}
+        # A required positional after an optional one is ambiguous: the handler receives a
+        # flat list and can't tell which slot a single value bound to. Reject it at build
+        # time, mirroring the variadic-must-be-last rule.
+        if spec.required and acc.optional? do
+          raise ArgumentError,
+                "command #{inspect(name)}: required positional argument #{inspect(spec.name)} " <>
+                  "cannot follow an optional one"
+        end
+
+        {spec,
+         %{
+           variadic?: acc.variadic? or spec.variadic,
+           optional?: acc.optional? or not spec.required
+         }}
       end)
 
     normalized

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -221,6 +221,7 @@ defmodule JustBash.CLI do
     args = Keyword.get(opts, :args, [])
 
     validate_node_kind!(name, commands, run)
+    validate_leaf_only!(name, commands, flags, args)
     validate_commands!(commands)
     validate_unique_names!(commands, name)
     flags = normalize_flags!(name, flags)
@@ -248,23 +249,27 @@ defmodule JustBash.CLI do
   """
   @spec run(t(), JustBash.t(), [String.t()], String.t()) :: {map(), JustBash.t()}
   def run(%__MODULE__{} = cli, bash, args, stdin) do
+    # Every routed result carries its resolved subcommand path (the valid prefix, even
+    # for help/usage errors) so command telemetry can attribute the bucket; the executor
+    # reads it into span metadata and strips it before the result reaches the shell.
     case route(cli, args, []) do
       {:leaf, leaf, path, rest} ->
         if wants_help?(rest) do
-          {help_result(Help.leaf_help(cli, path, leaf)), bash}
+          {tag_subcommand(help_result(Help.leaf_help(cli, path, leaf)), path), bash}
         else
           dispatch_leaf(cli, leaf, path, rest, bash, stdin)
         end
 
       {:no_subcommand, group, path, remaining} ->
         if wants_help?(remaining) do
-          {help_result(Help.group_help(cli, path, group)), bash}
+          {tag_subcommand(help_result(Help.group_help(cli, path, group)), path), bash}
         else
-          {usage_error(Help.missing_subcommand(cli, path, group)), bash}
+          {tag_subcommand(usage_error(Help.missing_subcommand(cli, path, group)), path), bash}
         end
 
       {:unknown_subcommand, group, path, token} ->
-        {usage_error(Help.unknown_subcommand(cli, path, group, token)), bash}
+        {tag_subcommand(usage_error(Help.unknown_subcommand(cli, path, group, token)), path),
+         bash}
     end
   end
 
@@ -356,6 +361,10 @@ defmodule JustBash.CLI do
   # %CLI{} or a %Command{} group; both expose `name`/`doc`/`commands`.
   defp route(group, [], path), do: {:no_subcommand, group, path, []}
 
+  # A `--` options terminator before a subcommand is consumed; routing continues with the
+  # rest, so `acme -- pr review` reaches `pr review` instead of erroring as a stray flag.
+  defp route(group, ["--" | rest], path), do: route(group, rest, path)
+
   defp route(group, ["-" <> _ | _] = remaining, path),
     do: {:no_subcommand, group, path, remaining}
 
@@ -388,8 +397,12 @@ defmodule JustBash.CLI do
       }
 
       case leaf.run.(invocation) do
-        {result, new_bash} -> {tag_subcommand(result, path), new_bash}
-        other -> other
+        {result, %JustBash{} = new_bash} ->
+          {tag_subcommand(result, path), new_bash}
+
+        other ->
+          raise ArgumentError,
+                "#{label} handler must return {result, bash}, got: #{inspect(other)}"
       end
     else
       {:error, message} ->
@@ -465,6 +478,17 @@ defmodule JustBash.CLI do
   end
 
   defp validate_node_kind!(_name, _commands, _run), do: :ok
+
+  # Groups route to children and never parse their own flags/args, so reject them on a
+  # group node — otherwise a misplaced flag is a silent no-op rather than a loud error.
+  defp validate_leaf_only!(name, commands, flags, args)
+       when commands != [] and (flags != [] or args != []) do
+    raise ArgumentError,
+          "command #{inspect(name)} is a group (:commands) and cannot define :flags or :args; " <>
+            "move them to a leaf command"
+  end
+
+  defp validate_leaf_only!(_name, _commands, _flags, _args), do: :ok
 
   defp validate_commands!(commands) when is_list(commands) do
     Enum.each(commands, fn

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -1,0 +1,559 @@
+defmodule JustBash.CLI do
+  @moduledoc """
+  Declarative, namespaced subcommand tools for JustBash.
+
+  `JustBash.CLI` turns a tree of subcommands — like `acme pr review --report 1234` — into
+  a single value you register in the `:commands` map. It handles **routing**, **typed
+  argument parsing**, and **auto-generated help and errors**, so host applications stop
+  hand-rolling `case`-statement routers and hand-maintained `--help` text.
+
+  A CLI is plain data: a `%JustBash.CLI{}` holding a tree of `JustBash.CLI.Command` nodes.
+  Build it with `new/2` and `command/2`, then register the struct directly:
+
+      alias JustBash.CLI
+
+      cli =
+        CLI.new("acme", doc: "Acme operations toolkit", commands: [
+          CLI.command("pr", doc: "Pull request management", commands: [
+            CLI.command("review",
+              doc: "Review a pull request",
+              flags: [
+                report:  [type: :integer, required: true, doc: "ID of the report to review"],
+                format:  [type: :string, default: "text", values: ~w(text json), doc: "Output format"],
+                verbose: [type: :boolean, short: "-v"]
+              ],
+              run: &Acme.PR.review/1)
+          ])
+        ])
+
+      bash = JustBash.new(commands: %{"acme" => cli})
+
+  Each leaf's `:run` is a one-argument handler that receives a
+  `JustBash.CLI.Invocation` and returns `{result, bash}` — the same contract as a
+  custom `JustBash.Commands.Command`:
+
+      def review(%JustBash.CLI.Invocation{flags: flags, bash: bash}) do
+        report = MyApp.PullRequests.fetch!(flags.report, bash.context.user)
+        {JustBash.Commands.Command.ok(render(report, flags.format)), bash}
+      end
+
+  ## Flags
+
+  Flag specs use the exact shape of `JustBash.Commands.ArgParser`: a keyword list of
+  `name: [type: ..., ...]`. Supported keys: `:type` (`:boolean`, `:string`, `:integer`,
+  `:float`, `:accumulator`), `:short`, `:long` (defaults to `--name`), `:default`,
+  `:required`, `:values` (enum), `:transform`, and `:doc` (used in help output).
+
+  ## Trust model
+
+  CLI handlers are ordinary host Elixir code with the same trust model and crash
+  isolation as any custom command — they are **not** sandboxed. A crashing handler is
+  caught and turned into an error result, but it runs with full access to the host.
+  """
+
+  alias JustBash.CLI.Command
+  alias JustBash.CLI.Docs
+  alias JustBash.CLI.Help
+  alias JustBash.CLI.Invocation
+  alias JustBash.Commands.ArgParser
+
+  # Exit code used for all usage errors (unknown command, bad flags, missing args),
+  # matching the convention of git/most CLIs.
+  @usage_exit 2
+
+  @enforce_keys [:name]
+  defstruct name: nil, doc: nil, commands: [], aliases: []
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          doc: String.t() | nil,
+          commands: [Command.t()],
+          aliases: [String.t()]
+        }
+
+  @typedoc "A CLI value: either a built struct or a module that `use`s `JustBash.CLI`."
+  @type spec :: t() | module()
+
+  @doc """
+  Returns the CLI definition. Implemented for you when you `use JustBash.CLI`; you supply
+  `spec/0`.
+  """
+  @callback spec() :: t()
+
+  @doc """
+  Make a module *be* a CLI command, so it can live alongside other
+  `JustBash.Commands.Command` modules and be registered by module name:
+
+      defmodule Acme.CLI do
+        use JustBash.CLI
+
+        @impl true
+        def spec do
+          JustBash.CLI.new("acme", doc: "Acme toolkit", commands: [...])
+        end
+      end
+
+      bash = JustBash.new(commands: %{"acme" => Acme.CLI})
+
+  This injects a `JustBash.Commands.Command`-compatible `names/0` and `execute/3` that
+  delegate to your `spec/0`. It is conventional `use`-wiring (like `use GenServer`), not a
+  DSL — the definition is still the plain `%JustBash.CLI{}` you return from `spec/0`.
+
+  Registering the struct directly (`%{"acme" => Acme.CLI.spec()}`) works too and skips the
+  module entirely; both run on the same engine.
+  """
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour JustBash.Commands.Command
+      @behaviour JustBash.CLI
+
+      @impl JustBash.Commands.Command
+      def names, do: [spec().name | spec().aliases]
+
+      @impl JustBash.Commands.Command
+      def execute(bash, args, stdin), do: JustBash.CLI.run(spec(), bash, args, stdin)
+
+      defoverridable names: 0
+    end
+  end
+
+  @doc """
+  Returns `true` if `value` is a CLI — a `%JustBash.CLI{}` struct or a module that
+  `use`s `JustBash.CLI`.
+  """
+  @spec cli?(term()) :: boolean()
+  def cli?(%__MODULE__{}), do: true
+  def cli?(module) when is_atom(module), do: cli_module?(module)
+  def cli?(_), do: false
+
+  @doc """
+  A human description of a registered custom-command `value`, for `type` and `command -V`.
+
+  CLI values report their subcommand count (`"acme is a CLI tool (12 commands)"`); plain
+  command modules fall back to bash's terse `"name is name"`.
+  """
+  @spec custom_command_description(term(), String.t()) :: String.t()
+  def custom_command_description(value, name) do
+    if cli?(value) do
+      count = value |> describe() |> Map.fetch!(:commands) |> length()
+      "#{name} is a CLI tool (#{count} #{pluralize(count, "command", "commands")})"
+    else
+      "#{name} is #{name}"
+    end
+  end
+
+  defp pluralize(1, singular, _plural), do: singular
+  defp pluralize(_, _singular, plural), do: plural
+
+  @doc """
+  Returns `true` if `module` `use`s `JustBash.CLI`.
+  """
+  @spec cli_module?(module()) :: boolean()
+  def cli_module?(module) when is_atom(module) do
+    Code.ensure_loaded?(module) and function_exported?(module, :spec, 0) and
+      __MODULE__ in module_behaviours(module)
+  end
+
+  defp module_behaviours(module) do
+    module.module_info(:attributes) |> Keyword.get_values(:behaviour) |> List.flatten()
+  rescue
+    _ -> []
+  end
+
+  # Resolve a struct or `use`-module to the underlying %JustBash.CLI{}.
+  defp resolve(%__MODULE__{} = cli), do: cli
+  defp resolve(module) when is_atom(module), do: module.spec()
+
+  @doc """
+  Build a CLI tool rooted at `name`.
+
+  ## Options
+
+    * `:doc` — one-line description of the tool
+    * `:commands` — a list of top-level `JustBash.CLI.Command` nodes (built with `command/2`)
+    * `:aliases` — additional names the tool can be registered under
+
+  Raises `ArgumentError` if names are invalid or top-level command names collide.
+  """
+  @spec new(String.t(), keyword()) :: t()
+  def new(name, opts \\ []) when is_binary(name) do
+    validate_name!(name, "CLI")
+
+    commands = Keyword.get(opts, :commands, [])
+    validate_commands!(commands)
+    validate_unique_names!(commands, name)
+
+    aliases = Keyword.get(opts, :aliases, [])
+    validate_aliases!(aliases)
+
+    %__MODULE__{
+      name: name,
+      doc: Keyword.get(opts, :doc),
+      commands: commands,
+      aliases: aliases
+    }
+  end
+
+  @doc """
+  Build a single command node.
+
+  A node is a **group** (routes to children) when given `:commands`, or a **leaf** (does
+  work) when given `:run`. Exactly one of the two must be provided.
+
+  ## Options
+
+    * `:doc` — one-line description shown in help output
+    * `:commands` — nested child nodes (makes this a group)
+    * `:run` — a one-arg handler `(JustBash.CLI.Invocation.t() -> {map(), JustBash.t()})`
+      (makes this a leaf)
+    * `:flags` — an `ArgParser` flag spec (leaves only)
+    * `:args` — positional argument specs (leaves only); see `t:JustBash.CLI.Command.arg_spec/0`
+
+  Raises `ArgumentError` on invalid shape (e.g. both or neither of `:commands`/`:run`).
+  """
+  @spec command(String.t(), keyword()) :: Command.t()
+  def command(name, opts \\ []) when is_binary(name) do
+    validate_name!(name, "command")
+
+    commands = Keyword.get(opts, :commands, [])
+    run = Keyword.get(opts, :run)
+    flags = Keyword.get(opts, :flags, [])
+    args = Keyword.get(opts, :args, [])
+
+    validate_node_kind!(name, commands, run)
+    validate_commands!(commands)
+    validate_unique_names!(commands, name)
+    flags = normalize_flags!(name, flags)
+    args = validate_args!(name, args)
+
+    %Command{
+      name: name,
+      doc: Keyword.get(opts, :doc),
+      flags: flags,
+      args: args,
+      commands: commands,
+      run: run
+    }
+  end
+
+  @doc """
+  Run a CLI against raw arguments.
+
+  Routes `args` through the command tree, parses the matched leaf's flags and
+  positionals, and invokes its handler. Returns `{result, bash}` — the same shape as
+  `c:JustBash.Commands.Command.execute/3`.
+
+  Usage problems (unknown subcommand, bad flag, missing argument) return an error result
+  with exit code `2` and a usage hint, rather than raising.
+  """
+  @spec run(t(), JustBash.t(), [String.t()], String.t()) :: {map(), JustBash.t()}
+  def run(%__MODULE__{} = cli, bash, args, stdin) do
+    case route(cli, args, []) do
+      {:leaf, leaf, path, rest} ->
+        if wants_help?(rest) do
+          {help_result(Help.leaf_help(cli, path, leaf)), bash}
+        else
+          dispatch_leaf(cli, leaf, path, rest, bash, stdin)
+        end
+
+      {:no_subcommand, group, path, remaining} ->
+        if wants_help?(remaining) do
+          {help_result(Help.group_help(cli, path, group)), bash}
+        else
+          {usage_error(Help.missing_subcommand(cli, path, group)), bash}
+        end
+
+      {:unknown_subcommand, group, path, token} ->
+        {usage_error(Help.unknown_subcommand(cli, path, group, token)), bash}
+    end
+  end
+
+  # `--help`/`-h` anywhere before a `--` terminator requests help.
+  defp wants_help?(tokens) do
+    tokens
+    |> Enum.take_while(&(&1 != "--"))
+    |> Enum.any?(&(&1 in ["--help", "-h"]))
+  end
+
+  @doc """
+  Return a plain-data description of the CLI's command tree.
+
+  Useful for generating agent-facing documentation or building tab completion. Every
+  leaf is listed with its full invocation `path` and resolved flag/argument specs:
+
+      JustBash.CLI.describe(cli)
+      #=> %{
+      #     name: "acme",
+      #     doc: "Acme operations toolkit",
+      #     aliases: [],
+      #     commands: [
+      #       %{path: ["pr", "review"], doc: "Review a pull request",
+      #         flags: [%{name: :report, type: :integer, required: true, ...}], args: []},
+      #       ...
+      #     ]
+      #   }
+  """
+  @spec describe(spec()) :: map()
+  def describe(cli_or_module) do
+    cli = resolve(cli_or_module)
+
+    %{
+      name: cli.name,
+      doc: cli.doc,
+      aliases: cli.aliases,
+      commands: describe_leaves(cli.commands, [])
+    }
+  end
+
+  @doc """
+  Render the CLI as a standalone document.
+
+  Pass `format: :text` (default) for a plain-text manual, or `format: :markdown` for a
+  markdown document suitable for an agent's system prompt.
+  """
+  @spec render_docs(spec(), keyword()) :: String.t()
+  def render_docs(cli_or_module, opts \\ []) do
+    Docs.render(resolve(cli_or_module), Keyword.get(opts, :format, :text))
+  end
+
+  defp describe_leaves(commands, prefix) do
+    Enum.flat_map(commands, fn command ->
+      path = prefix ++ [command.name]
+
+      if Command.group?(command) do
+        describe_leaves(command.commands, path)
+      else
+        [
+          %{
+            path: path,
+            doc: command.doc,
+            flags: describe_flags(command.flags),
+            args: command.args
+          }
+        ]
+      end
+    end)
+  end
+
+  defp describe_flags(flags) do
+    Enum.map(flags, fn {name, spec} ->
+      %{
+        name: name,
+        type: spec[:type],
+        short: spec[:short],
+        long: spec[:long],
+        required: spec[:required] || false,
+        default: spec[:default],
+        values: spec[:values],
+        doc: spec[:doc]
+      }
+    end)
+  end
+
+  # --- routing ---
+
+  # Walks the tree consuming leading positional tokens. `group` is either the root
+  # %CLI{} or a %Command{} group; both expose `name`/`doc`/`commands`.
+  defp route(group, [], path), do: {:no_subcommand, group, path, []}
+
+  defp route(group, ["-" <> _ | _] = remaining, path),
+    do: {:no_subcommand, group, path, remaining}
+
+  defp route(group, [token | rest], path) do
+    case Enum.find(group.commands, &(&1.name == token)) do
+      nil ->
+        {:unknown_subcommand, group, path, token}
+
+      %Command{run: nil} = child ->
+        route(child, rest, path ++ [token])
+
+      %Command{} = leaf ->
+        {:leaf, leaf, path ++ [token], rest}
+    end
+  end
+
+  # --- leaf dispatch ---
+
+  defp dispatch_leaf(cli, %Command{} = leaf, path, rest, bash, stdin) do
+    label = command_label(cli, path)
+
+    with {:ok, flags, positional} <- ArgParser.parse(rest, leaf.flags, command: label),
+         :ok <- validate_positionals(leaf.args, positional, label) do
+      invocation = %Invocation{
+        bash: bash,
+        flags: flags,
+        args: positional,
+        stdin: stdin,
+        path: path
+      }
+
+      case leaf.run.(invocation) do
+        {result, new_bash} -> {tag_subcommand(result, path), new_bash}
+        other -> other
+      end
+    else
+      {:error, message} ->
+        {tag_subcommand(usage_error(message <> Help.usage_line(cli, path, leaf)), path), bash}
+    end
+  end
+
+  defp validate_positionals(specs, positional, label) do
+    min = Enum.count(specs, & &1.required)
+    variadic? = Enum.any?(specs, & &1.variadic)
+    given = length(positional)
+
+    cond do
+      given < min ->
+        missing = specs |> Enum.drop(given) |> Enum.filter(& &1.required) |> Enum.map(& &1.name)
+        {:error, "#{label}: missing required argument: #{Enum.join(missing, ", ")}\n"}
+
+      not variadic? and given > length(specs) ->
+        extra = Enum.drop(positional, length(specs))
+        {:error, "#{label}: unexpected argument(s): #{Enum.join(extra, ", ")}\n"}
+
+      true ->
+        :ok
+    end
+  end
+
+  # --- result helpers ---
+
+  defp command_label(cli, path), do: Enum.join([cli.name | path], " ")
+
+  defp usage_error(message), do: %{stdout: "", stderr: message, exit_code: @usage_exit}
+
+  defp help_result(text), do: %{stdout: text, stderr: "", exit_code: 0}
+
+  # Stash the resolved subcommand path on the result so the executor can attach it to
+  # command telemetry, then strip it before the result reaches the shell (see
+  # JustBash.Interpreter.Executor). Only meaningful for results that are maps.
+  defp tag_subcommand(result, path) when is_map(result),
+    do: Map.put(result, :__subcommand__, path)
+
+  defp tag_subcommand(result, _path), do: result
+
+  # --- validation helpers ---
+
+  defp validate_name!(name, kind) do
+    cond do
+      not is_binary(name) or name == "" ->
+        raise ArgumentError, "#{kind} name must be a non-empty string, got: #{inspect(name)}"
+
+      String.contains?(name, " ") ->
+        raise ArgumentError, "#{kind} name must not contain spaces, got: #{inspect(name)}"
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_node_kind!(name, [], nil) do
+    raise ArgumentError,
+          "command #{inspect(name)} must be either a group (:commands) or a leaf (:run); got neither"
+  end
+
+  defp validate_node_kind!(name, commands, run) when commands != [] and not is_nil(run) do
+    raise ArgumentError,
+          "command #{inspect(name)} cannot be both a group (:commands) and a leaf (:run)"
+  end
+
+  defp validate_node_kind!(_name, _commands, nil), do: :ok
+
+  defp validate_node_kind!(name, _commands, run) when not is_function(run, 1) do
+    raise ArgumentError,
+          "command #{inspect(name)} :run must be a 1-arity function, got: #{inspect(run)}"
+  end
+
+  defp validate_node_kind!(_name, _commands, _run), do: :ok
+
+  defp validate_commands!(commands) when is_list(commands) do
+    Enum.each(commands, fn
+      %Command{} -> :ok
+      other -> raise ArgumentError, "expected a JustBash.CLI.Command, got: #{inspect(other)}"
+    end)
+  end
+
+  defp validate_commands!(other) do
+    raise ArgumentError,
+          ":commands must be a list of JustBash.CLI.Command, got: #{inspect(other)}"
+  end
+
+  defp validate_unique_names!(commands, parent) do
+    names = Enum.map(commands, & &1.name)
+    dupes = names -- Enum.uniq(names)
+
+    if dupes != [] do
+      raise ArgumentError,
+            "duplicate subcommand name(s) under #{inspect(parent)}: #{inspect(Enum.uniq(dupes))}"
+    end
+  end
+
+  defp validate_aliases!(aliases) when is_list(aliases) do
+    Enum.each(aliases, &validate_name!(&1, "alias"))
+  end
+
+  defp validate_aliases!(other) do
+    raise ArgumentError, ":aliases must be a list of strings, got: #{inspect(other)}"
+  end
+
+  # Validates flag specs and fills in a default `--long` form so every flag is reachable
+  # by its name (e.g. `:dry_run` -> `--dry-run`) unless an explicit `:long` is given.
+  defp normalize_flags!(name, flags) when is_list(flags) do
+    unless Keyword.keyword?(flags) do
+      raise ArgumentError,
+            "command #{inspect(name)} :flags must be a keyword list of flag specs, got: #{inspect(flags)}"
+    end
+
+    Enum.map(flags, fn {flag_name, spec} ->
+      unless Keyword.keyword?(spec) do
+        raise ArgumentError,
+              "command #{inspect(name)} flag #{inspect(flag_name)} spec must be a keyword list, got: #{inspect(spec)}"
+      end
+
+      {flag_name, Keyword.put_new(spec, :long, default_long(flag_name))}
+    end)
+  end
+
+  defp normalize_flags!(name, flags) do
+    raise ArgumentError,
+          "command #{inspect(name)} :flags must be a keyword list of flag specs, got: #{inspect(flags)}"
+  end
+
+  defp default_long(flag_name) do
+    "--" <> String.replace(Atom.to_string(flag_name), "_", "-")
+  end
+
+  defp validate_args!(name, args) when is_list(args) do
+    {normalized, _seen_variadic} =
+      Enum.map_reduce(args, false, fn arg, variadic_seen? ->
+        spec = normalize_arg!(name, arg)
+
+        if variadic_seen? do
+          raise ArgumentError,
+                "command #{inspect(name)}: a variadic positional argument must be last"
+        end
+
+        {spec, spec.variadic}
+      end)
+
+    normalized
+  end
+
+  defp validate_args!(name, other) do
+    raise ArgumentError, "command #{inspect(name)} :args must be a list, got: #{inspect(other)}"
+  end
+
+  defp normalize_arg!(_name, %{name: arg_name} = spec) when is_atom(arg_name) do
+    %{
+      name: arg_name,
+      doc: Map.get(spec, :doc),
+      required: Map.get(spec, :required, false),
+      variadic: Map.get(spec, :variadic, false)
+    }
+  end
+
+  defp normalize_arg!(name, other) do
+    raise ArgumentError,
+          "command #{inspect(name)}: each :args entry must be a map with an atom :name, got: #{inspect(other)}"
+  end
+end

--- a/lib/just_bash/cli/command.ex
+++ b/lib/just_bash/cli/command.ex
@@ -1,0 +1,64 @@
+defmodule JustBash.CLI.Command do
+  @moduledoc """
+  A single node in a `JustBash.CLI` command tree.
+
+  A node is either:
+
+    * a **group** — has nested `commands` and no `run` handler (it routes to children), or
+    * a **leaf** — has a `run` handler and no nested `commands` (it does the work).
+
+  Build nodes with `JustBash.CLI.command/2` rather than constructing the struct directly,
+  so validation runs.
+
+  ## Fields
+
+    * `:name` — the token used to route to this node (e.g. `"review"`)
+    * `:doc` — one-line description shown in help output
+    * `:flags` — a `JustBash.Commands.ArgParser` flag spec (keyword list); leaves only
+    * `:args` — positional argument specs (see `t:arg_spec/0`); leaves only
+    * `:commands` — nested child nodes (groups only)
+    * `:run` — the handler, `(JustBash.CLI.Invocation.t() -> {map(), JustBash.t()})`; leaves only
+  """
+
+  @enforce_keys [:name]
+  defstruct name: nil, doc: nil, flags: [], args: [], commands: [], run: nil
+
+  @typedoc """
+  A positional argument specification.
+
+    * `:name` — atom name (also the display label)
+    * `:doc` — one-line description
+    * `:required` — whether the argument must be present (default `false`)
+    * `:variadic` — when `true`, captures all remaining positionals (default `false`)
+  """
+  @type arg_spec :: %{
+          required(:name) => atom(),
+          optional(:doc) => String.t(),
+          optional(:required) => boolean(),
+          optional(:variadic) => boolean()
+        }
+
+  @type handler :: (JustBash.CLI.Invocation.t() -> {map(), JustBash.t()})
+
+  @type t :: %__MODULE__{
+          name: String.t(),
+          doc: String.t() | nil,
+          flags: keyword(),
+          args: [arg_spec()],
+          commands: [t()],
+          run: handler() | nil
+        }
+
+  @doc """
+  Returns `true` when the node routes to children rather than running a handler.
+  """
+  @spec group?(t()) :: boolean()
+  def group?(%__MODULE__{run: nil}), do: true
+  def group?(%__MODULE__{}), do: false
+
+  @doc """
+  Returns `true` when the node runs a handler.
+  """
+  @spec leaf?(t()) :: boolean()
+  def leaf?(%__MODULE__{} = command), do: not group?(command)
+end

--- a/lib/just_bash/cli/docs.ex
+++ b/lib/just_bash/cli/docs.ex
@@ -1,0 +1,125 @@
+defmodule JustBash.CLI.Docs do
+  @moduledoc """
+  Renders a whole `JustBash.CLI` as a document for human or agent consumption.
+
+  Used by `JustBash.CLI.render_docs/2`. Because docs are generated from the same spec
+  that drives routing and `--help`, the documentation a host injects into an agent's
+  system prompt never drifts from the CLI's actual behavior.
+  """
+
+  alias JustBash.CLI.Command
+  alias JustBash.CLI.Help
+
+  @doc """
+  Render `cli` in the given `format` (`:text` or `:markdown`).
+  """
+  @spec render(JustBash.CLI.t(), :text | :markdown) :: String.t()
+  def render(cli, :text) do
+    leaves = leaf_nodes(cli.commands, [])
+
+    [
+      Help.group_help(cli, [], cli)
+      | Enum.map(leaves, fn {path, node} -> Help.leaf_help(cli, path, node) end)
+    ]
+    |> Enum.join("\n")
+  end
+
+  def render(cli, :markdown) do
+    leaves = leaf_nodes(cli.commands, [])
+
+    header = ["# ", cli.name, "\n", optional_para(cli.doc)]
+    sections = Enum.map(leaves, fn {path, node} -> markdown_command(cli, path, node) end)
+
+    IO.iodata_to_binary([header, "\n", Enum.intersperse(sections, "\n")])
+  end
+
+  # Collect every leaf as {path, node}, depth-first, so docs list full invocation paths.
+  defp leaf_nodes(commands, prefix) do
+    Enum.flat_map(commands, fn cmd ->
+      path = prefix ++ [cmd.name]
+      if Command.group?(cmd), do: leaf_nodes(cmd.commands, path), else: [{path, cmd}]
+    end)
+  end
+
+  defp markdown_command(cli, path, %Command{} = node) do
+    label = Enum.join([cli.name | path], " ")
+    usage = String.trim_trailing(Help.usage_line(cli, path, node))
+
+    [
+      "## ",
+      label,
+      "\n",
+      optional_para(node.doc),
+      "\n```\n",
+      usage,
+      "\n```\n",
+      flags_table(node.flags),
+      args_table(node.args)
+    ]
+  end
+
+  defp optional_para(nil), do: []
+  defp optional_para(doc), do: ["\n", doc, "\n"]
+
+  defp flags_table([]), do: []
+
+  defp flags_table(flags) do
+    rows =
+      Enum.map(flags, fn {_name, spec} ->
+        [
+          "| `",
+          flag_forms(spec),
+          "` | ",
+          to_string(spec[:type]),
+          " | ",
+          yes_no(spec[:required]),
+          " | ",
+          default_cell(spec),
+          " | ",
+          cell(spec[:doc]),
+          " |\n"
+        ]
+      end)
+
+    [
+      "\n**Flags:**\n\n",
+      "| Flag | Type | Required | Default | Description |\n",
+      "|------|------|----------|---------|-------------|\n",
+      rows
+    ]
+  end
+
+  defp args_table([]), do: []
+
+  defp args_table(args) do
+    rows =
+      Enum.map(args, fn arg ->
+        ["| `", to_string(arg.name), "` | ", yes_no(arg.required), " | ", cell(arg[:doc]), " |\n"]
+      end)
+
+    [
+      "\n**Arguments:**\n\n",
+      "| Argument | Required | Description |\n",
+      "|----------|----------|-------------|\n",
+      rows
+    ]
+  end
+
+  defp flag_forms(spec) do
+    [spec[:short], spec[:long]] |> Enum.reject(&is_nil/1) |> Enum.join(", ")
+  end
+
+  defp default_cell(spec) do
+    case {spec[:type], spec[:default]} do
+      {:boolean, _} -> ""
+      {_, nil} -> ""
+      {_, default} -> to_string(default)
+    end
+  end
+
+  defp yes_no(true), do: "yes"
+  defp yes_no(_), do: "no"
+
+  defp cell(nil), do: ""
+  defp cell(text), do: text
+end

--- a/lib/just_bash/cli/help.ex
+++ b/lib/just_bash/cli/help.ex
@@ -68,8 +68,10 @@ defmodule JustBash.CLI.Help do
         name -> "Did you mean '#{Enum.join(path ++ [name], " ")}'?\n"
       end
 
+    # Point `--help` at the group the unknown token was a child of (`acme pr --help`), not
+    # always the root — that's where the available commands actually live.
     "#{cli.name}: unknown command '#{attempted}'\n" <>
-      suggestion <> "Run '#{cli.name} --help' for available commands.\n"
+      suggestion <> "Run '#{label(cli, path)} --help' for available commands.\n"
   end
 
   @doc """

--- a/lib/just_bash/cli/help.ex
+++ b/lib/just_bash/cli/help.ex
@@ -1,0 +1,237 @@
+defmodule JustBash.CLI.Help do
+  @moduledoc """
+  Renders `--help` text, usage lines, and usage errors for a `JustBash.CLI`.
+
+  All output is derived purely from the CLI's declarative spec, so help can never drift
+  from runtime behavior. Output format is consistent across every CLI built on the
+  feature — which is the point: agents recover from a typo or a missing flag in one turn
+  because the error always carries a usage line and (for unknown commands) a suggestion.
+  """
+
+  alias JustBash.CLI.Command
+
+  @doc """
+  Full `--help` text for a group node (the CLI root or a `%Command{}` group).
+
+  `path` is the subcommand path to the group (`[]` for the root).
+  """
+  @spec group_help(JustBash.CLI.t(), [String.t()], struct()) :: String.t()
+  def group_help(cli, path, group) do
+    label = label(cli, path)
+    children = group.commands
+
+    [
+      title(label, group.doc),
+      "Usage: #{label} <command> [args]\n",
+      commands_section(children),
+      "Run '#{label} <command> --help' for more information on a command.\n"
+    ]
+    |> compact_join()
+  end
+
+  @doc """
+  Full `--help` text for a leaf command.
+  """
+  @spec leaf_help(JustBash.CLI.t(), [String.t()], Command.t()) :: String.t()
+  def leaf_help(cli, path, %Command{} = leaf) do
+    [
+      title(label(cli, path), leaf.doc),
+      usage_line(cli, path, leaf),
+      args_section(leaf.args),
+      options_section(leaf.flags)
+    ]
+    |> compact_join()
+  end
+
+  @doc """
+  The one-line `Usage:` string for a leaf, used both in `--help` and in usage errors.
+  """
+  @spec usage_line(JustBash.CLI.t(), [String.t()], Command.t()) :: String.t()
+  def usage_line(cli, path, %Command{} = leaf) do
+    tokens =
+      Enum.map(leaf.flags, &flag_usage/1) ++ Enum.map(leaf.args, &arg_usage/1)
+
+    "Usage: #{Enum.join([label(cli, path) | tokens], " ")}\n"
+  end
+
+  @doc """
+  Error text for an unknown subcommand: a message, a "did you mean" suggestion when one
+  is close enough, and a pointer to `--help`.
+  """
+  @spec unknown_subcommand(JustBash.CLI.t(), [String.t()], struct(), String.t()) :: String.t()
+  def unknown_subcommand(cli, path, group, token) do
+    attempted = Enum.join(path ++ [token], " ")
+
+    suggestion =
+      case suggest(group.commands, token) do
+        nil -> ""
+        name -> "Did you mean '#{Enum.join(path ++ [name], " ")}'?\n"
+      end
+
+    "#{cli.name}: unknown command '#{attempted}'\n" <>
+      suggestion <> "Run '#{cli.name} --help' for available commands.\n"
+  end
+
+  @doc """
+  Error text for a group invoked without a subcommand: a message plus the group's
+  command listing.
+  """
+  @spec missing_subcommand(JustBash.CLI.t(), [String.t()], struct()) :: String.t()
+  def missing_subcommand(cli, path, group) do
+    label = label(cli, path)
+
+    "#{label}: missing subcommand\n" <>
+      commands_section(group.commands) <>
+      "Run '#{label} <command> --help' for more information on a command.\n"
+  end
+
+  # --- sections ---
+
+  defp title(label, nil), do: "#{label}\n"
+  defp title(label, doc), do: "#{label} - #{doc}\n"
+
+  defp commands_section([]), do: ""
+
+  defp commands_section(children) do
+    rows = Enum.map(children, fn child -> {child.name, command_summary(child)} end)
+    "Commands:\n" <> aligned_rows(rows)
+  end
+
+  defp command_summary(%Command{} = child) do
+    suffix = if Command.group?(child), do: " (group)", else: ""
+    "#{child.doc || ""}#{suffix}"
+  end
+
+  defp args_section([]), do: ""
+
+  defp args_section(args) do
+    rows = Enum.map(args, fn arg -> {"<#{arg.name}>", arg_detail(arg)} end)
+    "Arguments:\n" <> aligned_rows(rows)
+  end
+
+  defp arg_detail(arg) do
+    [arg[:doc], if(arg.required, do: "(required)")]
+    |> Enum.reject(&(is_nil(&1) or &1 == ""))
+    |> Enum.join(" ")
+  end
+
+  defp options_section([]), do: ""
+
+  defp options_section(flags) do
+    rows = Enum.map(flags, fn {_name, spec} = flag -> {flag_label(flag), flag_detail(spec)} end)
+    "Options:\n" <> aligned_rows(rows)
+  end
+
+  # --- flag/arg rendering ---
+
+  # Left column for the detail list, e.g. "-v, --verbose" or "--report <int>".
+  defp flag_label({_name, spec}) do
+    forms =
+      [spec[:short], spec[:long]]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(", ")
+
+    case placeholder(spec) do
+      nil -> forms
+      ph -> "#{forms} #{ph}"
+    end
+  end
+
+  defp flag_detail(spec) do
+    [
+      spec[:doc],
+      values_note(spec[:values]),
+      default_note(spec),
+      if(spec[:required], do: "(required)")
+    ]
+    |> Enum.reject(&(is_nil(&1) or &1 == ""))
+    |> Enum.join(" ")
+  end
+
+  defp values_note(nil), do: nil
+  defp values_note(values), do: "(values: #{Enum.join(values, ", ")})"
+
+  defp default_note(spec) do
+    case {spec[:type], spec[:default]} do
+      {:boolean, _} -> nil
+      {_, nil} -> nil
+      {_, default} -> "(default: #{default})"
+    end
+  end
+
+  # Inline usage token, e.g. "--report <int>" (required) or "[--format text|json]".
+  defp flag_usage({_name, spec}) do
+    token =
+      case placeholder(spec) do
+        nil -> primary_form(spec)
+        ph -> "#{primary_form(spec)} #{ph}"
+      end
+
+    if spec[:required], do: token, else: "[#{token}]"
+  end
+
+  defp primary_form(spec) do
+    cond do
+      spec[:type] == :boolean and spec[:short] -> spec[:short]
+      spec[:long] -> spec[:long]
+      true -> spec[:short]
+    end
+  end
+
+  defp arg_usage(arg) do
+    base = if arg.variadic, do: "<#{arg.name}>...", else: "<#{arg.name}>"
+    if arg.required, do: base, else: "[#{base}]"
+  end
+
+  # Enum values render as a|b inline; otherwise a type placeholder; booleans have none.
+  defp placeholder(spec) do
+    case spec[:values] do
+      nil -> type_placeholder(spec[:type])
+      values -> Enum.join(values, "|")
+    end
+  end
+
+  defp type_placeholder(:integer), do: "<int>"
+  defp type_placeholder(:float), do: "<float>"
+  defp type_placeholder(:string), do: "<string>"
+  defp type_placeholder(:accumulator), do: "<string>"
+  defp type_placeholder(_), do: nil
+
+  # --- suggestions ---
+
+  # Closest child name to `token` by Jaro distance, when confident enough.
+  defp suggest(children, token) do
+    children
+    |> Enum.map(fn child -> {child.name, String.jaro_distance(child.name, token)} end)
+    |> Enum.max_by(fn {_name, score} -> score end, fn -> nil end)
+    |> case do
+      {name, score} when score >= 0.7 -> name
+      _ -> nil
+    end
+  end
+
+  # --- formatting ---
+
+  defp label(cli, path), do: Enum.join([cli.name | path], " ")
+
+  # Two-column rows, left column padded to a common width.
+  defp aligned_rows(rows) do
+    width = rows |> Enum.map(fn {left, _} -> String.length(left) end) |> Enum.max(fn -> 0 end)
+
+    rows
+    |> Enum.map_join("", fn {left, right} ->
+      if right == "" do
+        "  #{left}\n"
+      else
+        "  #{String.pad_trailing(left, width)}   #{right}\n"
+      end
+    end)
+  end
+
+  # Join non-empty sections with a blank line between them, ending in a single newline.
+  defp compact_join(sections) do
+    sections
+    |> Enum.reject(&(&1 == "" or is_nil(&1)))
+    |> Enum.join("\n")
+  end
+end

--- a/lib/just_bash/cli/invocation.ex
+++ b/lib/just_bash/cli/invocation.ex
@@ -1,0 +1,32 @@
+defmodule JustBash.CLI.Invocation do
+  @moduledoc """
+  The single argument passed to a `JustBash.CLI` command handler.
+
+  A handler is a one-argument function that receives an `%Invocation{}` and returns
+  `{result, bash}` — exactly the contract of `c:JustBash.Commands.Command.execute/3`.
+
+      def review(%JustBash.CLI.Invocation{flags: flags, bash: bash}) do
+        report = MyApp.PullRequests.fetch!(flags.report, bash.context.user)
+        {JustBash.Commands.Command.ok(render(report, flags.format)), bash}
+      end
+
+  ## Fields
+
+    * `:bash` — the full `t:JustBash.t/0` struct (fs, env, context, …)
+    * `:flags` — a map of parsed flag values, keyed by the flag's atom name
+    * `:args` — the remaining positional arguments, as a list of strings
+    * `:stdin` — the command's stdin, as a string
+    * `:path` — the resolved subcommand path that routed here, e.g. `["pr", "review"]`
+  """
+
+  @enforce_keys [:bash, :flags, :args, :stdin, :path]
+  defstruct [:bash, :flags, :args, :stdin, :path]
+
+  @type t :: %__MODULE__{
+          bash: JustBash.t(),
+          flags: %{optional(atom()) => term()},
+          args: [String.t()],
+          stdin: String.t(),
+          path: [String.t()]
+        }
+end

--- a/lib/just_bash/commands/arg_parser.ex
+++ b/lib/just_bash/commands/arg_parser.ex
@@ -27,23 +27,28 @@ defmodule JustBash.Commands.ArgParser do
   - `:boolean` - Flag is present or absent (no value needed)
   - `:string` - Takes a string value
   - `:integer` - Takes an integer value
+  - `:float` - Takes a floating-point value
   - `:accumulator` - Accumulates multiple values into a list (for -H headers, etc.)
 
   ## Options
 
   - `:short` - Short flag form (e.g., "-s")
-  - `:long` - Long flag form (e.g., "--silent")  
-  - `:type` - Value type (`:boolean`, `:string`, `:integer`, `:accumulator`)
+  - `:long` - Long flag form (e.g., "--silent")
+  - `:type` - Value type (`:boolean`, `:string`, `:integer`, `:float`, `:accumulator`)
   - `:default` - Default value if flag not provided
+  - `:required` - When `true`, parsing fails if the flag is not provided
+  - `:values` - List of allowed values; parsing fails on anything else (enum)
   - `:transform` - Optional function to transform the value
   """
 
-  @type flag_type :: :boolean | :string | :integer | :accumulator
+  @type flag_type :: :boolean | :string | :integer | :float | :accumulator
   @type flag_spec :: [
           short: String.t(),
           long: String.t(),
           type: flag_type(),
           default: any(),
+          required: boolean(),
+          values: [any()],
           transform: (String.t() -> any())
         ]
   @type flags_spec :: [{atom(), flag_spec()}]
@@ -72,9 +77,13 @@ defmodule JustBash.Commands.ArgParser do
       allow_unknown: Keyword.get(opts, :allow_unknown, false)
     }
 
-    # Build defaults and parse arguments
-    defaults = build_defaults(flags)
-    parse_loop(args, ctx, defaults, [])
+    # Parse into a map of only the flags that were actually provided, so we can
+    # distinguish "set" from "defaulted" for required-flag checking. Defaults are
+    # merged in afterwards.
+    with {:ok, provided, positional} <- parse_loop(args, ctx, %{}, []),
+         :ok <- check_required(flags, provided, ctx.command) do
+      {:ok, merge_defaults(flags, provided), positional}
+    end
   end
 
   defp build_flag_maps(flags) do
@@ -85,18 +94,43 @@ defmodule JustBash.Commands.ArgParser do
     end)
   end
 
-  defp build_defaults(flags) do
-    Enum.reduce(flags, %{}, fn {name, spec}, acc ->
-      default =
-        case spec[:type] do
-          :boolean -> Keyword.get(spec, :default, false)
-          :accumulator -> Keyword.get(spec, :default, [])
-          _ -> Keyword.get(spec, :default)
-        end
-
-      Map.put(acc, name, default)
+  # Fill in defaults for any flag that was not provided on the command line.
+  defp merge_defaults(flags, provided) do
+    Enum.reduce(flags, provided, fn {name, spec}, acc ->
+      if Map.has_key?(acc, name) do
+        acc
+      else
+        Map.put(acc, name, default_for(spec))
+      end
     end)
   end
+
+  defp default_for(spec) do
+    case spec[:type] do
+      :boolean -> Keyword.get(spec, :default, false)
+      :accumulator -> Keyword.get(spec, :default, [])
+      _ -> Keyword.get(spec, :default)
+    end
+  end
+
+  # Fail if any flag marked `required: true` was not provided.
+  defp check_required(flags, provided, command) do
+    Enum.reduce_while(flags, :ok, fn {name, spec}, :ok ->
+      if spec[:required] && not Map.has_key?(provided, name) do
+        {:halt, {:error, format_required_error(command, spec)}}
+      else
+        {:cont, :ok}
+      end
+    end)
+  end
+
+  defp flag_display_name(spec), do: spec[:long] || spec[:short]
+
+  defp format_required_error("", spec),
+    do: "missing required flag: #{flag_display_name(spec)}\n"
+
+  defp format_required_error(cmd, spec),
+    do: "#{cmd}: missing required flag: #{flag_display_name(spec)}\n"
 
   defp parse_loop([], _ctx, opts, positional) do
     {:ok, opts, Enum.reverse(positional)}
@@ -209,7 +243,7 @@ defmodule JustBash.Commands.ArgParser do
         new_opts = Map.put(opts, name, true)
         parse_loop(args, ctx, new_opts, positional)
 
-      type when type in [:string, :integer, :accumulator] ->
+      type when type in [:string, :integer, :float, :accumulator] ->
         case args do
           [value | rest] ->
             case apply_value(opts, name, spec, value) do
@@ -227,30 +261,57 @@ defmodule JustBash.Commands.ArgParser do
   end
 
   defp apply_value(opts, name, spec, value) do
+    with {:ok, typed} <- coerce_value(spec[:type], value),
+         transformed = apply_transform(spec, typed),
+         :ok <- check_enum(spec, transformed) do
+      {:ok, store_value(opts, name, spec, transformed)}
+    end
+  end
+
+  defp coerce_value(:string, value), do: {:ok, value}
+  defp coerce_value(:accumulator, value), do: {:ok, value}
+
+  defp coerce_value(:boolean, value), do: {:ok, value in ["true", "1", "yes"]}
+
+  defp coerce_value(:integer, value) do
+    case Integer.parse(value) do
+      {n, ""} -> {:ok, n}
+      {n, _} -> {:ok, n}
+      :error -> {:error, "invalid integer value: #{value}\n"}
+    end
+  end
+
+  defp coerce_value(:float, value) do
+    case Float.parse(value) do
+      {f, _} -> {:ok, f}
+      :error -> {:error, "invalid float value: #{value}\n"}
+    end
+  end
+
+  # Accumulators append to a list; every other type overwrites.
+  defp store_value(opts, name, spec, value) do
     case spec[:type] do
-      :string ->
-        transformed = apply_transform(spec, value)
-        {:ok, Map.put(opts, name, transformed)}
-
-      :integer ->
-        case Integer.parse(value) do
-          {n, _} ->
-            transformed = apply_transform(spec, n)
-            {:ok, Map.put(opts, name, transformed)}
-
-          :error ->
-            {:error, "invalid integer value: #{value}\n"}
-        end
-
       :accumulator ->
-        transformed = apply_transform(spec, value)
         current = Map.get(opts, name, [])
-        {:ok, Map.put(opts, name, current ++ [transformed])}
+        Map.put(opts, name, current ++ [value])
 
-      :boolean ->
-        # For boolean with explicit value
-        bool_value = value in ["true", "1", "yes"]
-        {:ok, Map.put(opts, name, bool_value)}
+      _ ->
+        Map.put(opts, name, value)
+    end
+  end
+
+  defp check_enum(spec, value) do
+    case spec[:values] do
+      nil ->
+        :ok
+
+      values ->
+        if value in values do
+          :ok
+        else
+          {:error,
+           "invalid value for #{flag_display_name(spec)}: #{value} (allowed: #{Enum.join(values, ", ")})\n"}
+        end
     end
   end
 

--- a/lib/just_bash/commands/arg_parser.ex
+++ b/lib/just_bash/commands/arg_parser.ex
@@ -273,18 +273,19 @@ defmodule JustBash.Commands.ArgParser do
 
   defp coerce_value(:boolean, value), do: {:ok, value in ["true", "1", "yes"]}
 
+  # Strict: the whole value must be the number, so a typo like "42x" or a
+  # thousands-separated "1_000" is a loud error rather than a silent truncation to 42/1.
   defp coerce_value(:integer, value) do
     case Integer.parse(value) do
       {n, ""} -> {:ok, n}
-      {n, _} -> {:ok, n}
-      :error -> {:error, "invalid integer value: #{value}\n"}
+      _ -> {:error, "invalid integer value: #{value}\n"}
     end
   end
 
   defp coerce_value(:float, value) do
     case Float.parse(value) do
-      {f, _} -> {:ok, f}
-      :error -> {:error, "invalid float value: #{value}\n"}
+      {f, ""} -> {:ok, f}
+      _ -> {:error, "invalid float value: #{value}\n"}
     end
   end
 

--- a/lib/just_bash/commands/command.ex
+++ b/lib/just_bash/commands/command.ex
@@ -15,6 +15,13 @@ defmodule JustBash.Commands.Command do
 
   @doc """
   Execute the command with the given arguments and stdin.
+
+  The returned result map must carry `:stdout`, `:stderr`, and `:exit_code`, but **may
+  contain extra keys**. The executor preserves them past result validation, dropping only
+  internal control-flow signals before the result reaches the shell. This is load-bearing:
+  `JustBash.CLI` smuggles its resolved subcommand path through under `:__subcommand__` so
+  command telemetry can attribute it (the executor pops it into span metadata). Do not
+  tighten the result match to reject unknown keys.
   """
   @callback execute(bash(), args :: [String.t()], stdin :: String.t()) :: execution_result()
 

--- a/lib/just_bash/commands/command_builtin.ex
+++ b/lib/just_bash/commands/command_builtin.ex
@@ -59,7 +59,10 @@ defmodule JustBash.Commands.CommandBuiltin do
             {out <> "#{name} is a function\n", err, found}
 
           :custom ->
-            {out <> "#{name} is #{name}\n", err, found}
+            description =
+              JustBash.CLI.custom_command_description(Map.get(bash.commands, name), name)
+
+            {out <> description <> "\n", err, found}
 
           :builtin ->
             {out <> "#{name} is a shell builtin\n", err, found}

--- a/lib/just_bash/commands/type.ex
+++ b/lib/just_bash/commands/type.ex
@@ -38,7 +38,7 @@ defmodule JustBash.Commands.Type do
         {:ok, "#{name} is a shell builtin"}
 
       Map.has_key?(bash.commands, name) ->
-        {:ok, "#{name} is #{name}"}
+        {:ok, JustBash.CLI.custom_command_description(Map.get(bash.commands, name), name)}
 
       Registry.exists?(name) ->
         path = find_in_path(bash, name)

--- a/lib/just_bash/interpreter/executor.ex
+++ b/lib/just_bash/interpreter/executor.ex
@@ -408,12 +408,22 @@ defmodule JustBash.Interpreter.Executor do
                   )
               end
 
-            {{result, new_bash},
-             %{
-               exit_code: result.exit_code,
-               bytes_in: byte_size(effective_stdin),
-               bytes_out: byte_size(result.stdout) + byte_size(result.stderr)
-             }}
+            # A JustBash.CLI router stashes the resolved subcommand path here; surface it
+            # in telemetry and strip it before the result reaches the shell.
+            {subcommand, result} = Map.pop(result, :__subcommand__)
+
+            stop_metadata = %{
+              exit_code: result.exit_code,
+              bytes_in: byte_size(effective_stdin),
+              bytes_out: byte_size(result.stdout) + byte_size(result.stderr)
+            }
+
+            stop_metadata =
+              if subcommand,
+                do: Map.put(stop_metadata, :subcommand, subcommand),
+                else: stop_metadata
+
+            {{result, new_bash}, stop_metadata}
           end)
 
         func_body ->
@@ -819,12 +829,12 @@ defmodule JustBash.Interpreter.Executor do
 
   @control_signal_keys [:__break__, :__continue__, :__return__]
 
-  defp execute_custom_command(bash, cmd_name, module, args, stdin) do
+  defp execute_custom_command(bash, cmd_name, command, args, stdin) do
     bash = Limit.step!(bash)
 
     # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
     try do
-      case module.execute(bash, args, stdin) do
+      case dispatch_custom_command(command, bash, args, stdin) do
         {%{stdout: stdout, stderr: stderr, exit_code: exit_code} = result, %JustBash{} = new_bash}
         when is_binary(stdout) and is_binary(stderr) and is_integer(exit_code) and exit_code >= 0 ->
           # Strip any internal control-flow signals that could leak from custom commands
@@ -844,6 +854,16 @@ defmodule JustBash.Interpreter.Executor do
         message = "custom command #{kind}: #{inspect(reason)}"
         custom_command_error(bash, cmd_name, message)
     end
+  end
+
+  # A registered command is either a module implementing JustBash.Commands.Command,
+  # or a %JustBash.CLI{} declarative subcommand tool.
+  defp dispatch_custom_command(%JustBash.CLI{} = cli, bash, args, stdin) do
+    JustBash.CLI.run(cli, bash, args, stdin)
+  end
+
+  defp dispatch_custom_command(module, bash, args, stdin) when is_atom(module) do
+    module.execute(bash, args, stdin)
   end
 
   defp custom_command_error(bash, cmd_name, message) do

--- a/lib/just_bash/telemetry.ex
+++ b/lib/just_bash/telemetry.ex
@@ -39,6 +39,9 @@ defmodule JustBash.Telemetry do
     * Measurement: `%{duration: native_time, monotonic_time: integer}`
     * Metadata: `%{command: String.t(), args: list(String.t()), exit_code: integer,
       bytes_in: integer, bytes_out: integer, telemetry_span_context: reference()}`
+    * When the command is a `JustBash.CLI` tool, metadata also includes
+      `subcommand: list(String.t())` — the resolved subcommand path (e.g. `["pr", "review"]`)
+      — so observability doesn't collapse an entire CLI into a single `command` bucket.
 
   * `[:just_bash, :command, :exception]` - Emitted when a command raises
     * Measurement: `%{duration: native_time, monotonic_time: integer}`

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -79,6 +79,22 @@ defmodule JustBash.CLI.BuilderTest do
         CLI.command("x", flags: %{not: :keyword}, run: fn i -> {ok(), i.bash} end)
       end
     end
+
+    test "raises when a group node is given flags" do
+      child = CLI.command("review", run: fn i -> {ok(), i.bash} end)
+
+      assert_raise ArgumentError, ~r/group .* cannot define :flags or :args/, fn ->
+        CLI.command("pr", commands: [child], flags: [verbose: [type: :boolean]])
+      end
+    end
+
+    test "raises when a group node is given positional args" do
+      child = CLI.command("review", run: fn i -> {ok(), i.bash} end)
+
+      assert_raise ArgumentError, ~r/group .* cannot define :flags or :args/, fn ->
+        CLI.command("pr", commands: [child], args: [%{name: :id}])
+      end
+    end
   end
 
   describe "new/2" do

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -74,6 +74,73 @@ defmodule JustBash.CLI.BuilderTest do
       end
     end
 
+    test "raises when a required positional follows an optional one" do
+      assert_raise ArgumentError,
+                   ~r/required positional argument .* cannot follow an optional/,
+                   fn ->
+                     CLI.command("x",
+                       args: [%{name: :a}, %{name: :b, required: true}],
+                       run: fn i -> {ok(), i.bash} end
+                     )
+                   end
+    end
+
+    test "allows required positionals before optional ones" do
+      cmd =
+        CLI.command("x",
+          args: [%{name: :a, required: true}, %{name: :b}],
+          run: fn i -> {ok(), i.bash} end
+        )
+
+      assert [%{name: :a, required: true}, %{name: :b, required: false}] = cmd.args
+    end
+
+    test "raises when a flag declares both :required and :default" do
+      assert_raise ArgumentError, ~r/cannot be both :required and have a :default/, fn ->
+        CLI.command("x",
+          flags: [n: [type: :integer, required: true, default: 1]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when a flag :default is not a member of :values" do
+      assert_raise ArgumentError, ~r/:default "xml" is not one of :values/, fn ->
+        CLI.command("x",
+          flags: [format: [type: :string, default: "xml", values: ~w(text json)]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "allows a flag :default that is a member of :values" do
+      cmd =
+        CLI.command("x",
+          flags: [format: [type: :string, default: "text", values: ~w(text json)]],
+          run: fn i -> {ok(), i.bash} end
+        )
+
+      assert cmd.flags[:format][:default] == "text"
+    end
+
+    test "raises when a flag claims the reserved --help long form" do
+      assert_raise ArgumentError, ~r/--help.* is reserved/, fn ->
+        CLI.command("x",
+          flags: [help: [type: :boolean]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when a flag claims the reserved -h short form" do
+      assert_raise ArgumentError, ~r/-h.* is reserved/, fn ->
+        CLI.command("x",
+          flags: [height: [type: :integer, short: "-h"]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
     test "raises on flags that are not a keyword list" do
       assert_raise ArgumentError, ~r/:flags must be a keyword list/, fn ->
         CLI.command("x", flags: %{not: :keyword}, run: fn i -> {ok(), i.bash} end)

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -1,0 +1,111 @@
+defmodule JustBash.CLI.BuilderTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.CLI
+  alias JustBash.CLI.Command
+
+  describe "command/2" do
+    test "builds a leaf with a run handler" do
+      run = fn inv -> {%{stdout: "", stderr: "", exit_code: 0}, inv.bash} end
+      cmd = CLI.command("list", doc: "List things", run: run)
+
+      assert %Command{name: "list", doc: "List things", run: ^run, commands: []} = cmd
+      assert Command.leaf?(cmd)
+      refute Command.group?(cmd)
+    end
+
+    test "builds a group with nested commands" do
+      child = CLI.command("review", run: fn inv -> {ok(), inv.bash} end)
+      group = CLI.command("pr", doc: "PRs", commands: [child])
+
+      assert %Command{name: "pr", commands: [^child], run: nil} = group
+      assert Command.group?(group)
+      refute Command.leaf?(group)
+    end
+
+    test "normalizes positional arg specs with defaults" do
+      cmd =
+        CLI.command("show", args: [%{name: :id, required: true}], run: fn i -> {ok(), i.bash} end)
+
+      assert [%{name: :id, required: true, variadic: false, doc: nil}] = cmd.args
+    end
+
+    test "raises when a node is neither group nor leaf" do
+      assert_raise ArgumentError, ~r/either a group .* or a leaf/, fn ->
+        CLI.command("oops")
+      end
+    end
+
+    test "raises when a node is both group and leaf" do
+      child = CLI.command("x", run: fn i -> {ok(), i.bash} end)
+
+      assert_raise ArgumentError, ~r/cannot be both/, fn ->
+        CLI.command("pr", commands: [child], run: fn i -> {ok(), i.bash} end)
+      end
+    end
+
+    test "raises on a non-1-arity run handler" do
+      assert_raise ArgumentError, ~r/:run must be a 1-arity function/, fn ->
+        CLI.command("x", run: fn _a, _b -> :nope end)
+      end
+    end
+
+    test "raises on duplicate child names" do
+      a = CLI.command("dup", run: fn i -> {ok(), i.bash} end)
+      b = CLI.command("dup", run: fn i -> {ok(), i.bash} end)
+
+      assert_raise ArgumentError, ~r/duplicate subcommand name/, fn ->
+        CLI.command("group", commands: [a, b])
+      end
+    end
+
+    test "raises on a name with spaces" do
+      assert_raise ArgumentError, ~r/must not contain spaces/, fn ->
+        CLI.command("pr review", run: fn i -> {ok(), i.bash} end)
+      end
+    end
+
+    test "raises on a variadic arg that is not last" do
+      assert_raise ArgumentError, ~r/variadic positional argument must be last/, fn ->
+        CLI.command("x",
+          args: [%{name: :rest, variadic: true}, %{name: :tail}],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises on flags that are not a keyword list" do
+      assert_raise ArgumentError, ~r/:flags must be a keyword list/, fn ->
+        CLI.command("x", flags: %{not: :keyword}, run: fn i -> {ok(), i.bash} end)
+      end
+    end
+  end
+
+  describe "new/2" do
+    test "builds a CLI root" do
+      cmd = CLI.command("list", run: fn i -> {ok(), i.bash} end)
+      cli = CLI.new("acme", doc: "Acme toolkit", commands: [cmd], aliases: ["ac"])
+
+      assert %CLI{name: "acme", doc: "Acme toolkit", commands: [^cmd], aliases: ["ac"]} = cli
+    end
+
+    test "defaults to no commands and no aliases" do
+      assert %CLI{commands: [], aliases: []} = CLI.new("acme")
+    end
+
+    test "raises on an empty name" do
+      assert_raise ArgumentError, ~r/non-empty string/, fn -> CLI.new("") end
+    end
+
+    test "raises on colliding top-level command names" do
+      a = CLI.command("dup", run: fn i -> {ok(), i.bash} end)
+      b = CLI.command("dup", run: fn i -> {ok(), i.bash} end)
+
+      assert_raise ArgumentError, ~r/duplicate subcommand name/, fn ->
+        CLI.new("acme", commands: [a, b])
+      end
+    end
+  end
+
+  defp ok, do: %{stdout: "", stderr: "", exit_code: 0}
+end

--- a/test/cli/help_test.exs
+++ b/test/cli/help_test.exs
@@ -123,6 +123,19 @@ defmodule JustBash.CLI.HelpTest do
       refute result.stderr =~ "Did you mean"
     end
 
+    test "unknown subcommand under a group points --help at the group, not the root" do
+      result = run("acme pr reviw")
+      assert result.exit_code == 2
+      assert result.stderr =~ "Run 'acme pr --help' for available commands."
+      refute result.stderr =~ "Run 'acme --help'"
+    end
+
+    test "unknown top-level subcommand points --help at the root" do
+      result = run("acme nope")
+      assert result.exit_code == 2
+      assert result.stderr =~ "Run 'acme --help' for available commands."
+    end
+
     test "missing required flag includes the usage line" do
       result = run("acme pr review")
       assert result.exit_code == 2

--- a/test/cli/help_test.exs
+++ b/test/cli/help_test.exs
@@ -1,0 +1,133 @@
+defmodule JustBash.CLI.HelpTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.CLI
+  alias JustBash.Commands.Command
+
+  defp acme do
+    CLI.new("acme",
+      doc: "Acme operations toolkit",
+      commands: [
+        CLI.command("pr",
+          doc: "Pull request management",
+          commands: [
+            CLI.command("review",
+              doc: "Review a pull request",
+              flags: [
+                report: [type: :integer, required: true, doc: "ID of the report to review"],
+                format: [
+                  type: :string,
+                  default: "text",
+                  values: ~w(text json),
+                  doc: "Output format"
+                ],
+                verbose: [type: :boolean, short: "-v", doc: "Verbose output"]
+              ],
+              run: fn inv -> {Command.ok("ok\n"), inv.bash} end
+            ),
+            CLI.command("open",
+              doc: "Open a pull request",
+              args: [%{name: :id, required: true, doc: "PR id"}],
+              run: fn inv -> {Command.ok("ok\n"), inv.bash} end
+            )
+          ]
+        ),
+        CLI.command("whoami", doc: "Print user", run: fn inv -> {Command.ok("u\n"), inv.bash} end)
+      ]
+    )
+  end
+
+  defp run(script) do
+    {result, _bash} = JustBash.exec(JustBash.new(commands: %{"acme" => acme()}), script)
+    result
+  end
+
+  describe "root --help" do
+    test "lists top-level commands and exits 0" do
+      result = run("acme --help")
+      assert result.exit_code == 0
+      assert result.stdout =~ "acme - Acme operations toolkit"
+      assert result.stdout =~ "Usage: acme <command> [args]"
+      assert result.stdout =~ "Commands:"
+      assert result.stdout =~ "pr"
+      assert result.stdout =~ "whoami"
+      assert result.stdout =~ "Pull request management (group)"
+      assert result.stdout =~ "Run 'acme <command> --help'"
+    end
+
+    test "-h is an alias for --help" do
+      assert run("acme -h").stdout =~ "Usage: acme <command> [args]"
+    end
+
+    test "a group with no subcommand shows its commands and exits 2" do
+      result = run("acme pr")
+      assert result.exit_code == 2
+      assert result.stderr =~ "acme pr: missing subcommand"
+      assert result.stderr =~ "review"
+      assert result.stderr =~ "open"
+    end
+  end
+
+  describe "group --help" do
+    test "lists the group's children" do
+      result = run("acme pr --help")
+      assert result.exit_code == 0
+      assert result.stdout =~ "acme pr - Pull request management"
+      assert result.stdout =~ "Usage: acme pr <command> [args]"
+      assert result.stdout =~ "review"
+      assert result.stdout =~ "Review a pull request"
+    end
+  end
+
+  describe "leaf --help" do
+    test "shows a usage line with required and optional flags" do
+      result = run("acme pr review --help")
+      assert result.exit_code == 0
+      assert result.stdout =~ "acme pr review - Review a pull request"
+
+      assert result.stdout =~
+               "Usage: acme pr review --report <int> [--format text|json] [-v]"
+    end
+
+    test "documents each flag with annotations" do
+      result = run("acme pr review --help")
+      assert result.stdout =~ "Options:"
+      assert result.stdout =~ "--report <int>"
+      assert result.stdout =~ "ID of the report to review (required)"
+      assert result.stdout =~ "(values: text, json)"
+      assert result.stdout =~ "(default: text)"
+      assert result.stdout =~ "-v, --verbose"
+    end
+
+    test "documents positional arguments" do
+      result = run("acme pr open --help")
+      assert result.stdout =~ "Usage: acme pr open <id>"
+      assert result.stdout =~ "Arguments:"
+      assert result.stdout =~ "<id>"
+      assert result.stdout =~ "PR id (required)"
+    end
+  end
+
+  describe "errors carry usage and suggestions" do
+    test "unknown subcommand suggests the closest match" do
+      result = run("acme pr reviw --report 1")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown command 'pr reviw'"
+      assert result.stderr =~ "Did you mean 'pr review'?"
+    end
+
+    test "an unrelated unknown subcommand offers no suggestion" do
+      result = run("acme pr zzzzzzz")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown command 'pr zzzzzzz'"
+      refute result.stderr =~ "Did you mean"
+    end
+
+    test "missing required flag includes the usage line" do
+      result = run("acme pr review")
+      assert result.exit_code == 2
+      assert result.stderr =~ "missing required flag: --report"
+      assert result.stderr =~ "Usage: acme pr review --report <int>"
+    end
+  end
+end

--- a/test/cli/introspection_test.exs
+++ b/test/cli/introspection_test.exs
@@ -1,0 +1,87 @@
+defmodule JustBash.CLI.IntrospectionTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.CLI
+  alias JustBash.Commands.Command
+
+  defp acme do
+    CLI.new("acme",
+      doc: "Acme operations toolkit",
+      aliases: ["ac"],
+      commands: [
+        CLI.command("pr",
+          doc: "Pull request management",
+          commands: [
+            CLI.command("review",
+              doc: "Review a pull request",
+              flags: [
+                report: [type: :integer, required: true, doc: "Report ID"],
+                format: [type: :string, default: "text", values: ~w(text json), doc: "Format"]
+              ],
+              run: fn inv -> {Command.ok(), inv.bash} end
+            ),
+            CLI.command("open",
+              doc: "Open a PR",
+              args: [%{name: :id, required: true, doc: "PR id"}],
+              run: fn inv -> {Command.ok(), inv.bash} end
+            )
+          ]
+        ),
+        CLI.command("whoami", doc: "Print user", run: fn inv -> {Command.ok(), inv.bash} end)
+      ]
+    )
+  end
+
+  describe "describe/1" do
+    test "returns the tool metadata" do
+      desc = CLI.describe(acme())
+      assert desc.name == "acme"
+      assert desc.doc == "Acme operations toolkit"
+      assert desc.aliases == ["ac"]
+    end
+
+    test "flattens leaves with full invocation paths" do
+      paths = CLI.describe(acme()).commands |> Enum.map(& &1.path)
+      assert paths == [["pr", "review"], ["pr", "open"], ["whoami"]]
+    end
+
+    test "resolves flag specs into plain maps with derived long forms" do
+      review = CLI.describe(acme()).commands |> Enum.find(&(&1.path == ["pr", "review"]))
+      report = Enum.find(review.flags, &(&1.name == :report))
+
+      assert report.type == :integer
+      assert report.required == true
+      assert report.long == "--report"
+
+      format = Enum.find(review.flags, &(&1.name == :format))
+      assert format.default == "text"
+      assert format.values == ["text", "json"]
+    end
+
+    test "includes positional argument specs" do
+      open = CLI.describe(acme()).commands |> Enum.find(&(&1.path == ["pr", "open"]))
+      assert [%{name: :id, required: true}] = open.args
+    end
+  end
+
+  describe "render_docs/2" do
+    test "defaults to text and includes commands and usage" do
+      text = CLI.render_docs(acme())
+      assert text =~ "acme - Acme operations toolkit"
+      assert text =~ "Usage: acme pr review --report <int>"
+      assert text =~ "Usage: acme pr open <id>"
+    end
+
+    test "markdown format produces tables" do
+      md = CLI.render_docs(acme(), format: :markdown)
+      assert md =~ "# acme"
+      assert md =~ "## acme pr review"
+      assert md =~ "```\nUsage: acme pr review --report <int> [--format text|json]\n```"
+      assert md =~ "| Flag | Type | Required | Default | Description |"
+      assert md =~ "| `--report` | integer | yes |  | Report ID |"
+      assert md =~ "## acme pr open"
+      assert md =~ "| Argument | Required | Description |"
+      assert md =~ "| `id` | yes | PR id |"
+    end
+  end
+end

--- a/test/cli/routing_test.exs
+++ b/test/cli/routing_test.exs
@@ -122,7 +122,8 @@ defmodule JustBash.CLI.RoutingTest do
       result = run("acme pr nope")
       assert result.exit_code == 2
       assert result.stderr =~ "unknown command 'pr nope'"
-      assert result.stderr =~ "Run 'acme --help'"
+      # The help pointer targets the group the unknown token sat under, not the root.
+      assert result.stderr =~ "Run 'acme pr --help'"
     end
 
     test "missing required flag exits 2" do

--- a/test/cli/routing_test.exs
+++ b/test/cli/routing_test.exs
@@ -1,0 +1,166 @@
+defmodule JustBash.CLI.RoutingTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.CLI
+  alias JustBash.Commands.Command
+
+  # A small CLI exercised through the full shell, the way a host would register it.
+  #
+  #   acme pr review --report N [--format text|json] [-v]
+  #   acme pr open <id>
+  #   acme product list
+  #   acme whoami            (reads bash.context)
+  defp acme do
+    CLI.new("acme",
+      doc: "Acme operations toolkit",
+      aliases: ["ac"],
+      commands: [
+        CLI.command("pr",
+          doc: "Pull request management",
+          commands: [
+            CLI.command("review",
+              doc: "Review a pull request",
+              flags: [
+                report: [type: :integer, required: true, doc: "Report ID"],
+                format: [type: :string, default: "text", values: ~w(text json), doc: "Format"],
+                verbose: [type: :boolean, short: "-v"]
+              ],
+              run: fn inv ->
+                tag = if inv.flags.verbose, do: "VERBOSE ", else: ""
+                out = "#{tag}review report=#{inv.flags.report} format=#{inv.flags.format}\n"
+                {Command.ok(out), inv.bash}
+              end
+            ),
+            CLI.command("open",
+              doc: "Open a pull request",
+              args: [%{name: :id, required: true, doc: "PR id"}],
+              run: fn inv -> {Command.ok("open #{Enum.join(inv.args, ",")}\n"), inv.bash} end
+            )
+          ]
+        ),
+        CLI.command("product",
+          doc: "Product lifecycle",
+          commands: [
+            CLI.command("list",
+              doc: "List products",
+              run: fn inv -> {Command.ok("p1\np2\n"), inv.bash} end
+            )
+          ]
+        ),
+        CLI.command("whoami",
+          doc: "Print the current user from context",
+          run: fn inv -> {Command.ok("#{inv.bash.context.user}\n"), inv.bash} end
+        )
+      ]
+    )
+  end
+
+  defp run(script, opts \\ []) do
+    bash = JustBash.new(Keyword.merge([commands: %{"acme" => acme()}], opts))
+    {result, _bash} = JustBash.exec(bash, script)
+    result
+  end
+
+  describe "registration" do
+    test "a CLI struct registers as a command" do
+      result = run("acme product list")
+      assert result.stdout == "p1\np2\n"
+      assert result.exit_code == 0
+    end
+
+    test "registering under an alias not in name/aliases raises" do
+      assert_raise ArgumentError, ~r/registered as "nope"/, fn ->
+        JustBash.new(commands: %{"nope" => acme()})
+      end
+    end
+
+    test "a CLI cannot override a protected builtin" do
+      cli = CLI.new("cd", commands: [CLI.command("x", run: fn i -> {Command.ok(), i.bash} end)])
+
+      assert_raise ArgumentError, ~r/protected builtin/, fn ->
+        JustBash.new(commands: %{"cd" => cli})
+      end
+    end
+  end
+
+  describe "routing" do
+    test "routes a nested leaf and parses typed flags" do
+      result = run("acme pr review --report 42 --format json")
+      assert result.stdout == "review report=42 format=json\n"
+      assert result.exit_code == 0
+    end
+
+    test "applies flag defaults" do
+      result = run("acme pr review --report 7")
+      assert result.stdout == "review report=7 format=text\n"
+    end
+
+    test "supports short boolean flags" do
+      result = run("acme pr review --report 7 -v")
+      assert result.stdout == "VERBOSE review report=7 format=text\n"
+    end
+
+    test "binds positional arguments" do
+      result = run("acme pr open 123")
+      assert result.stdout == "open 123\n"
+    end
+
+    test "handlers retain access to bash.context" do
+      result = run("acme whoami", context: %{user: "dave"})
+      assert result.stdout == "dave\n"
+    end
+  end
+
+  describe "errors" do
+    test "unknown subcommand exits 2 with a hint" do
+      result = run("acme pr nope")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown command 'pr nope'"
+      assert result.stderr =~ "Run 'acme --help'"
+    end
+
+    test "missing required flag exits 2" do
+      result = run("acme pr review")
+      assert result.exit_code == 2
+      assert result.stderr =~ "missing required flag: --report"
+    end
+
+    test "invalid enum value exits 2" do
+      result = run("acme pr review --report 1 --format yaml")
+      assert result.exit_code == 2
+      assert result.stderr =~ "invalid value for --format: yaml"
+    end
+
+    test "missing required positional exits 2" do
+      result = run("acme pr open")
+      assert result.exit_code == 2
+      assert result.stderr =~ "missing required argument: id"
+    end
+
+    test "too many positionals exits 2" do
+      result = run("acme pr open 1 2")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unexpected argument(s): 2"
+    end
+
+    test "a group with no subcommand exits 2" do
+      result = run("acme pr")
+      assert result.exit_code == 2
+      assert result.stderr =~ "missing subcommand"
+    end
+  end
+
+  describe "crash isolation" do
+    test "a crashing handler is caught and turned into an error" do
+      cli =
+        CLI.new("boom",
+          commands: [CLI.command("go", run: fn _inv -> raise "kaboom" end)]
+        )
+
+      bash = JustBash.new(commands: %{"boom" => cli})
+      {result, _bash} = JustBash.exec(bash, "boom go")
+      assert result.exit_code == 1
+      assert result.stderr =~ "boom"
+    end
+  end
+end

--- a/test/cli/routing_test.exs
+++ b/test/cli/routing_test.exs
@@ -109,6 +109,12 @@ defmodule JustBash.CLI.RoutingTest do
       result = run("acme whoami", context: %{user: "dave"})
       assert result.stdout == "dave\n"
     end
+
+    test "a leading -- is consumed as an options terminator before a subcommand" do
+      result = run("acme -- pr review --report 5")
+      assert result.exit_code == 0
+      assert result.stdout == "review report=5 format=text\n"
+    end
   end
 
   describe "errors" do
@@ -161,6 +167,18 @@ defmodule JustBash.CLI.RoutingTest do
       {result, _bash} = JustBash.exec(bash, "boom go")
       assert result.exit_code == 1
       assert result.stderr =~ "boom"
+    end
+
+    test "a handler that returns a non-tuple yields a clear, CLI-attributed error" do
+      cli =
+        CLI.new("boom",
+          commands: [CLI.command("bad", run: fn _inv -> :not_a_tuple end)]
+        )
+
+      bash = JustBash.new(commands: %{"boom" => cli})
+      {result, _bash} = JustBash.exec(bash, "boom bad")
+      assert result.exit_code == 1
+      assert result.stderr =~ "handler must return {result, bash}"
     end
   end
 end

--- a/test/cli/shell_integration_test.exs
+++ b/test/cli/shell_integration_test.exs
@@ -1,0 +1,89 @@
+defmodule JustBash.CLI.ShellIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.CLI
+  alias JustBash.Commands.Command
+
+  defp acme do
+    CLI.new("acme",
+      doc: "Acme operations toolkit",
+      commands: [
+        CLI.command("pr",
+          doc: "PRs",
+          commands: [
+            CLI.command("review", run: fn inv -> {Command.ok("r\n"), inv.bash} end),
+            CLI.command("open", run: fn inv -> {Command.ok("o\n"), inv.bash} end)
+          ]
+        ),
+        CLI.command("whoami", run: fn inv -> {Command.ok("w\n"), inv.bash} end)
+      ]
+    )
+  end
+
+  defmodule Greet do
+    @behaviour Command
+    @impl true
+    def names, do: ["greet"]
+    @impl true
+    def execute(bash, _args, _stdin), do: {Command.ok("hi\n"), bash}
+  end
+
+  defp run(script) do
+    bash = JustBash.new(commands: %{"acme" => acme(), "greet" => Greet})
+    {result, _bash} = JustBash.exec(bash, script)
+    result
+  end
+
+  describe "type" do
+    test "describes a CLI tool with its subcommand count" do
+      result = run("type acme")
+      assert result.stdout == "acme is a CLI tool (3 commands)\n"
+    end
+
+    test "still describes a plain command module the terse way" do
+      assert run("type greet").stdout == "greet is greet\n"
+    end
+  end
+
+  describe "command -V" do
+    test "describes a CLI tool" do
+      assert run("command -V acme").stdout == "acme is a CLI tool (3 commands)\n"
+    end
+  end
+
+  def handle_event(_event, _measure, meta, {ref, pid}), do: send(pid, {ref, meta})
+
+  describe "telemetry" do
+    setup do
+      ref = make_ref()
+      handler_id = "cli-subcommand-#{inspect(ref)}"
+
+      :telemetry.attach(
+        handler_id,
+        [:just_bash, :command, :stop],
+        &__MODULE__.handle_event/4,
+        {ref, self()}
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      %{ref: ref}
+    end
+
+    test "includes the resolved subcommand path in command telemetry", %{ref: ref} do
+      run("acme pr review")
+      assert_received {^ref, %{command: "acme", subcommand: ["pr", "review"]}}
+    end
+
+    test "non-CLI commands carry no subcommand key", %{ref: ref} do
+      run("greet")
+      assert_received {^ref, %{command: "greet"} = meta}
+      refute Map.has_key?(meta, :subcommand)
+    end
+
+    test "the subcommand key never leaks into command output" do
+      result = run("acme pr review")
+      assert result.stdout == "r\n"
+      refute Map.has_key?(result, :__subcommand__)
+    end
+  end
+end

--- a/test/cli/shell_integration_test.exs
+++ b/test/cli/shell_integration_test.exs
@@ -85,5 +85,28 @@ defmodule JustBash.CLI.ShellIntegrationTest do
       assert result.stdout == "r\n"
       refute Map.has_key?(result, :__subcommand__)
     end
+
+    test "tags the routed path on a group's --help", %{ref: ref} do
+      run("acme pr --help")
+      assert_received {^ref, %{command: "acme", subcommand: ["pr"]}}
+    end
+
+    test "tags the resolved prefix on an unknown subcommand", %{ref: ref} do
+      run("acme pr nope")
+      assert_received {^ref, %{command: "acme", subcommand: ["pr"]}}
+    end
+
+    test "tags the empty path when the root is invoked without a subcommand", %{ref: ref} do
+      run("acme")
+      assert_received {^ref, %{command: "acme", subcommand: []}}
+    end
+
+    test "the subcommand key never leaks into help or error output" do
+      help = run("acme pr --help")
+      refute Map.has_key?(help, :__subcommand__)
+
+      error = run("acme pr nope")
+      refute Map.has_key?(error, :__subcommand__)
+    end
   end
 end

--- a/test/cli/use_macro_test.exs
+++ b/test/cli/use_macro_test.exs
@@ -1,0 +1,82 @@
+defmodule JustBash.CLI.UseMacroTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.CLI
+  alias JustBash.Commands.Command
+
+  defmodule AcmeCLI do
+    use JustBash.CLI
+
+    @impl true
+    def spec do
+      CLI.new("acme",
+        doc: "Acme operations toolkit",
+        aliases: ["ac"],
+        commands: [
+          CLI.command("greet",
+            doc: "Greet someone",
+            args: [%{name: :who, required: true}],
+            run: fn inv -> {Command.ok("hi #{Enum.join(inv.args, " ")}\n"), inv.bash} end
+          )
+        ]
+      )
+    end
+  end
+
+  test "a use-module is a valid Command" do
+    assert function_exported?(AcmeCLI, :names, 0)
+    assert function_exported?(AcmeCLI, :execute, 3)
+    assert AcmeCLI.names() == ["acme", "ac"]
+  end
+
+  test "registers and dispatches by module name" do
+    bash = JustBash.new(commands: %{"acme" => AcmeCLI})
+    {result, _bash} = JustBash.exec(bash, "acme greet world")
+    assert result.stdout == "hi world\n"
+  end
+
+  test "registers under an alias" do
+    bash = JustBash.new(commands: %{"ac" => AcmeCLI})
+    {result, _bash} = JustBash.exec(bash, "ac greet there")
+    assert result.stdout == "hi there\n"
+  end
+
+  test "dispatches identically to a struct-registered CLI" do
+    struct_bash = JustBash.new(commands: %{"acme" => AcmeCLI.spec()})
+    module_bash = JustBash.new(commands: %{"acme" => AcmeCLI})
+
+    {r1, _} = JustBash.exec(struct_bash, "acme greet x")
+    {r2, _} = JustBash.exec(module_bash, "acme greet x")
+    assert r1.stdout == r2.stdout
+  end
+
+  test "help works through a use-module" do
+    bash = JustBash.new(commands: %{"acme" => AcmeCLI})
+    {result, _bash} = JustBash.exec(bash, "acme --help")
+    assert result.stdout =~ "acme - Acme operations toolkit"
+    assert result.stdout =~ "greet"
+  end
+
+  describe "cli?/1 and cli_module?/1" do
+    test "detects a use-module" do
+      assert CLI.cli_module?(AcmeCLI)
+      assert CLI.cli?(AcmeCLI)
+    end
+
+    test "detects a struct" do
+      assert CLI.cli?(AcmeCLI.spec())
+    end
+
+    test "rejects non-CLI modules and values" do
+      refute CLI.cli_module?(Enum)
+      refute CLI.cli?(Enum)
+      refute CLI.cli?("acme")
+      refute CLI.cli?(%{})
+    end
+  end
+
+  test "describe/1 and render_docs/2 accept a use-module" do
+    assert CLI.describe(AcmeCLI).name == "acme"
+    assert CLI.render_docs(AcmeCLI, format: :markdown) =~ "# acme"
+  end
+end

--- a/test/commands/arg_parser_test.exs
+++ b/test/commands/arg_parser_test.exs
@@ -55,6 +55,16 @@ defmodule JustBash.Commands.ArgParserTest do
       {:ok, opts, _} = ArgParser.parse([], @basic_flags)
       assert opts.count == 1
     end
+
+    test "rejects a value with trailing characters" do
+      assert {:error, message} = ArgParser.parse(["-n", "10x"], @basic_flags)
+      assert message =~ "invalid integer value: 10x"
+    end
+
+    test "rejects an underscore-separated value rather than silently truncating" do
+      assert {:error, message} = ArgParser.parse(["-n", "1_000"], @basic_flags)
+      assert message =~ "invalid integer value: 1_000"
+    end
   end
 
   describe "parse/3 with accumulator flags" do
@@ -153,6 +163,11 @@ defmodule JustBash.Commands.ArgParserTest do
     test "errors on a non-numeric value" do
       assert {:error, message} = ArgParser.parse(["--ratio", "abc"], @float_flags)
       assert message =~ "invalid float value: abc"
+    end
+
+    test "rejects a value with trailing characters" do
+      assert {:error, message} = ArgParser.parse(["--ratio", "1.5.6"], @float_flags)
+      assert message =~ "invalid float value: 1.5.6"
     end
   end
 

--- a/test/commands/arg_parser_test.exs
+++ b/test/commands/arg_parser_test.exs
@@ -134,4 +134,77 @@ defmodule JustBash.Commands.ArgParserTest do
       assert opts.method == "POST"
     end
   end
+
+  describe "float type" do
+    @float_flags [
+      ratio: [long: "--ratio", type: :float]
+    ]
+
+    test "parses a float value" do
+      {:ok, opts, _} = ArgParser.parse(["--ratio", "1.5"], @float_flags)
+      assert opts.ratio == 1.5
+    end
+
+    test "parses an integer-looking value as a float" do
+      {:ok, opts, _} = ArgParser.parse(["--ratio", "2"], @float_flags)
+      assert opts.ratio == 2.0
+    end
+
+    test "errors on a non-numeric value" do
+      assert {:error, message} = ArgParser.parse(["--ratio", "abc"], @float_flags)
+      assert message =~ "invalid float value: abc"
+    end
+  end
+
+  describe "required option" do
+    @required_flags [
+      report: [long: "--report", type: :integer, required: true],
+      format: [long: "--format", type: :string, default: "text"]
+    ]
+
+    test "succeeds when the required flag is provided" do
+      {:ok, opts, _} = ArgParser.parse(["--report", "12"], @required_flags)
+      assert opts.report == 12
+    end
+
+    test "errors when a required flag is missing" do
+      assert {:error, message} = ArgParser.parse([], @required_flags)
+      assert message =~ "missing required flag: --report"
+    end
+
+    test "includes the command name in the required error when given" do
+      assert {:error, message} =
+               ArgParser.parse([], @required_flags, command: "acme pr review")
+
+      assert message =~ "acme pr review: missing required flag: --report"
+    end
+
+    test "uses the short flag name in the error when no long form exists" do
+      flags = [count: [short: "-n", type: :integer, required: true]]
+      assert {:error, message} = ArgParser.parse([], flags)
+      assert message =~ "missing required flag: -n"
+    end
+  end
+
+  describe "values (enum) option" do
+    @enum_flags [
+      format: [long: "--format", type: :string, values: ["text", "json"], default: "text"]
+    ]
+
+    test "accepts an allowed value" do
+      {:ok, opts, _} = ArgParser.parse(["--format", "json"], @enum_flags)
+      assert opts.format == "json"
+    end
+
+    test "errors on a disallowed value" do
+      assert {:error, message} = ArgParser.parse(["--format", "yaml"], @enum_flags)
+      assert message =~ "invalid value for --format: yaml"
+      assert message =~ "text, json"
+    end
+
+    test "allows the default when the flag is omitted" do
+      {:ok, opts, _} = ArgParser.parse([], @enum_flags)
+      assert opts.format == "text"
+    end
+  end
 end

--- a/test/eval/commands/kv_cli_test.exs
+++ b/test/eval/commands/kv_cli_test.exs
@@ -1,0 +1,76 @@
+defmodule JustBash.Eval.Commands.KVCliTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.Eval.Commands.KVCli
+
+  defp new_bash, do: JustBash.new(commands: %{"kv" => KVCli})
+
+  describe "behavioral parity with the hand-rolled KV" do
+    test "set and get, including multi-word values" do
+      bash = new_bash()
+      {_, bash} = JustBash.exec(bash, "kv set greeting hello world")
+      {result, _} = JustBash.exec(bash, "kv get greeting")
+      assert result.stdout == "hello world\n"
+    end
+
+    test "get on a missing key exits 1" do
+      {result, _} = JustBash.exec(new_bash(), "kv get nope")
+      assert result.exit_code == 1
+      assert result.stderr =~ "not found"
+    end
+
+    test "delete removes a key" do
+      bash = new_bash()
+      {_, bash} = JustBash.exec(bash, "kv set tmp v")
+      {_, bash} = JustBash.exec(bash, "kv delete tmp")
+      {result, _} = JustBash.exec(bash, "kv get tmp")
+      assert result.exit_code == 1
+    end
+
+    test "list, dump, and count" do
+      bash = new_bash()
+      {_, bash} = JustBash.exec(bash, "kv set zebra z")
+      {_, bash} = JustBash.exec(bash, "kv set apple a")
+
+      assert elem(JustBash.exec(bash, "kv list"), 0).stdout == "apple\nzebra\n"
+      assert elem(JustBash.exec(bash, "kv dump"), 0).stdout == "apple=a\nzebra=z\n"
+      assert elem(JustBash.exec(bash, "kv count"), 0).stdout == "2\n"
+    end
+
+    test "works in pipelines and command substitution" do
+      bash = new_bash()
+      {_, bash} = JustBash.exec(bash, "kv set name Bob")
+      {result, _} = JustBash.exec(bash, ~s|echo "Hi, $(kv get name)"|)
+      assert result.stdout == "Hi, Bob\n"
+    end
+  end
+
+  describe "what the CLI layer adds for free" do
+    test "auto-generated --help lists the subcommands" do
+      {result, _} = JustBash.exec(new_bash(), "kv --help")
+      assert result.exit_code == 0
+      assert result.stdout =~ "kv - A key-value store"
+      assert result.stdout =~ "set"
+      assert result.stdout =~ "Store a key-value pair"
+    end
+
+    test "per-command --help shows a usage line" do
+      {result, _} = JustBash.exec(new_bash(), "kv set --help")
+      assert result.stdout =~ "Usage: kv set <key> <value>..."
+    end
+
+    test "unknown subcommand exits 2 with a suggestion" do
+      {result, _} = JustBash.exec(new_bash(), "kv lst")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown command 'lst'"
+      assert result.stderr =~ "Did you mean 'list'?"
+    end
+
+    test "missing required argument exits 2 with usage" do
+      {result, _} = JustBash.exec(new_bash(), "kv get")
+      assert result.exit_code == 2
+      assert result.stderr =~ "missing required argument: key"
+      assert result.stderr =~ "Usage: kv get <key>"
+    end
+  end
+end

--- a/test/telemetry_test.exs
+++ b/test/telemetry_test.exs
@@ -105,8 +105,13 @@ defmodule JustBash.TelemetryTest do
       script = "echo hello; echo world"
       {result, _bash} = JustBash.exec(bash, script)
 
+      # Bind this run's session pid from the start event so a concurrent async test's
+      # session :stop (delivered to us by the globally-attached handler) can't be matched
+      # here by mistake.
+      assert_received {^ref, [:just_bash, :session, :run, :start], _, %{session: pid}}
+
       assert_received {^ref, [:just_bash, :session, :run, :stop], _,
-                       %{bytes_in: bytes_in, bytes_out: bytes_out}}
+                       %{session: ^pid, bytes_in: bytes_in, bytes_out: bytes_out}}
 
       assert bytes_in == byte_size(script)
       assert bytes_out == byte_size(result.stdout) + byte_size(result.stderr)


### PR DESCRIPTION
Closes #38.

## Summary

Adds **`JustBash.CLI`** — a declarative, data-driven subcommand layer for building namespaced tools like `acme pr review --report 1234`. It compiles down to a value in the existing `commands` map, so nothing about dispatch, protected builtins, or the `Command` behaviour changes.

A CLI is plain data: a `%JustBash.CLI{}` tree of `JustBash.CLI.Command` nodes, built with `CLI.new/2` and `CLI.command/2`, run by a single engine (`CLI.run/4`).

```elixir
alias JustBash.CLI
alias JustBash.Commands.Command

cli =
  CLI.new("acme", doc: "Acme operations toolkit", commands: [
    CLI.command("pr", doc: "Pull request management", commands: [
      CLI.command("review",
        doc: "Review a pull request",
        flags: [
          report:  [type: :integer, required: true, doc: "ID of the report to review"],
          format:  [type: :string, default: "text", values: ~w(text json), doc: "Output format"],
          verbose: [type: :boolean, short: "-v"]
        ],
        run: &Acme.PR.review/1)
    ])
  ])

bash = JustBash.new(commands: %{"acme" => cli})
```

## Design notes

This is the issue's **Alternative #4** (data-driven core), taken further: the struct is the single source of truth and there is **no block DSL**. The library is ~86 plain `@behaviour` command modules with exactly one macro in `lib/` (the `~b` sigil), so a `group do … command do … end end` DSL would be the only construct of its kind. Instead:

- `group`/`command` are unified into one nestable `command` (a node with children is a group; a node with a `run` is a leaf) — matching git/cargo/kubectl.
- `doc:` is used everywhere (not `about:` for nodes and `doc:` for flags).
- Handlers take a single `%JustBash.CLI.Invocation{}` (`flags`, `args`, `bash`, `stdin`, `path`) and return `{result, bash}` — the same contract as a custom command, keeping full access to `bash.fs`/`bash.context`.
- An optional `use JustBash.CLI` + `spec/0` lets a CLI live as a module (GenServer-style wiring, not a DSL). Registering the struct directly works too; both run on the same engine.

## What's included

- **Routing engine** `CLI.run/4`: nested routing, typed flag parsing, positional arity (incl. variadic), `--`/`--flag=value` forms.
- **Parser extensions** to `ArgParser`: `:float`, `:required`, `:values` (enum) — all opt-in, existing callers unchanged and regression-tested.
- **Help + errors**: auto `--help`/`-h` at every level; unknown subcommand → exit 2 + usage + `Did you mean …?` (`String.jaro_distance`); missing/invalid args → exit 2 + usage line.
- **Introspection**: `CLI.describe/1` (nested map) and `CLI.render_docs/2` (`:text`/`:markdown`) — same source of truth as runtime, so agent-prompt docs can't drift.
- **Shell integration**: `type` / `command -V` report `"acme is a CLI tool (N commands)"`.
- **Telemetry**: `[:just_bash, :command]` stop metadata carries the resolved `subcommand: ["pr","review"]` path (transient result key, read into span metadata then stripped — no contract change).
- **Showcase**: `eval/commands/kv.ex` ported to `eval/commands/kv_cli.ex` (before/after), plus a README section.

## Acceptance criteria (from #38)

- [x] `%CLI{}`/`use`-module registers as a valid command (passes `normalize_commands!`), with aliases
- [x] Nested routing + precedence; unknown subcommand → exit 2 + usage + did-you-mean
- [x] Typed flags/positionals with `required`, defaults, enums, accumulators; parse errors → exit 2 + usage
- [x] Auto-generated `--help`/`-h` at every level, from the spec
- [x] `describe/1` and `render_docs/2` (`:text`, `:markdown`)
- [x] Subcommand path in `[:just_bash, :command]` telemetry metadata
- [x] `type` / `command -v` aware of CLI modules
- [x] Handlers retain full `bash` access and crash isolation
- [x] Docs: README section + `kv.ex` before/after

## Also

Fixes a pre-existing flaky telemetry test (`telemetry_test.exs:103`) that matched a session `:stop` event without binding the session pid — a concurrent async test's event could land in its mailbox. Now binds the pid from `:start`, as its sibling test already does.

## Verification

All five gates pass: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict` (only the pre-existing intentional fixture finding), `mix test` (**3607 tests, 0 failures**), `mix dialyzer` (clean).

## Behavior change (review follow-up — dab60ef)

Hardening from code review. The one item worth release-note attention:

- **`ArgParser` `:integer`/`:float` parsing is now strict.** A value with trailing
  characters is rejected instead of silently truncated: `--max-time 30s` / `--report 42x`
  / `1_000` now error (`invalid integer value: …`) rather than parsing as `30`/`42`/`1`.
  This matches real CLI behavior (`curl --max-time 30s` errors). The only existing
  `:integer` consumer is `curl` (`--max-time`, `--connect-timeout`); the full suite passes,
  so nothing depended on the lenient behavior.

Other review fixes (no external behavior impact): reject `:flags`/`:args` on group nodes,
tag the resolved subcommand path on help/usage-error telemetry, consume a leading `--`
options terminator in routing, and raise a clear error on a malformed handler return.
