### PR TITLE
feat(cli): address consumer feedback from issue #38

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,28 @@ JustBash.CLI.describe(cli)
 JustBash.CLI.render_docs(cli, format: :markdown)  # a markdown manual
 ```
 
+A few options on `command/2` cover the rough edges a real consumer hits:
+
+- **`:examples`** — worked examples, co-located with the command and surfaced in `--help`,
+  `describe/1`, and `render_docs`: `examples: ["acme pr review --report 42", %{cmd: "...", doc: "..."}]`.
+- **`:validate`** — a `(Invocation -> :ok | {:error, msg})` callback for cross-field rules
+  (e.g. `start <= end`); an error produces the same exit-2 + usage line as a flag error, so
+  every failure has one contract. (A flag `:transform` may likewise return `{:error, msg}`
+  for single-field checks like a numeric range.)
+- **`allow_unknown_flags: true`** — collect undeclared flags into `inv.extra_flags` (a raw
+  token list) instead of erroring, for a leaf that forwards them to a dynamic backend.
+- **`visible?: fn bash -> ... end`** — make a node *absent* (unroutable and omitted from
+  help/`describe`) for callers it rejects, decided from `bash.context`. Pass the same `bash`
+  to `describe(cli, bash)` to get the catalog that caller sees. For fully dynamic trees,
+  build the `%JustBash.CLI{}` per session and conditionally append gated groups — the tree
+  is plain data, so routing, help, and `describe` always reflect exactly what you built.
+- **`on_missing_subcommand: :help`** — print the command listing at exit 0 (instead of a
+  usage error) when a group is invoked with no subcommand.
+
+For handler-level unit tests, drive through `CLI.run/4` or `CLI.invoke(spec, path, args, bash, stdin)`
+rather than hand-building an `%Invocation{}` — only the parser merges flag defaults, so a
+hand-built invocation would see `nil` where a `:default` should be.
+
 If you prefer a CLI to live as a module alongside your other command modules, `use
 JustBash.CLI` and define `spec/0` (conventional `use`-wiring, not a DSL):
 

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -56,6 +56,41 @@ defmodule JustBash.CLI do
   `:type` — e.g. `type: :integer, values: [1, 2]` (integers, not `~w(1 2)`). The raw
   `:values` list is also what `describe/1` and the help text surface to agents.
 
+  Flag names are atoms, so a name that is an Elixir reserved word (e.g. `end`, `fn`, `do`)
+  can't be written bare in the keyword list. Give it an explicit `:long` instead:
+  `end_date: [type: :string, long: "--end"]`.
+
+  Beyond required-ness, types, and `:values`, two hooks cover custom validation, both
+  producing the same exit-2 + usage-line failure as a flag error:
+
+    * a flag's `:transform` may return `{:error, message}` for single-field checks (a numeric
+      range, a parseable date);
+    * a command-level `:validate` callback runs after parsing for cross-field rules
+      (`start <= end`). See `command/2`.
+
+  ## Passthrough flags
+
+  A leaf that wraps a backend whose flags aren't known at definition time can set
+  `allow_unknown_flags: true`. Undeclared flags are then collected into
+  `Invocation.extra_flags` as a raw token list (ready to forward verbatim) instead of
+  erroring, while declared flags and positionals are parsed as usual. Put declared
+  positionals before passthrough flags, and prefer `--flag=value` form for unambiguous
+  forwarding. See `command/2`.
+
+  ## Authorization
+
+  To make a subtree **present only for some callers** — genuinely absent, not just hidden —
+  there are two approaches:
+
+    * **Build the tree from context (first-class).** A `%JustBash.CLI{}` is plain data, so
+      build it per session and conditionally append gated groups based on `bash.context`
+      before registering it. Routing, help, and `describe/1` all reflect exactly the tree
+      you built. This is the most flexible path and the right one for fully dynamic trees.
+    * **A `:visible?` predicate (declarative sugar).** Attach `visible?: fn bash -> ... end`
+      to a node; `run/4` prunes nodes the predicate rejects before routing, so they're
+      unroutable (reported as unknown commands) and omitted from help. Pass the same `bash`
+      to `describe/2`/`render_docs/2` to get the catalog as that caller sees it.
+
   ## Reserved flags
 
   `--help` and `-h` are reserved: the router intercepts them before a leaf ever parses, so a
@@ -96,13 +131,14 @@ defmodule JustBash.CLI do
   @usage_exit 2
 
   @enforce_keys [:name]
-  defstruct name: nil, doc: nil, commands: [], aliases: []
+  defstruct name: nil, doc: nil, commands: [], aliases: [], on_missing_subcommand: :error
 
   @type t :: %__MODULE__{
           name: String.t(),
           doc: String.t() | nil,
           commands: [Command.t()],
-          aliases: [String.t()]
+          aliases: [String.t()],
+          on_missing_subcommand: :error | :help
         }
 
   @typedoc "A CLI value: either a built struct or a module that `use`s `JustBash.CLI`."
@@ -212,6 +248,8 @@ defmodule JustBash.CLI do
     * `:doc` — one-line description of the tool
     * `:commands` — a list of top-level `JustBash.CLI.Command` nodes (built with `command/2`)
     * `:aliases` — additional names the tool can be registered under
+    * `:on_missing_subcommand` — `:error` (default) or `:help`; what the root does when
+      invoked with no subcommand (see `command/2`)
 
   Raises `ArgumentError` if names are invalid or top-level command names collide.
   """
@@ -226,11 +264,15 @@ defmodule JustBash.CLI do
     aliases = Keyword.get(opts, :aliases, [])
     validate_aliases!(aliases)
 
+    on_missing = Keyword.get(opts, :on_missing_subcommand, :error)
+    validate_on_missing!(name, on_missing)
+
     %__MODULE__{
       name: name,
       doc: Keyword.get(opts, :doc),
       commands: commands,
-      aliases: aliases
+      aliases: aliases,
+      on_missing_subcommand: on_missing
     }
   end
 
@@ -248,6 +290,19 @@ defmodule JustBash.CLI do
       (makes this a leaf)
     * `:flags` — an `ArgParser` flag spec (leaves only)
     * `:args` — positional argument specs (leaves only); see `t:JustBash.CLI.Command.arg_spec/0`
+    * `:examples` — a list of worked examples (leaves only); each is a string or a map
+      `%{cmd: String.t(), doc: String.t() | nil}`, surfaced in help, `describe/1`, and docs
+    * `:validate` — a `(JustBash.CLI.Invocation.t() -> :ok | {:error, String.t()})` callback
+      (leaves only) run after parsing and before `:run`; an `{:error, msg}` produces the same
+      exit-2 + usage line as a flag error, giving cross-field validation a home
+    * `:allow_unknown_flags` — when `true` (leaves only), undeclared flags are collected into
+      `Invocation.extra_flags` (a raw token list) instead of erroring. Declared positionals
+      should precede passthrough flags, and `--flag=value` is forwarded as one token
+    * `:visible?` — a `(JustBash.t() -> boolean())` predicate; when it returns `false` the
+      node is **absent** for that caller — unroutable (reported as an unknown command) and
+      omitted from help and `describe/2`
+    * `:on_missing_subcommand` — `:error` (default) or `:help` (groups only); `:help` prints
+      the command listing at exit 0 instead of a usage error when the group is invoked bare
 
   Raises `ArgumentError` on invalid shape (e.g. both or neither of `:commands`/`:run`).
   """
@@ -259,21 +314,40 @@ defmodule JustBash.CLI do
     run = Keyword.get(opts, :run)
     flags = Keyword.get(opts, :flags, [])
     args = Keyword.get(opts, :args, [])
+    examples = Keyword.get(opts, :examples, [])
+    validate = Keyword.get(opts, :validate)
+    allow_unknown_flags = Keyword.get(opts, :allow_unknown_flags, false)
+    visible? = Keyword.get(opts, :visible?)
+    on_missing = Keyword.get(opts, :on_missing_subcommand, :error)
 
     validate_node_kind!(name, commands, run)
     validate_leaf_only!(name, commands, flags, args)
+    reject_on_group!(name, commands, :examples, examples, [])
+    reject_on_group!(name, commands, :validate, validate, nil)
+    reject_on_group!(name, commands, :allow_unknown_flags, allow_unknown_flags, false)
+    reject_on_leaf!(name, run, :on_missing_subcommand, on_missing, :error)
     validate_commands!(commands)
     validate_unique_names!(commands, name)
+    validate_callback!(name, :validate, validate)
+    validate_callback!(name, :visible?, visible?)
+    validate_boolean!(name, :allow_unknown_flags, allow_unknown_flags)
+    validate_on_missing!(name, on_missing)
     flags = normalize_flags!(name, flags)
     args = validate_args!(name, args)
+    examples = normalize_examples!(name, examples)
 
     %Command{
       name: name,
       doc: Keyword.get(opts, :doc),
       flags: flags,
       args: args,
+      examples: examples,
       commands: commands,
-      run: run
+      run: run,
+      validate: validate,
+      allow_unknown_flags: allow_unknown_flags,
+      visible?: visible?,
+      on_missing_subcommand: on_missing
     }
   end
 
@@ -285,10 +359,25 @@ defmodule JustBash.CLI do
   `c:JustBash.Commands.Command.execute/3`.
 
   Usage problems (unknown subcommand, bad flag, missing argument) return an error result
-  with exit code `2` and a usage hint, rather than raising.
+  with exit code `2` and a usage hint, rather than raising. A command-level `:validate`
+  failure uses the same exit-2 + usage-line shape.
+
+  Nodes whose `:visible?` predicate rejects this `bash` are pruned before routing, so they
+  are reported as unknown commands and never appear in help (see the moduledoc's
+  "Authorization" section).
+
+  > #### Result carries `:__subcommand__` {: .info}
+  > The returned `result` map includes a `:__subcommand__` key holding the resolved path,
+  > for command telemetry. The shell executor reads it into span metadata and strips it
+  > before the result reaches the shell, but a host calling `run/4` (or `invoke/5`) directly
+  > will see it. It's safe to ignore — read `:exit_code`/`:stdout`/`:stderr` as usual.
   """
   @spec run(t(), JustBash.t(), [String.t()], String.t()) :: {map(), JustBash.t()}
   def run(%__MODULE__{} = cli, bash, args, stdin) do
+    # Prune nodes hidden from this caller (by their `:visible?` predicate) once up front, so
+    # routing, help, and errors all operate on the same caller-specific view of the tree.
+    cli = prune_visible(cli, bash)
+
     # Every routed result carries its resolved subcommand path (the valid prefix, even
     # for help/usage errors) so command telemetry can attribute the bucket; the executor
     # reads it into span metadata and strips it before the result reaches the shell.
@@ -301,7 +390,7 @@ defmodule JustBash.CLI do
         end
 
       {:no_subcommand, group, path, remaining} ->
-        if wants_help?(remaining) do
+        if wants_help?(remaining) or group.on_missing_subcommand == :help do
           {tag_subcommand(help_result(Help.group_help(cli, path, group)), path), bash}
         else
           {tag_subcommand(usage_error(Help.missing_subcommand(cli, path, group)), path), bash}
@@ -310,6 +399,33 @@ defmodule JustBash.CLI do
       {:unknown_subcommand, group, path, token} ->
         {tag_subcommand(usage_error(Help.unknown_subcommand(cli, path, group, token)), path),
          bash}
+    end
+  end
+
+  @doc """
+  Invoke a leaf at an explicit `path`, bypassing routing and visibility.
+
+  Intended for handler-level unit tests: it builds the `%JustBash.CLI.Invocation{}` exactly
+  as `run/4` does — merging flag defaults, collecting `extra_flags`, and running `:validate`
+  — then calls the handler and returns `{result, bash}`. Prefer this (or `run/4`) over
+  hand-building an `%Invocation{}`, which skips default-merging.
+
+      {result, _bash} = JustBash.CLI.invoke(spec, ["pr", "review"], ["--report", "7"], bash)
+
+  Raises `ArgumentError` if `path` does not resolve to a leaf.
+  """
+  @spec invoke(spec(), [String.t()], [String.t()], JustBash.t(), String.t()) ::
+          {map(), JustBash.t()}
+  def invoke(cli_or_module, path, args, bash, stdin \\ "") do
+    cli = resolve(cli_or_module)
+
+    case resolve_leaf(cli.commands, path) do
+      {:ok, leaf} ->
+        dispatch_leaf(cli, leaf, path, args, bash, stdin)
+
+      :error ->
+        raise ArgumentError,
+              "#{cli.name}: #{Enum.join(path, " ")} is not a leaf command"
     end
   end
 
@@ -324,7 +440,8 @@ defmodule JustBash.CLI do
   Return a plain-data description of the CLI's command tree.
 
   Useful for generating agent-facing documentation or building tab completion. Every
-  leaf is listed with its full invocation `path` and resolved flag/argument specs:
+  leaf is listed with its full invocation `path`, resolved flag/argument specs, worked
+  `examples`, and whether it accepts passthrough flags (`allow_unknown_flags`):
 
       JustBash.CLI.describe(cli)
       #=> %{
@@ -333,14 +450,20 @@ defmodule JustBash.CLI do
       #     aliases: [],
       #     commands: [
       #       %{path: ["pr", "review"], doc: "Review a pull request",
-      #         flags: [%{name: :report, type: :integer, required: true, ...}], args: []},
+      #         flags: [%{name: :report, type: :integer, required: true, ...}], args: [],
+      #         examples: [%{cmd: "acme pr review --report 42", doc: nil}],
+      #         allow_unknown_flags: false},
       #       ...
       #     ]
       #   }
+
+  Pass a `bash` as the second argument to get the catalog as a specific caller sees it:
+  nodes whose `:visible?` predicate returns `false` for that `bash` are omitted, mirroring
+  what routing and `--help` expose. With no `bash` (the default), every node is described.
   """
-  @spec describe(spec()) :: map()
-  def describe(cli_or_module) do
-    cli = resolve(cli_or_module)
+  @spec describe(spec(), JustBash.t() | nil) :: map()
+  def describe(cli_or_module, bash \\ nil) do
+    cli = cli_or_module |> resolve() |> maybe_prune(bash)
 
     %{
       name: cli.name,
@@ -354,12 +477,17 @@ defmodule JustBash.CLI do
   Render the CLI as a standalone document.
 
   Pass `format: :text` (default) for a plain-text manual, or `format: :markdown` for a
-  markdown document suitable for an agent's system prompt.
+  markdown document suitable for an agent's system prompt. Pass `bash: bash` to render only
+  the commands that caller can see (see `describe/2`).
   """
   @spec render_docs(spec(), keyword()) :: String.t()
   def render_docs(cli_or_module, opts \\ []) do
-    Docs.render(resolve(cli_or_module), Keyword.get(opts, :format, :text))
+    cli = cli_or_module |> resolve() |> maybe_prune(Keyword.get(opts, :bash))
+    Docs.render(cli, Keyword.get(opts, :format, :text))
   end
+
+  defp maybe_prune(cli, nil), do: cli
+  defp maybe_prune(cli, bash), do: prune_visible(cli, bash)
 
   defp describe_leaves(commands, prefix) do
     Enum.flat_map(commands, fn command ->
@@ -373,7 +501,9 @@ defmodule JustBash.CLI do
             path: path,
             doc: command.doc,
             flags: describe_flags(command.flags),
-            args: command.args
+            args: command.args,
+            examples: command.examples,
+            allow_unknown_flags: command.allow_unknown_flags
           }
         ]
       end
@@ -425,33 +555,118 @@ defmodule JustBash.CLI do
     end
   end
 
+  # --- visibility ---
+
+  # Prune nodes whose `:visible?` predicate rejects this caller, so they're genuinely absent
+  # (not merely hidden). A group emptied by pruning is dropped too — it was only a container
+  # for now-invisible children.
+  defp prune_visible(%__MODULE__{} = cli, bash) do
+    %{cli | commands: prune_commands(cli.commands, bash)}
+  end
+
+  defp prune_commands(commands, bash) do
+    Enum.flat_map(commands, fn command ->
+      cond do
+        not visible?(command, bash) ->
+          []
+
+        Command.group?(command) ->
+          case prune_commands(command.commands, bash) do
+            [] -> []
+            kept -> [%{command | commands: kept}]
+          end
+
+        true ->
+          [command]
+      end
+    end)
+  end
+
+  defp visible?(%Command{visible?: nil}, _bash), do: true
+  defp visible?(%Command{visible?: fun}, bash) when is_function(fun, 1), do: !!fun.(bash)
+
+  # Resolve an explicit subcommand `path` to its leaf (used by `invoke/5`, which skips routing).
+  defp resolve_leaf(commands, [name]) do
+    case Enum.find(commands, &(&1.name == name)) do
+      %Command{run: run} = leaf when not is_nil(run) -> {:ok, leaf}
+      _ -> :error
+    end
+  end
+
+  defp resolve_leaf(commands, [name | rest]) do
+    case Enum.find(commands, &(&1.name == name)) do
+      %Command{run: nil} = group -> resolve_leaf(group.commands, rest)
+      _ -> :error
+    end
+  end
+
+  defp resolve_leaf(_commands, []), do: :error
+
   # --- leaf dispatch ---
 
   defp dispatch_leaf(cli, %Command{} = leaf, path, rest, bash, stdin) do
     label = command_label(cli, path)
 
-    with {:ok, flags, positional} <- ArgParser.parse(rest, leaf.flags, command: label),
-         :ok <- validate_positionals(leaf.args, positional, label) do
-      invocation = %Invocation{
-        bash: bash,
-        flags: flags,
-        args: positional,
-        stdin: stdin,
-        path: path
-      }
-
-      case leaf.run.(invocation) do
-        {result, %JustBash{} = new_bash} ->
-          {tag_subcommand(result, path), new_bash}
-
-        other ->
-          raise ArgumentError,
-                "#{label} handler must return {result, bash}, got: #{inspect(other)}"
-      end
+    with {:ok, flags, positional, extra} <- parse_leaf_args(leaf, rest, label),
+         :ok <- validate_positionals(leaf.args, positional, label),
+         invocation = build_invocation(leaf, flags, positional, extra, bash, stdin, path),
+         :ok <- run_validate(leaf, invocation) do
+      dispatch_run(label, leaf, path, invocation)
     else
       {:error, message} ->
         {tag_subcommand(usage_error(message <> Help.usage_line(cli, path, leaf)), path), bash}
     end
+  end
+
+  # Parse a leaf's flags, normalizing to a 4-tuple so the caller is uniform. A leaf that
+  # opts into `allow_unknown_flags` collects undeclared flags into `extra`; otherwise `extra`
+  # is always empty.
+  defp parse_leaf_args(%Command{allow_unknown_flags: true} = leaf, rest, label) do
+    ArgParser.parse(rest, leaf.flags, command: label, collect_unknown: true)
+  end
+
+  defp parse_leaf_args(%Command{} = leaf, rest, label) do
+    case ArgParser.parse(rest, leaf.flags, command: label) do
+      {:ok, flags, positional} -> {:ok, flags, positional, []}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp build_invocation(_leaf, flags, positional, extra, bash, stdin, path) do
+    %Invocation{
+      bash: bash,
+      flags: flags,
+      args: positional,
+      extra_flags: extra,
+      stdin: stdin,
+      path: path
+    }
+  end
+
+  # Run a leaf's `:validate` callback before its handler. An error is shaped exactly like a
+  # flag error (caught by the `with`'s else clause): exit 2 with the usage line appended.
+  defp run_validate(%Command{validate: nil}, _invocation), do: :ok
+
+  defp run_validate(%Command{validate: fun}, invocation) when is_function(fun, 1) do
+    case fun.(invocation) do
+      :ok -> :ok
+      {:error, message} when is_binary(message) -> {:error, ensure_newline(message)}
+    end
+  end
+
+  defp dispatch_run(label, %Command{} = leaf, path, invocation) do
+    case leaf.run.(invocation) do
+      {result, %JustBash{} = new_bash} ->
+        {tag_subcommand(result, path), new_bash}
+
+      other ->
+        raise ArgumentError,
+              "#{label} handler must return {result, bash}, got: #{inspect(other)}"
+    end
+  end
+
+  defp ensure_newline(message) do
+    if String.ends_with?(message, "\n"), do: message, else: message <> "\n"
   end
 
   defp validate_positionals(specs, positional, label) do
@@ -533,6 +748,69 @@ defmodule JustBash.CLI do
   end
 
   defp validate_leaf_only!(_name, _commands, _flags, _args), do: :ok
+
+  # Leaf-only opts are meaningless on a group (which never parses or dispatches); reject
+  # them loudly rather than silently ignoring a misplaced option.
+  defp reject_on_group!(name, commands, opt, value, default)
+       when commands != [] and value != default do
+    raise ArgumentError,
+          "command #{inspect(name)} is a group (:commands) and cannot define #{inspect(opt)}; " <>
+            "move it to a leaf command"
+  end
+
+  defp reject_on_group!(_name, _commands, _opt, _value, _default), do: :ok
+
+  # `:on_missing_subcommand` only makes sense on a group/root; a leaf has no subcommands.
+  defp reject_on_leaf!(name, run, opt, value, default)
+       when not is_nil(run) and value != default do
+    raise ArgumentError,
+          "command #{inspect(name)} is a leaf (:run) and cannot define #{inspect(opt)}"
+  end
+
+  defp reject_on_leaf!(_name, _run, _opt, _value, _default), do: :ok
+
+  defp validate_callback!(_name, _opt, nil), do: :ok
+  defp validate_callback!(_name, _opt, fun) when is_function(fun, 1), do: :ok
+
+  defp validate_callback!(name, opt, other) do
+    raise ArgumentError,
+          "command #{inspect(name)} #{inspect(opt)} must be a 1-arity function or nil, got: #{inspect(other)}"
+  end
+
+  defp validate_boolean!(_name, _opt, value) when is_boolean(value), do: :ok
+
+  defp validate_boolean!(name, opt, other) do
+    raise ArgumentError,
+          "command #{inspect(name)} #{inspect(opt)} must be a boolean, got: #{inspect(other)}"
+  end
+
+  defp validate_on_missing!(_name, mode) when mode in [:error, :help], do: :ok
+
+  defp validate_on_missing!(name, other) do
+    raise ArgumentError,
+          "#{inspect(name)} :on_missing_subcommand must be :error or :help, got: #{inspect(other)}"
+  end
+
+  # Normalize examples to `%{cmd:, doc:}` maps so `describe/1` stays JSON-clean.
+  defp normalize_examples!(name, examples) when is_list(examples) do
+    Enum.map(examples, &normalize_example!(name, &1))
+  end
+
+  defp normalize_examples!(name, other) do
+    raise ArgumentError,
+          "command #{inspect(name)} :examples must be a list, got: #{inspect(other)}"
+  end
+
+  defp normalize_example!(_name, cmd) when is_binary(cmd), do: %{cmd: cmd, doc: nil}
+
+  defp normalize_example!(_name, %{cmd: cmd} = example) when is_binary(cmd),
+    do: %{cmd: cmd, doc: Map.get(example, :doc)}
+
+  defp normalize_example!(name, other) do
+    raise ArgumentError,
+          "command #{inspect(name)}: each :examples entry must be a string or a map with a " <>
+            ":cmd string, got: #{inspect(other)}"
+  end
 
   defp validate_commands!(commands) when is_list(commands) do
     Enum.each(commands, fn

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -412,6 +412,10 @@ defmodule JustBash.CLI do
 
       {result, _bash} = JustBash.CLI.invoke(spec, ["pr", "review"], ["--report", "7"], bash)
 
+  Because it skips visibility pruning, `invoke/5` is **not an authorization boundary**: it will
+  dispatch a leaf whose `:visible?` predicate would reject this `bash`. Use `run/4` for any
+  caller-gated dispatch; reach for `invoke/5` only in tests or trusted internal call sites.
+
   Raises `ArgumentError` if `path` does not resolve to a leaf.
   """
   @spec invoke(spec(), [String.t()], [String.t()], JustBash.t(), String.t()) ::
@@ -559,9 +563,20 @@ defmodule JustBash.CLI do
 
   # Prune nodes whose `:visible?` predicate rejects this caller, so they're genuinely absent
   # (not merely hidden). A group emptied by pruning is dropped too — it was only a container
-  # for now-invisible children.
+  # for now-invisible children. Skip the rebuild entirely when no node gates on visibility
+  # (the common case), so `run/4` stays allocation-free for ungated trees.
   defp prune_visible(%__MODULE__{} = cli, bash) do
-    %{cli | commands: prune_commands(cli.commands, bash)}
+    if any_visibility?(cli.commands) do
+      %{cli | commands: prune_commands(cli.commands, bash)}
+    else
+      cli
+    end
+  end
+
+  defp any_visibility?(commands) do
+    Enum.any?(commands, fn %Command{visible?: vis, commands: children} ->
+      not is_nil(vis) or any_visibility?(children)
+    end)
   end
 
   defp prune_commands(commands, bash) do
@@ -647,10 +662,18 @@ defmodule JustBash.CLI do
   # flag error (caught by the `with`'s else clause): exit 2 with the usage line appended.
   defp run_validate(%Command{validate: nil}, _invocation), do: :ok
 
-  defp run_validate(%Command{validate: fun}, invocation) when is_function(fun, 1) do
+  defp run_validate(%Command{validate: fun, name: name}, invocation) when is_function(fun, 1) do
     case fun.(invocation) do
-      :ok -> :ok
-      {:error, message} when is_binary(message) -> {:error, ensure_newline(message)}
+      :ok ->
+        :ok
+
+      {:error, message} when is_binary(message) ->
+        {:error, ensure_newline(message)}
+
+      other ->
+        raise ArgumentError,
+              "command #{inspect(name)} :validate must return :ok or {:error, message :: String.t()}, " <>
+                "got: #{inspect(other)}"
     end
   end
 

--- a/lib/just_bash/cli/command.ex
+++ b/lib/just_bash/cli/command.ex
@@ -16,12 +16,32 @@ defmodule JustBash.CLI.Command do
     * `:doc` — one-line description shown in help output
     * `:flags` — a `JustBash.Commands.ArgParser` flag spec (keyword list); leaves only
     * `:args` — positional argument specs (see `t:arg_spec/0`); leaves only
+    * `:examples` — worked examples surfaced in help, `describe/1`, and docs (see `t:example/0`)
     * `:commands` — nested child nodes (groups only)
     * `:run` — the handler, `(JustBash.CLI.Invocation.t() -> {map(), JustBash.t()})`; leaves only
+    * `:validate` — optional `(JustBash.CLI.Invocation.t() -> :ok | {:error, String.t()})`
+      run after parsing and before `:run`; an error yields the same exit-2 + usage line as a
+      flag error (leaves only)
+    * `:allow_unknown_flags` — when `true`, undeclared flags are collected into
+      `Invocation.extra_flags` instead of erroring (leaves only)
+    * `:visible?` — optional `(JustBash.t() -> boolean())` predicate; when it returns `false`
+      the node is **absent** (unroutable and omitted from help/`describe`) for that caller
+    * `:on_missing_subcommand` — `:error` (default) or `:help`; what a bare group does when
+      invoked without a subcommand (groups and the root only)
   """
 
   @enforce_keys [:name]
-  defstruct name: nil, doc: nil, flags: [], args: [], commands: [], run: nil
+  defstruct name: nil,
+            doc: nil,
+            flags: [],
+            args: [],
+            examples: [],
+            commands: [],
+            run: nil,
+            validate: nil,
+            allow_unknown_flags: false,
+            visible?: nil,
+            on_missing_subcommand: :error
 
   @typedoc """
   A positional argument specification.
@@ -38,15 +58,28 @@ defmodule JustBash.CLI.Command do
           optional(:variadic) => boolean()
         }
 
+  @typedoc """
+  A worked example, normalized to a map. `:cmd` is the example invocation; `:doc` is an
+  optional one-line description.
+  """
+  @type example :: %{cmd: String.t(), doc: String.t() | nil}
+
   @type handler :: (JustBash.CLI.Invocation.t() -> {map(), JustBash.t()})
+  @type validator :: (JustBash.CLI.Invocation.t() -> :ok | {:error, String.t()})
+  @type visibility :: (JustBash.t() -> boolean())
 
   @type t :: %__MODULE__{
           name: String.t(),
           doc: String.t() | nil,
           flags: keyword(),
           args: [arg_spec()],
+          examples: [example()],
           commands: [t()],
-          run: handler() | nil
+          run: handler() | nil,
+          validate: validator() | nil,
+          allow_unknown_flags: boolean(),
+          visible?: visibility() | nil,
+          on_missing_subcommand: :error | :help
         }
 
   @doc """

--- a/lib/just_bash/cli/docs.ex
+++ b/lib/just_bash/cli/docs.ex
@@ -54,8 +54,21 @@ defmodule JustBash.CLI.Docs do
       usage,
       "\n```\n",
       flags_table(node.flags),
