### PR TITLE
feat: add put_context/3 and get_context/3 accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,34 @@ bash =
 result.stdout  #=> "alice\n"
 ```
 
+#### Updating context after construction
+
+The `:context` option seeds caller data at construction. To add or update entries *afterward*, use
+the `put_context/3` and `get_context/3` accessors (modeled on `Plug.Conn.put_private/3`). Both target
+the same `context` map, keys are atoms, and the map is ignored by builtins and the interpreter.
+
+```elixir
+defmodule MyApp.Commands.Counter do
+  @behaviour JustBash.Commands.Command
+
+  @impl true
+  def names, do: ["counter_ctx"]
+
+  @impl true
+  def execute(bash, _args, _stdin) do
+    count = JustBash.get_context(bash, :count, 0)
+    {%{stdout: "#{count}\n", stderr: "", exit_code: 0}, bash}
+  end
+end
+
+bash =
+  JustBash.new(commands: %{"counter_ctx" => MyApp.Commands.Counter})
+  |> JustBash.put_context(:count, 41)
+
+{result, _bash} = JustBash.exec(bash, "counter_ctx")
+result.stdout  #=> "41\n"
+```
+
 Important caveats:
 
 - Custom commands run arbitrary Elixir code in the host BEAM process

--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -156,6 +156,7 @@ defmodule JustBash do
   - `:context` - Optional map of caller data for custom commands. Stored on the `JustBash` struct
     as `context` and readable inside any custom command as `bash.context`. Defaults to `%{}`.
     Not used by builtins or the interpreter; only host-defined custom commands should read it.
+    To add or update entries *after* construction, use `put_context/3` and `get_context/3`.
   - `:network` - Network configuration map with:
     - `:enabled` - Whether network access is allowed (default: false)
     - `:allow_list` - Allowed hosts/patterns. Use `:all` to allow all hosts, or a list of
@@ -589,5 +590,61 @@ defmodule JustBash do
         error_msg = "#{path}: No such file or directory\n"
         {%{stdout: "", stderr: error_msg, exit_code: 1, env: bash.env}, bash}
     end
+  end
+
+  @doc """
+  Store a host-side value on the `JustBash` struct's `context` map under an atom key.
+
+  This is the post-construction counterpart to the `:context` option of `new/1`,
+  modeled on `Plug.Conn.put_private/3`. The `context` map is reserved for the
+  library *caller* to stash arbitrary data that travels with the struct. Keys
+  must be atoms; values may be any term. Builtins and the interpreter never read
+  `context` — only host-defined custom commands should, via `bash.context` or
+  `get_context/3`.
+
+  Use the `:context` option to seed values at construction, and `put_context/3`
+  to add or update them afterward — both target the same `context` map.
+
+  ## Examples
+
+      bash = JustBash.new()
+      bash = JustBash.put_context(bash, :request_id, "abc123")
+      bash.context
+      #=> %{request_id: "abc123"}
+
+      # Construction-time seeding and post-construction updates compose:
+      bash =
+        JustBash.new(context: %{tenant: "acme"})
+        |> JustBash.put_context(:request_id, "abc123")
+      bash.context
+      #=> %{tenant: "acme", request_id: "abc123"}
+  """
+  @spec put_context(t(), atom(), term()) :: t()
+  def put_context(%JustBash{context: context} = bash, key, value) when is_atom(key) do
+    %{bash | context: Map.put(context, key, value)}
+  end
+
+  @doc """
+  Read a host-side value from the `JustBash` struct's `context` map.
+
+  Returns `default` (which itself defaults to `nil`) when the key is absent.
+  Keys must be atoms. This reads the same map seeded by the `:context` option of
+  `new/1` and written by `put_context/3`.
+
+  ## Examples
+
+      bash = JustBash.new() |> JustBash.put_context(:request_id, "abc123")
+      JustBash.get_context(bash, :request_id)
+      #=> "abc123"
+
+      JustBash.get_context(bash, :missing)
+      #=> nil
+
+      JustBash.get_context(bash, :missing, :fallback)
+      #=> :fallback
+  """
+  @spec get_context(t(), atom(), term()) :: term()
+  def get_context(%JustBash{context: context}, key, default \\ nil) when is_atom(key) do
+    Map.get(context, key, default)
   end
 end

--- a/test/custom_commands_test.exs
+++ b/test/custom_commands_test.exs
@@ -198,6 +198,27 @@ defmodule JustBash.CustomCommandsTest do
     end
   end
 
+  defmodule ContextProbe do
+    @behaviour JustBash.Commands.Command
+
+    @impl true
+    def names, do: ["ctxprobe"]
+
+    @impl true
+    def execute(bash, args, _stdin) do
+      out =
+        case args do
+          [key | _] ->
+            inspect(JustBash.get_context(bash, String.to_atom(key), "DEFAULT"))
+
+          [] ->
+            inspect(bash.context)
+        end
+
+      {%{stdout: out <> "\n", stderr: "", exit_code: 0}, bash}
+    end
+  end
+
   defmodule Counter do
     @doc "A command that reads a file, increments the number in it, and writes it back"
     @behaviour JustBash.Commands.Command
@@ -299,6 +320,42 @@ defmodule JustBash.CustomCommandsTest do
       {result, _} = JustBash.exec(bash, "ctxdump")
       assert String.trim(result.stdout) == inspect(%{})
       assert result.exit_code == 0
+    end
+  end
+
+  describe "custom command context via put_context" do
+    test "custom command reads context seeded via put_context" do
+      bash =
+        JustBash.new(commands: %{"ctxprobe" => ContextProbe})
+        |> JustBash.put_context(:token, "secret")
+
+      {result, _} = JustBash.exec(bash, "ctxprobe token")
+      assert String.trim(result.stdout) == inspect("secret")
+      assert result.exit_code == 0
+    end
+
+    test "custom command sees empty context map when nothing seeded" do
+      bash = JustBash.new(commands: %{"ctxprobe" => ContextProbe})
+      {result, _} = JustBash.exec(bash, "ctxprobe")
+      assert String.trim(result.stdout) == inspect(%{})
+      assert result.exit_code == 0
+    end
+
+    test "custom command can use get_context with a default" do
+      bash = JustBash.new(commands: %{"ctxprobe" => ContextProbe})
+      {result, _} = JustBash.exec(bash, "ctxprobe missing")
+      assert String.trim(result.stdout) == inspect("DEFAULT")
+      assert result.exit_code == 0
+    end
+
+    test "context survives across exec calls in the returned bash struct" do
+      bash =
+        JustBash.new(commands: %{"ctxprobe" => ContextProbe})
+        |> JustBash.put_context(:token, "secret")
+
+      {_result, bash} = JustBash.exec(bash, "ctxprobe token")
+      {result, _} = JustBash.exec(bash, "ctxprobe token")
+      assert String.trim(result.stdout) == inspect("secret")
     end
   end
 

--- a/test/just_bash_test.exs
+++ b/test/just_bash_test.exs
@@ -128,6 +128,79 @@ defmodule JustBashTest do
     end
   end
 
+  describe "put_context/3 and get_context/3" do
+    test "context defaults to an empty map" do
+      bash = JustBash.new()
+      assert bash.context == %{}
+    end
+
+    test "put_context stores a value retrievable by get_context" do
+      bash = JustBash.new() |> JustBash.put_context(:k, "v")
+      assert JustBash.get_context(bash, :k) == "v"
+      assert bash.context == %{k: "v"}
+    end
+
+    test "get_context returns nil for a missing key by default" do
+      assert JustBash.get_context(JustBash.new(), :missing) == nil
+    end
+
+    test "get_context returns the supplied default for a missing key" do
+      assert JustBash.get_context(JustBash.new(), :missing, :fallback) == :fallback
+    end
+
+    test "put_context overwrites an existing key" do
+      bash =
+        JustBash.new()
+        |> JustBash.put_context(:k, 1)
+        |> JustBash.put_context(:k, 2)
+
+      assert JustBash.get_context(bash, :k) == 2
+    end
+
+    test "put_context with a non-atom key raises FunctionClauseError" do
+      bash = JustBash.new()
+
+      assert_raise FunctionClauseError, fn ->
+        JustBash.put_context(bash, "str", 1)
+      end
+    end
+
+    test "get_context with a non-atom key raises FunctionClauseError" do
+      bash = JustBash.new()
+
+      assert_raise FunctionClauseError, fn ->
+        JustBash.get_context(bash, "str")
+      end
+    end
+
+    test "put_context accepts any term as value" do
+      value = {:a, [1, 2, 3]}
+      bash = JustBash.new() |> JustBash.put_context(:data, value)
+      assert JustBash.get_context(bash, :data) == value
+    end
+
+    test "put_context composes with the :context option seeding" do
+      bash =
+        JustBash.new(context: %{a: 1})
+        |> JustBash.put_context(:b, 2)
+
+      assert bash.context == %{a: 1, b: 2}
+      assert JustBash.get_context(bash, :a) == 1
+      assert JustBash.get_context(bash, :b) == 2
+      assert JustBash.get_context(bash, :missing) == nil
+    end
+
+    test "put_context preserves other context keys" do
+      bash =
+        JustBash.new()
+        |> JustBash.put_context(:a, 1)
+        |> JustBash.put_context(:b, 2)
+
+      assert JustBash.get_context(bash, :a) == 1
+      assert JustBash.get_context(bash, :b) == 2
+    end
+  end
+
   describe "exec/2" do
     test "executes echo command" do
       bash = JustBash.new()


### PR DESCRIPTION
Resolves #40.

## Summary

Issue #40 proposed adding an opaque `private: %{}` field to `%JustBash{}` with `put_private/3`/`get_private/3` accessors (Plug.Conn.private style) for host-side data seeded *after* construction.

While implementing, we found the struct already has a `context: %{}` field (added in #34) with the same host-data semantics — a new `private` field would be completely duplicative. Instead, this PR gives the existing `context` map the post-construction ergonomics the issue actually wanted.

## Changes

- **`put_context/3`** — `@spec put_context(t(), atom(), term()) :: t()`, `when is_atom(key)` guard; writes into the existing `context` map.
- **`get_context/3`** — `@spec get_context(t(), atom(), term()) :: term()`, `default \\ nil`, atom-key guard; reads `context`.
- Both modeled on `Plug.Conn.put_private/3`. They target the **same** `context` map seeded by the `:context` option of `new/1`, so construction-time seeding and post-construction updates compose.
- `:context` option docs cross-reference the accessors; new README section "Updating context after construction".
- Custom commands already receive the full struct, so `bash.context` / `get_context/3` is reachable inside `execute/3` with no callback change.

### Example

```elixir
bash =
  JustBash.new(context: %{tenant: "acme"})
  |> JustBash.put_context(:request_id, "abc123")

JustBash.get_context(bash, :request_id)  #=> "abc123"
JustBash.get_context(bash, :missing, :fallback)  #=> :fallback
```

## Tests

`put_context`/`get_context` roundtrip, nil/supplied defaults, overwrite, key-preservation, arbitrary term values, non-atom key raising `FunctionClauseError`, composition with `:context` seeding, and a `ContextProbe` custom command reading `bash.context` through `execute/3` (incl. persistence across `exec` calls).

## Validation

- ✅ `mix compile --warnings-as-errors`
- ✅ `mix format --check-formatted`
- ✅ `mix credo --strict` (only the pre-existing sanctioned fixture finding)
- ✅ `mix test` — 56 properties, 3542 tests, 0 failures
- ✅ `mix dialyzer` — clean

## Notes

- No new constructor option and no new struct field — purely additive accessors.
- The accessors require atom keys (per the issue's Plug rationale); the `:context` option still accepts any map, so callers using non-atom keys keep reading `bash.context` directly.