### PR TITLE
fix: printf %b support and no-progress guard against format-recycle hangs

### DIFF
--- a/lib/just_bash/commands/echo.ex
+++ b/lib/just_bash/commands/echo.ex
@@ -35,7 +35,11 @@ defmodule JustBash.Commands.Echo do
 
   defp parse_flags(rest, flags), do: {flags, rest}
 
-  defp interpret_escapes(str) do
+  # Also used by printf's %b directive, which shares echo -e's escape
+  # dialect (\0NNN octals, unlike $'...' ANSI-C quoting's \NNN).
+  @doc false
+  @spec interpret_escapes(String.t()) :: binary()
+  def interpret_escapes(str) do
     do_interpret_escapes(str, "")
   end
 

--- a/lib/just_bash/commands/printf.ex
+++ b/lib/just_bash/commands/printf.ex
@@ -3,8 +3,9 @@ defmodule JustBash.Commands.Printf do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.Echo
 
-  @format_regex ~r/%(-)?(0)?(\d+)?(?:\.(\d+))?([sdxXofec%])/
+  @format_regex ~r/%(-)?(0)?(\d+)?(?:\.(\d+))?([sdxXofecb%])/
 
   @impl true
   def names, do: ["printf"]
@@ -42,7 +43,14 @@ defmodule JustBash.Commands.Printf do
 
   defp recycle_format(format, args, acc) do
     {result, remaining} = apply_formats_with_remaining(format, args)
-    recycle_format(format, remaining, [result | acc])
+
+    if length(remaining) < length(args) do
+      recycle_format(format, remaining, [result | acc])
+    else
+      # A pass that consumed no arguments (an unrecognized directive) must
+      # not recycle the format forever.
+      recycle_format(format, [], [result | acc])
+    end
   end
 
   defp apply_formats_with_remaining(format, args) do
@@ -95,6 +103,10 @@ defmodule JustBash.Commands.Printf do
     formatted = do_format(spec, "", precision)
     padded = apply_width(formatted, left_align, zero_pad, width)
     {padded, []}
+  end
+
+  defp do_format("b", arg, _precision) do
+    Echo.interpret_escapes(arg)
   end
 
   defp do_format("s", arg, precision) do

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -136,6 +136,36 @@ defmodule JustBash.Commands.UtilitiesTest do
       assert result.stdout == "a\tb"
     end
 
+    test "printf %b expands escape sequences in the argument" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, ~S[printf "%b" "A\tB\n"])
+      assert result.stdout == "A\tB\n"
+      assert result.exit_code == 0
+    end
+
+    @tag timeout: 5_000
+    test "printf %b with hex escapes emits raw bytes and terminates" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, ~S[printf "%b" "A\xffB\n"])
+      assert result.stdout == <<?A, 0xFF, ?B, ?\n>>
+    end
+
+    test "printf %b recycles the format across arguments" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, ~S[printf "%b\n" "a\tb" "c"])
+      assert result.stdout == "a\tb\nc\n"
+    end
+
+    # Bash errors on unknown directives; we pass them through literally.
+    # Either way, a directive that consumes no argument must not recycle
+    # the format forever.
+    @tag timeout: 5_000
+    test "printf with an unrecognized directive terminates instead of looping" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, ~S[printf "%v\n" x])
+      assert result.stdout == "%v\n"
+    end
+
     test "printf with %x hex format" do
       bash = JustBash.new()
       {result, _} = JustBash.exec(bash, "printf '%x' 255")


### PR DESCRIPTION
Found while running agents against the sandbox: `printf "%b" "A\xffB\n"` — an ordinary command any agent will eventually type — hung `JustBash.exec/2` forever. An untrusted script could take down the host with one line.

`printf` recycles its format string while arguments remain, but `%b` was not in the format regex, so each recycle pass consumed zero arguments and recursed with the same list. The same hang fired for any unrecognized directive with at least one argument (`%q`, `%v`, `%i`, …).

Two changes:
- **`%b` is now a real directive**, sharing `echo -e`'s escape dialect (`\n`, `\t`, `\xHH`, `\0NNN` — exposed as `Echo.interpret_escapes/1`), so `printf "%b" "A\xffB\n"` emits the raw bytes bash does.
- **A recycle pass that consumes no arguments stops after one iteration** — the hang class is closed for every unknown directive, present and future. Unknown directives pass through literally where bash reports `invalid format character`; the divergence is noted in the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpxHS5iGm9ktgpnL9QZu9x