-      args_table(node.args)
+      args_table(node.args),
+      examples_block(node.examples)
     ]
+  end
+
+  defp examples_block([]), do: []
+
+  defp examples_block(examples) do
+    rows =
+      Enum.map(examples, fn
+        %{cmd: cmd, doc: nil} -> ["- `", cmd, "`\n"]
+        %{cmd: cmd, doc: doc} -> ["- `", cmd, "` — ", doc, "\n"]
+      end)
+
+    ["\n**Examples:**\n\n", rows]
   end
 
   defp optional_para(nil), do: []

--- a/lib/just_bash/cli/help.ex
+++ b/lib/just_bash/cli/help.ex
@@ -38,7 +38,8 @@ defmodule JustBash.CLI.Help do
       title(label(cli, path), leaf.doc),
       usage_line(cli, path, leaf),
       args_section(leaf.args),
-      options_section(leaf.flags)
+      options_section(leaf.flags),
+      examples_section(leaf.examples)
     ]
     |> compact_join()
   end
@@ -122,6 +123,16 @@ defmodule JustBash.CLI.Help do
   defp options_section(flags) do
     rows = Enum.map(flags, fn {_name, spec} = flag -> {flag_label(flag), flag_detail(spec)} end)
     "Options:\n" <> aligned_rows(rows)
+  end
+
+  defp examples_section([]), do: ""
+
+  defp examples_section(examples) do
+    "Examples:\n" <>
+      Enum.map_join(examples, "", fn
+        %{cmd: cmd, doc: nil} -> "  #{cmd}\n"
+        %{cmd: cmd, doc: doc} -> "  #{cmd}\n      #{doc}\n"
+      end)
   end
 
   # --- flag/arg rendering ---

--- a/lib/just_bash/cli/invocation.ex
+++ b/lib/just_bash/cli/invocation.ex
@@ -15,17 +15,21 @@ defmodule JustBash.CLI.Invocation do
     * `:bash` — the full `t:JustBash.t/0` struct (fs, env, context, …)
     * `:flags` — a map of parsed flag values, keyed by the flag's atom name
     * `:args` — the remaining positional arguments, as a list of strings
+    * `:extra_flags` — undeclared flag tokens collected when the leaf sets
+      `allow_unknown_flags: true`, as a raw list of strings (empty otherwise); ready to
+      forward verbatim to a backend
     * `:stdin` — the command's stdin, as a string
     * `:path` — the resolved subcommand path that routed here, e.g. `["pr", "review"]`
   """
 
   @enforce_keys [:bash, :flags, :args, :stdin, :path]
-  defstruct [:bash, :flags, :args, :stdin, :path]
+  defstruct [:bash, :flags, :args, :stdin, :path, extra_flags: []]
 
   @type t :: %__MODULE__{
           bash: JustBash.t(),
           flags: %{optional(atom()) => term()},
           args: [String.t()],
+          extra_flags: [String.t()],
           stdin: String.t(),
           path: [String.t()]
         }

--- a/lib/just_bash/commands/arg_parser.ex
+++ b/lib/just_bash/commands/arg_parser.ex
@@ -376,9 +376,18 @@ defmodule JustBash.Commands.ArgParser do
 
       fun when is_function(fun, 1) ->
         case fun.(value) do
-          {:ok, transformed} -> {:ok, transformed}
-          {:error, message} when is_binary(message) -> {:error, ensure_newline(message)}
-          bare -> {:ok, bare}
+          {:ok, transformed} ->
+            {:ok, transformed}
+
+          {:error, message} when is_binary(message) ->
+            {:error, ensure_newline(message)}
+
+          {:error, other} ->
+            raise ArgumentError,
+                  ":transform error message must be a String.t(), got: {:error, #{inspect(other)}}"
+
+          bare ->
+            {:ok, bare}
         end
     end
   end

--- a/lib/just_bash/commands/arg_parser.ex
+++ b/lib/just_bash/commands/arg_parser.ex
@@ -38,10 +38,14 @@ defmodule JustBash.Commands.ArgParser do
   - `:default` - Default value if flag not provided
   - `:required` - When `true`, parsing fails if the flag is not provided
   - `:values` - List of allowed values; parsing fails on anything else (enum)
-  - `:transform` - Optional function to transform the value
+  - `:transform` - Optional function to transform the (coerced) value. It may return a
+    bare value, `{:ok, value}`, or `{:error, message}`; the error channel fails parsing
+    with that message, giving single-field validation (e.g. a numeric range) the same
+    failure shape as a type or enum error.
   """
 
   @type flag_type :: :boolean | :string | :integer | :float | :accumulator
+  @type transform :: (term() -> term() | {:ok, term()} | {:error, String.t()})
   @type flag_spec :: [
           short: String.t(),
           long: String.t(),
@@ -49,40 +53,57 @@ defmodule JustBash.Commands.ArgParser do
           default: any(),
           required: boolean(),
           values: [any()],
-          transform: (String.t() -> any())
+          transform: transform()
         ]
   @type flags_spec :: [{atom(), flag_spec()}]
 
   # Parser context struct to reduce function arity
   defmodule Context do
     @moduledoc false
-    defstruct [:short_map, :long_map, :command, :allow_unknown]
+    defstruct [:short_map, :long_map, :command, :allow_unknown, :collect_unknown]
   end
 
   @doc """
   Parse command-line arguments according to the flag specification.
 
   Returns `{:ok, opts_map, positional_args}` or `{:error, message}`.
+
+  ## Options
+
+    * `:command` — name included in error messages (e.g. `"acme pr review"`)
+    * `:allow_unknown` — when `true`, an unrecognized flag is treated as a positional
+      argument instead of an error
+    * `:collect_unknown` — when `true`, unrecognized flags (and, for the bare `--flag value`
+      form, a following non-flag token taken as the flag's value) are collected into a
+      separate ordered list and the call returns a **4-tuple**
+      `{:ok, opts, positional, extra}`. Positionals stay out of `extra`, so a host can
+      forward the raw `extra` tokens to a backend whose flags aren't known at definition
+      time. `--flag=value` is forwarded as a single token.
   """
   @spec parse([String.t()], flags_spec(), keyword()) ::
-          {:ok, map(), [String.t()]} | {:error, String.t()}
+          {:ok, map(), [String.t()]}
+          | {:ok, map(), [String.t()], [String.t()]}
+          | {:error, String.t()}
   def parse(args, flags, opts \\ []) do
     # Build lookup maps for efficient flag matching
     {short_map, long_map} = build_flag_maps(flags)
+    collect_unknown = Keyword.get(opts, :collect_unknown, false)
 
     ctx = %Context{
       short_map: short_map,
       long_map: long_map,
       command: Keyword.get(opts, :command, ""),
-      allow_unknown: Keyword.get(opts, :allow_unknown, false)
+      allow_unknown: Keyword.get(opts, :allow_unknown, false),
+      collect_unknown: collect_unknown
     }
 
     # Parse into a map of only the flags that were actually provided, so we can
     # distinguish "set" from "defaulted" for required-flag checking. Defaults are
     # merged in afterwards.
-    with {:ok, provided, positional} <- parse_loop(args, ctx, %{}, []),
+    with {:ok, provided, positional, extra} <- parse_loop(args, ctx, %{}, [], []),
          :ok <- check_required(flags, provided, ctx.command) do
-      {:ok, merge_defaults(flags, provided), positional}
+      merged = merge_defaults(flags, provided)
+      if collect_unknown, do: {:ok, merged, positional, extra}, else: {:ok, merged, positional}
     end
   end
 
@@ -132,17 +153,17 @@ defmodule JustBash.Commands.ArgParser do
   defp format_required_error(cmd, spec),
     do: "#{cmd}: missing required flag: #{flag_display_name(spec)}\n"
 
-  defp parse_loop([], _ctx, opts, positional) do
-    {:ok, opts, Enum.reverse(positional)}
+  defp parse_loop([], _ctx, opts, positional, extra) do
+    {:ok, opts, Enum.reverse(positional), Enum.reverse(extra)}
   end
 
   # Stop parsing flags after --
-  defp parse_loop(["--" | rest], _ctx, opts, positional) do
-    {:ok, opts, Enum.reverse(positional) ++ rest}
+  defp parse_loop(["--" | rest], _ctx, opts, positional, extra) do
+    {:ok, opts, Enum.reverse(positional) ++ rest, Enum.reverse(extra)}
   end
 
   # Long flag with = value: --flag=value
-  defp parse_loop([<<"--", rest::binary>> = arg | args], ctx, opts, positional) do
+  defp parse_loop([<<"--", rest::binary>> = arg | args], ctx, opts, positional, extra) do
     case String.split(rest, "=", parts: 2) do
       [flag_name, value] ->
         long_flag = "--" <> flag_name
@@ -151,70 +172,99 @@ defmodule JustBash.Commands.ArgParser do
           {name, spec} ->
             case apply_value(opts, name, spec, value) do
               {:ok, new_opts} ->
-                parse_loop(args, ctx, new_opts, positional)
+                parse_loop(args, ctx, new_opts, positional, extra)
 
               {:error, _} = err ->
                 err
             end
 
           nil ->
-            if ctx.allow_unknown do
-              parse_loop(args, ctx, opts, [arg | positional])
-            else
-              {:error, format_unknown_error(ctx.command, arg)}
-            end
+            # `--flag=value` is self-contained — never consume a following token as its value.
+            unknown_self_contained(arg, args, ctx, opts, positional, extra)
         end
 
       [_flag_name] ->
         # No =, regular long flag
-        parse_long_flag(arg, args, ctx, opts, positional)
+        parse_long_flag(arg, args, ctx, opts, positional, extra)
     end
   end
 
   # Short flag
-  defp parse_loop([<<"-", _::binary>> = arg | args], ctx, opts, positional) do
-    parse_short_flag(arg, args, ctx, opts, positional)
+  defp parse_loop([<<"-", _::binary>> = arg | args], ctx, opts, positional, extra) do
+    parse_short_flag(arg, args, ctx, opts, positional, extra)
   end
 
   # Positional argument
-  defp parse_loop([arg | args], ctx, opts, positional) do
-    parse_loop(args, ctx, opts, [arg | positional])
+  defp parse_loop([arg | args], ctx, opts, positional, extra) do
+    parse_loop(args, ctx, opts, [arg | positional], extra)
   end
 
-  defp parse_long_flag(flag, args, ctx, opts, positional) do
+  defp parse_long_flag(flag, args, ctx, opts, positional, extra) do
     case Map.get(ctx.long_map, flag) do
       {name, spec} ->
-        handle_flag(name, spec, args, ctx, opts, positional)
+        handle_flag(name, spec, args, ctx, opts, positional, extra)
 
       nil ->
-        if ctx.allow_unknown do
-          parse_loop(args, ctx, opts, [flag | positional])
-        else
-          {:error, format_unknown_error(ctx.command, flag)}
-        end
+        unknown_valued(flag, args, ctx, opts, positional, extra)
     end
   end
 
-  defp parse_short_flag(flag, args, ctx, opts, positional) do
+  defp parse_short_flag(flag, args, ctx, opts, positional, extra) do
     with nil <- Map.get(ctx.short_map, flag),
          nil <- Map.get(ctx.long_map, flag) do
-      handle_unknown_short_flag(flag, args, ctx, opts, positional)
+      handle_unknown_short_flag(flag, args, ctx, opts, positional, extra)
     else
-      {name, spec} -> handle_flag(name, spec, args, ctx, opts, positional)
+      {name, spec} -> handle_flag(name, spec, args, ctx, opts, positional, extra)
     end
   end
 
-  defp handle_unknown_short_flag(flag, args, ctx, opts, positional) do
+  defp handle_unknown_short_flag(flag, args, ctx, opts, positional, extra) do
     case expand_combined_flags(flag, ctx) do
       {:ok, expanded} ->
-        parse_loop(expanded ++ args, ctx, opts, positional)
+        parse_loop(expanded ++ args, ctx, opts, positional, extra)
 
       :error ->
-        if ctx.allow_unknown,
-          do: parse_loop(args, ctx, opts, [flag | positional]),
-          else: {:error, format_unknown_error(ctx.command, flag)}
+        unknown_valued(flag, args, ctx, opts, positional, extra)
     end
   end
+
+  # An unrecognized self-contained token (`--flag=value`). In collect mode it is forwarded
+  # verbatim to `extra`; in allow mode it becomes a positional; otherwise it's an error.
+  defp unknown_self_contained(arg, args, ctx, opts, positional, extra) do
+    cond do
+      ctx.collect_unknown -> parse_loop(args, ctx, opts, positional, [arg | extra])
+      ctx.allow_unknown -> parse_loop(args, ctx, opts, [arg | positional], extra)
+      true -> {:error, format_unknown_error(ctx.command, arg)}
+    end
+  end
+
+  # An unrecognized bare flag (`--flag` or `-x`). In collect mode it is forwarded to `extra`
+  # along with a following non-flag token taken as its value (the `--flag value` passthrough
+  # form); in allow mode it becomes a positional; otherwise it's an error.
+  defp unknown_valued(flag, args, ctx, opts, positional, extra) do
+    cond do
+      ctx.collect_unknown ->
+        {extra, args} = consume_passthrough_value(flag, args, extra)
+        parse_loop(args, ctx, opts, positional, extra)
+
+      ctx.allow_unknown ->
+        parse_loop(args, ctx, opts, [flag | positional], extra)
+
+      true ->
+        {:error, format_unknown_error(ctx.command, flag)}
+    end
+  end
+
+  # Forward `flag`, plus the next token as its value when that token isn't itself a flag.
+  # `extra` is built reversed, so prepend value-then-flag to keep `[flag, value]` order.
+  defp consume_passthrough_value(flag, [<<"-", _::binary>> | _] = args, extra),
+    do: {[flag | extra], args}
+
+  defp consume_passthrough_value(flag, [value | rest], extra),
+    do: {[value, flag | extra], rest}
+
+  defp consume_passthrough_value(flag, [] = args, extra),
+    do: {[flag | extra], args}
 
   # Expand combined short flags like -fsSL into [-f, -s, -S, -L].
   # Only succeeds if ALL letters map to known boolean short flags.
@@ -237,18 +287,18 @@ defmodule JustBash.Commands.ArgParser do
 
   defp expand_combined_flags(_, _ctx), do: :error
 
-  defp handle_flag(name, spec, args, ctx, opts, positional) do
+  defp handle_flag(name, spec, args, ctx, opts, positional, extra) do
     case spec[:type] do
       :boolean ->
         new_opts = Map.put(opts, name, true)
-        parse_loop(args, ctx, new_opts, positional)
+        parse_loop(args, ctx, new_opts, positional, extra)
 
       type when type in [:string, :integer, :float, :accumulator] ->
         case args do
           [value | rest] ->
             case apply_value(opts, name, spec, value) do
               {:ok, new_opts} ->
-                parse_loop(rest, ctx, new_opts, positional)
+                parse_loop(rest, ctx, new_opts, positional, extra)
 
               {:error, _} = err ->
                 err
@@ -262,7 +312,7 @@ defmodule JustBash.Commands.ArgParser do
 
   defp apply_value(opts, name, spec, value) do
     with {:ok, typed} <- coerce_value(spec[:type], value),
-         transformed = apply_transform(spec, typed),
+         {:ok, transformed} <- apply_transform(spec, typed),
          :ok <- check_enum(spec, transformed) do
       {:ok, store_value(opts, name, spec, transformed)}
     end
@@ -316,11 +366,25 @@ defmodule JustBash.Commands.ArgParser do
     end
   end
 
+  # A transform may return a bare value (legacy), `{:ok, value}`, or `{:error, message}`.
+  # The error channel lets a single-field validation (e.g. a numeric range) fail with the
+  # same shape as a type/enum error, so it flows through the caller's `with`.
   defp apply_transform(spec, value) do
     case spec[:transform] do
-      nil -> value
-      fun when is_function(fun, 1) -> fun.(value)
+      nil ->
+        {:ok, value}
+
+      fun when is_function(fun, 1) ->
+        case fun.(value) do
+          {:ok, transformed} -> {:ok, transformed}
+          {:error, message} when is_binary(message) -> {:error, ensure_newline(message)}
+          bare -> {:ok, bare}
+        end
     end
+  end
+
+  defp ensure_newline(message) do
+    if String.ends_with?(message, "\n"), do: message, else: message <> "\n"
   end
 
   defp format_unknown_error("", flag), do: "unknown option: #{flag}\n"

--- a/test/cli/authorization_test.exs
+++ b/test/cli/authorization_test.exs
@@ -1,0 +1,85 @@
+defmodule JustBash.CLI.AuthorizationTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.CLI
+  alias JustBash.Commands.Command
+
+  # `admin` group is present only when bash.context.admin is true. `whoami` is always present.
+  defp acme do
+    CLI.new("acme",
+      doc: "Acme toolkit",
+      commands: [
+        CLI.command("whoami",
+          doc: "Print the current user",
+          run: fn inv -> {Command.ok("#{inv.bash.context.user}\n"), inv.bash} end
+        ),
+        CLI.command("admin",
+          doc: "Privileged operations",
+          visible?: fn bash -> bash.context[:admin] == true end,
+          commands: [
+            CLI.command("rotate",
+              doc: "Rotate secrets",
+              run: fn inv -> {Command.ok("rotated\n"), inv.bash} end
+            )
+          ]
+        )
+      ]
+    )
+  end
+
+  defp run(script, context) do
+    bash = JustBash.new(commands: %{"acme" => acme()}, context: context)
+    {result, _bash} = JustBash.exec(bash, script)
+    result
+  end
+
+  describe "routing under a visibility predicate" do
+    test "a hidden subtree is routable for an authorized caller" do
+      result = run("acme admin rotate", %{user: "dave", admin: true})
+      assert result.exit_code == 0
+      assert result.stdout == "rotated\n"
+    end
+
+    test "a hidden subtree is genuinely absent (unknown command) for an unauthorized caller" do
+      result = run("acme admin rotate", %{user: "dave", admin: false})
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown command 'admin'"
+    end
+
+    test "always-visible commands work regardless of context" do
+      assert run("acme whoami", %{user: "dave", admin: false}).stdout == "dave\n"
+    end
+  end
+
+  describe "help reflects visibility" do
+    test "an unauthorized caller does not see the hidden group in --help" do
+      result = run("acme --help", %{user: "dave", admin: false})
+      assert result.stdout =~ "whoami"
+      refute result.stdout =~ "admin"
+    end
+
+    test "an authorized caller sees the hidden group in --help" do
+      result = run("acme --help", %{user: "dave", admin: true})
+      assert result.stdout =~ "admin"
+    end
+  end
+
+  describe "describe/2 reflects visibility" do
+    test "filters by the given caller's context" do
+      bash_user = JustBash.new(context: %{user: "dave", admin: false})
+      bash_admin = JustBash.new(context: %{user: "dave", admin: true})
+
+      user_paths = CLI.describe(acme(), bash_user).commands |> Enum.map(& &1.path)
+      admin_paths = CLI.describe(acme(), bash_admin).commands |> Enum.map(& &1.path)
+
+      refute ["admin", "rotate"] in user_paths
+      assert ["admin", "rotate"] in admin_paths
+    end
+
+    test "describe/1 with no bash shows every command" do
+      paths = CLI.describe(acme()).commands |> Enum.map(& &1.path)
+      assert ["admin", "rotate"] in paths
+      assert ["whoami"] in paths
+    end
+  end
+end

--- a/test/cli/help_test.exs
+++ b/test/cli/help_test.exs
@@ -28,6 +28,10 @@ defmodule JustBash.CLI.HelpTest do
             CLI.command("open",
               doc: "Open a pull request",
               args: [%{name: :id, required: true, doc: "PR id"}],
+              examples: [
+                "acme pr open 123",
+                %{cmd: "acme pr open 456", doc: "open PR 456"}
+              ],
               run: fn inv -> {Command.ok("ok\n"), inv.bash} end
             )
           ]
@@ -105,6 +109,48 @@ defmodule JustBash.CLI.HelpTest do
       assert result.stdout =~ "Arguments:"
       assert result.stdout =~ "<id>"
       assert result.stdout =~ "PR id (required)"
+    end
+
+    test "lists worked examples" do
+      result = run("acme pr open --help")
+      assert result.stdout =~ "Examples:"
+      assert result.stdout =~ "acme pr open 123"
+      assert result.stdout =~ "acme pr open 456"
+      assert result.stdout =~ "open PR 456"
+    end
+  end
+
+  describe "on_missing_subcommand" do
+    defp help_group_cli do
+      CLI.new("acme",
+        commands: [
+          CLI.command("pr",
+            doc: "Pull request management",
+            on_missing_subcommand: :help,
+            commands: [
+              CLI.command("list",
+                doc: "List PRs",
+                run: fn inv -> {Command.ok("l\n"), inv.bash} end
+              )
+            ]
+          )
+        ]
+      )
+    end
+
+    test "a bare group with :help prints the listing at exit 0" do
+      {result, _bash} =
+        JustBash.exec(JustBash.new(commands: %{"acme" => help_group_cli()}), "acme pr")
+
+      assert result.exit_code == 0
+      assert result.stdout =~ "Usage: acme pr <command> [args]"
+      assert result.stdout =~ "list"
+    end
+
+    test "the default :error still exits 2 with a missing-subcommand message" do
+      result = run("acme pr")
+      assert result.exit_code == 2
+      assert result.stderr =~ "missing subcommand"
     end
   end
 

--- a/test/cli/introspection_test.exs
+++ b/test/cli/introspection_test.exs
@@ -23,9 +23,16 @@ defmodule JustBash.CLI.IntrospectionTest do
             CLI.command("open",
               doc: "Open a PR",
               args: [%{name: :id, required: true, doc: "PR id"}],
+              examples: [%{cmd: "acme pr open 123", doc: "open PR 123"}],
               run: fn inv -> {Command.ok(), inv.bash} end
             )
           ]
+        ),
+        CLI.command("run",
+          doc: "Run, forwarding backend flags",
+          args: [%{name: :target, required: true}],
+          allow_unknown_flags: true,
+          run: fn inv -> {Command.ok(), inv.bash} end
         ),
         CLI.command("whoami", doc: "Print user", run: fn inv -> {Command.ok(), inv.bash} end)
       ]
@@ -42,7 +49,16 @@ defmodule JustBash.CLI.IntrospectionTest do
 
     test "flattens leaves with full invocation paths" do
       paths = CLI.describe(acme()).commands |> Enum.map(& &1.path)
-      assert paths == [["pr", "review"], ["pr", "open"], ["whoami"]]
+      assert paths == [["pr", "review"], ["pr", "open"], ["run"], ["whoami"]]
+    end
+
+    test "surfaces examples and allow_unknown_flags per leaf" do
+      open = CLI.describe(acme()).commands |> Enum.find(&(&1.path == ["pr", "open"]))
+      assert open.examples == [%{cmd: "acme pr open 123", doc: "open PR 123"}]
+      assert open.allow_unknown_flags == false
+
+      run = CLI.describe(acme()).commands |> Enum.find(&(&1.path == ["run"]))
+      assert run.allow_unknown_flags == true
     end
 
     test "resolves flag specs into plain maps with derived long forms" do
@@ -82,6 +98,12 @@ defmodule JustBash.CLI.IntrospectionTest do
       assert md =~ "## acme pr open"
       assert md =~ "| Argument | Required | Description |"
       assert md =~ "| `id` | yes | PR id |"
+    end
+
+    test "markdown format includes worked examples" do
+      md = CLI.render_docs(acme(), format: :markdown)
+      assert md =~ "**Examples:**"
+      assert md =~ "- `acme pr open 123` — open PR 123"
     end
   end
 end

--- a/test/cli/invoke_test.exs
+++ b/test/cli/invoke_test.exs
@@ -1,0 +1,51 @@
+defmodule JustBash.CLI.InvokeTest do
+  use ExUnit.Case, async: true
+
+  alias JustBash.CLI
+  alias JustBash.Commands.Command
+
+  defp acme do
+    CLI.new("acme",
+      commands: [
+        CLI.command("pr",
+          doc: "PRs",
+          commands: [
+            CLI.command("review",
+              flags: [
+                report: [type: :integer, required: true],
+                format: [type: :string, default: "text", values: ~w(text json)]
+              ],
+              run: fn inv ->
+                {Command.ok("report=#{inv.flags.report} format=#{inv.flags.format}\n"), inv.bash}
+              end
+            )
+          ]
+        )
+      ]
+    )
+  end
+
+  test "invokes a leaf by explicit path and merges flag defaults" do
+    bash = JustBash.new()
+    {result, _bash} = CLI.invoke(acme(), ["pr", "review"], ["--report", "7"], bash)
+    assert result.exit_code == 0
+    # `format` came through as its default, not nil — the surprise a hand-built Invocation hits.
+    assert result.stdout == "report=7 format=text\n"
+  end
+
+  test "surfaces parse errors the same way run/4 does (exit 2 + usage)" do
+    bash = JustBash.new()
+    {result, _bash} = CLI.invoke(acme(), ["pr", "review"], [], bash)
+    assert result.exit_code == 2
+    assert result.stderr =~ "missing required flag: --report"
+    assert result.stderr =~ "Usage: acme pr review"
+  end
+
+  test "raises when the path is not a leaf" do
+    bash = JustBash.new()
+
+    assert_raise ArgumentError, ~r/is not a leaf command/, fn ->
+      CLI.invoke(acme(), ["pr"], [], bash)
+    end
+  end
+end

--- a/test/cli/routing_test.exs
+++ b/test/cli/routing_test.exs
@@ -157,6 +157,109 @@ defmodule JustBash.CLI.RoutingTest do
     end
   end
 
+  describe "passthrough flags" do
+    defp passthrough_cli do
+      CLI.new("acme",
+        commands: [
+          CLI.command("run",
+            doc: "Run on a target, forwarding backend flags",
+            args: [%{name: :target, required: true}],
+            allow_unknown_flags: true,
+            flags: [verbose: [type: :boolean, short: "-v"]],
+            run: fn inv ->
+              {Command.ok("target=#{hd(inv.args)} extra=#{inspect(inv.extra_flags)}\n"), inv.bash}
+            end
+          )
+        ]
+      )
+    end
+
+    defp run_pt(script) do
+      bash = JustBash.new(commands: %{"acme" => passthrough_cli()})
+      {result, _bash} = JustBash.exec(bash, script)
+      result
+    end
+
+    test "collects undeclared flags into extra_flags, keeping positionals clean" do
+      result = run_pt("acme run target --some-dynamic-flag value")
+      assert result.exit_code == 0
+      assert result.stdout == ~s(target=target extra=["--some-dynamic-flag", "value"]\n)
+    end
+
+    test "still parses declared flags normally" do
+      result = run_pt("acme run target -v --dyn x")
+      assert result.exit_code == 0
+      assert result.stdout == ~s(target=target extra=["--dyn", "x"]\n)
+    end
+
+    test "an undeclared flag still errors when allow_unknown_flags is not set" do
+      result = run("acme pr review --report 1 --bogus x")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: --bogus"
+    end
+  end
+
+  describe "command-level validation" do
+    defp validating_cli do
+      CLI.new("acme",
+        commands: [
+          CLI.command("book",
+            doc: "Book a range",
+            flags: [
+              start: [type: :integer, required: true, long: "--start"],
+              finish: [type: :integer, required: true, long: "--finish"]
+            ],
+            validate: fn inv ->
+              if inv.flags.start <= inv.flags.finish,
+                do: :ok,
+                else: {:error, "acme book: --start must be <= --finish"}
+            end,
+            run: fn inv -> {Command.ok("booked\n"), inv.bash} end
+          )
+        ]
+      )
+    end
+
+    defp run_val(script) do
+      bash = JustBash.new(commands: %{"acme" => validating_cli()})
+      {result, _bash} = JustBash.exec(bash, script)
+      result
+    end
+
+    test "an :ok validation proceeds to the handler" do
+      result = run_val("acme book --start 1 --finish 5")
+      assert result.exit_code == 0
+      assert result.stdout == "booked\n"
+    end
+
+    test "an {:error, msg} validation exits 2 with a usage line" do
+      result = run_val("acme book --start 5 --finish 1")
+      assert result.exit_code == 2
+      assert result.stderr =~ "--start must be <= --finish"
+      assert result.stderr =~ "Usage: acme book"
+    end
+
+    test "validation runs after defaults are merged" do
+      cli =
+        CLI.new("acme",
+          commands: [
+            CLI.command("go",
+              flags: [mode: [type: :string, default: "fast"]],
+              validate: fn inv ->
+                if inv.flags.mode == "fast", do: :ok, else: {:error, "bad mode"}
+              end,
+              run: fn inv -> {Command.ok("#{inv.flags.mode}\n"), inv.bash} end
+            )
+          ]
+        )
+
+      bash = JustBash.new(commands: %{"acme" => cli})
+      {result, _bash} = JustBash.exec(bash, "acme go")
+      assert result.exit_code == 0
+      assert result.stdout == "fast\n"
+    end
+  end
+
   describe "crash isolation" do
     test "a crashing handler is caught and turned into an error" do
       cli =

--- a/test/cli/routing_test.exs
+++ b/test/cli/routing_test.exs
@@ -197,6 +197,22 @@ defmodule JustBash.CLI.RoutingTest do
       assert result.exit_code == 2
       assert result.stderr =~ "unknown option: --bogus"
     end
+
+    # Documented limitation: an unknown `--flag` consumes the following non-flag token as its
+    # value, so a positional placed *after* a passthrough flag is swallowed into extra_flags.
+    # The convention (positionals first, or `--flag=value`) avoids this; the test pins the
+    # behavior so a change to the heuristic is a deliberate, visible decision.
+    test "a positional after a passthrough flag is swallowed (declare positionals first)" do
+      result = run_pt("acme run --dyn target")
+      assert result.exit_code == 2
+      assert result.stderr =~ "missing required argument"
+    end
+
+    test "--flag=value form does not swallow a following positional" do
+      result = run_pt("acme run --dyn=value target")
+      assert result.exit_code == 0
+      assert result.stdout == ~s(target=target extra=["--dyn=value"]\n)
+    end
   end
 
   describe "command-level validation" do
@@ -257,6 +273,23 @@ defmodule JustBash.CLI.RoutingTest do
       {result, _bash} = JustBash.exec(bash, "acme go")
       assert result.exit_code == 0
       assert result.stdout == "fast\n"
+    end
+
+    test "a :validate returning a malformed value raises a clear, CLI-attributed error" do
+      cli =
+        CLI.new("acme",
+          commands: [
+            CLI.command("go",
+              validate: fn _inv -> :nope end,
+              run: fn inv -> {Command.ok(), inv.bash} end
+            )
+          ]
+        )
+
+      bash = JustBash.new(commands: %{"acme" => cli})
+      {result, _bash} = JustBash.exec(bash, "acme go")
+      assert result.exit_code == 1
+      assert result.stderr =~ ":validate must return :ok or {:error, message"
     end
   end
 

--- a/test/commands/arg_parser_test.exs
+++ b/test/commands/arg_parser_test.exs
@@ -103,6 +103,57 @@ defmodule JustBash.Commands.ArgParserTest do
     end
   end
 
+  describe "parse/3 with collect_unknown" do
+    test "returns a 4-tuple collecting unknown flags into extra" do
+      {:ok, opts, positional, extra} =
+        ArgParser.parse(["-v", "target", "--dyn", "x"], @basic_flags, collect_unknown: true)
+
+      assert opts.verbose == true
+      assert positional == ["target"]
+      assert extra == ["--dyn", "x"]
+    end
+
+    test "forwards --flag=value as a single token" do
+      {:ok, _opts, _positional, extra} =
+        ArgParser.parse(["--dyn=x"], @basic_flags, collect_unknown: true)
+
+      assert extra == ["--dyn=x"]
+    end
+
+    test "does not consume a following flag as a value" do
+      {:ok, opts, _positional, extra} =
+        ArgParser.parse(["--dyn", "-v"], @basic_flags, collect_unknown: true)
+
+      assert opts.verbose == true
+      assert extra == ["--dyn"]
+    end
+
+    test "collects unknown short flags and their value" do
+      {:ok, _opts, positional, extra} =
+        ArgParser.parse(["target", "-Z", "val"], @basic_flags, collect_unknown: true)
+
+      assert positional == ["target"]
+      assert extra == ["-Z", "val"]
+    end
+
+    test "known flags and positionals stay out of extra" do
+      {:ok, opts, positional, extra} =
+        ArgParser.parse(["-o", "out", "file", "--dyn", "v"], @basic_flags, collect_unknown: true)
+
+      assert opts.output == "out"
+      assert positional == ["file"]
+      assert extra == ["--dyn", "v"]
+    end
+
+    test "no unknown flags yields an empty extra list" do
+      {:ok, _opts, positional, extra} =
+        ArgParser.parse(["-v", "file"], @basic_flags, collect_unknown: true)
+
+      assert positional == ["file"]
+      assert extra == []
+    end
+  end
+
   describe "parse/3 special cases" do
     test "stops parsing flags after --" do
       {:ok, opts, positional} =
@@ -140,6 +191,35 @@ defmodule JustBash.Commands.ArgParserTest do
     ]
 
     test "applies transform function to value" do
+      {:ok, opts, _} = ArgParser.parse(["-X", "post"], @transform_flags)
+      assert opts.method == "POST"
+    end
+  end
+
+  describe "transform error channel" do
+    defp ratio_flags do
+      [
+        ratio: [
+          long: "--ratio",
+          type: :float,
+          transform: fn f ->
+            if f >= 0.0 and f <= 1.0, do: {:ok, f}, else: {:error, "ratio must be in 0.0..1.0"}
+          end
+        ]
+      ]
+    end
+
+    test "returns the value when transform returns {:ok, v}" do
+      {:ok, opts, _} = ArgParser.parse(["--ratio", "0.5"], ratio_flags())
+      assert opts.ratio == 0.5
+    end
+
+    test "errors when transform returns {:error, msg}" do
+      assert {:error, msg} = ArgParser.parse(["--ratio", "2.0"], ratio_flags())
+      assert msg =~ "ratio must be in 0.0..1.0"
+    end
+
+    test "still supports a bare-value transform" do
       {:ok, opts, _} = ArgParser.parse(["-X", "post"], @transform_flags)
       assert opts.method == "POST"
     end

--- a/test/commands/arg_parser_test.exs
+++ b/test/commands/arg_parser_test.exs
@@ -223,6 +223,14 @@ defmodule JustBash.Commands.ArgParserTest do
       {:ok, opts, _} = ArgParser.parse(["-X", "post"], @transform_flags)
       assert opts.method == "POST"
     end
+
+    test "raises when transform returns {:error, non_binary} rather than silently passing it" do
+      flags = [n: [long: "--n", type: :integer, transform: fn _ -> {:error, :not_a_string} end]]
+
+      assert_raise ArgumentError, ~r/error message must be a String\.t\(\)/, fn ->
+        ArgParser.parse(["--n", "1"], flags)
+      end
+    end
   end
 
   describe "float type" do


### PR DESCRIPTION
Addresses the feedback from the first real consumer of `JustBash.CLI` in #38.

## The four real gaps

1. **Passthrough flags (#1)** — `command("run", allow_unknown_flags: true, ...)` collects undeclared flags into a new `Invocation.extra_flags` raw token list, keeping declared positionals clean in `args`. Backed by a `collect_unknown: true` mode in `ArgParser.parse/3` that returns a 4-tuple; the existing 3-tuple path is unchanged for all current callers.
2. **Validation + unified errors (#3)** — a command-level `:validate` callback `(Invocation -> :ok | {:error, msg})` runs after parsing / before the handler and produces the **same** exit-2 + `Usage:` line as a flag error. A flag `:transform` may now also return `{:error, msg}` for single-field checks (e.g. a numeric range), flowing through the same path.
3. **Visibility / authorization (#2)** — a declarative `visible?: fn bash -> ... end` predicate prunes the tree once in `run/4`, so a gated subtree is genuinely *absent* (reported as an unknown command, omitted from `--help` and `describe/2`). The context-driven struct-building pattern is documented as the first-class auth story.
4. **First-class `:examples` (#4)** — surfaced in `--help`, `describe/1`, and `render_docs` (text + markdown).

## Smaller ergonomics (all)

- **`CLI.invoke/5`** test helper that builds the `Invocation` the same way `run/4` does (merging flag defaults), so handler-level tests don't hit `nil` defaults.
- **`:on_missing_subcommand`** (`:error` default | `:help`) — a bare group can print its listing at exit 0.
- Doc notes: the `__subcommand__` key visible to direct `run/4`/`invoke/5` callers, and reserved-word flag names needing an explicit `:long`. README updated with every new option.

## Design note for review

The `extra_flags` heuristic consumes one following non-`-` token as an unknown flag's value (so `--dyn value` forwards as `["--dyn", "value"]`). Documented convention: declared positionals before passthrough flags, prefer `--flag=value`. If the ambiguity bites, the fallback is to collect only flag-shaped tokens and require `--flag=value`.

## Testing

All five gates pass: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix test` (3671 tests, 0 failures), `mix credo --strict` (only the pre-existing intentional fixture finding), `mix dialyzer` (0 new errors). New/expanded tests cover passthrough flags, `:validate` / transform error channel, visibility pruning + `describe/2`, examples in help/describe/docs, `invoke/5`, and `:on_missing_subcommand`.