### PR TITLE
docs: organize the ExDoc sidebar and fix awk type-reference warnings

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,10 +1,7 @@
 [
-  # AWK parser/evaluator type specs use internal types
-  {"lib/just_bash/commands/awk/evaluator.ex", :unknown_type},
   # file_outputs key is always present in initial state (line 52) but dialyzer
   # can't infer it through all execute_statement clause paths
   {"lib/just_bash/commands/awk/evaluator.ex", :map_update},
-  {"lib/just_bash/commands/awk/parser.ex", :unknown_type},
   # jq AST node types: parser produces :module_directives and :def tuples that
   # dialyzer can't infer from its analysis of the parser return type
   {"lib/just_bash/commands/jq/evaluator.ex", :pattern_match},
@@ -13,11 +10,10 @@
   {"lib/just_bash/commands/jq/evaluator/functions.ex", :pattern_match},
   # vfs 0.1 does not include :enotempty in VFS.Error's kind union, but POSIX
   # rm of a non-empty directory needs it (rmdir(2) ENOTEMPTY). We construct
-  # and match it anyway — VFS.Error.new/2 doesn't validate kinds at runtime —
-  # and have proposed adding :enotempty to the union in vfs 0.2. Remove both
-  # skips when vfs ships it.
+  # it anyway — VFS.Error.new/2 doesn't validate kinds at runtime — and have
+  # proposed adding :enotempty to the union in vfs 0.2. Remove this skip when
+  # vfs ships it.
   {"lib/just_bash/fs/memory.ex", :call},
-  {"lib/just_bash/commands/rm.ex", :pattern_match},
   # format_array_key catch-all handles any type defensively, but dialyzer infers
   # callers only pass float/integer/binary values covered by earlier clauses
   {"lib/just_bash/commands/awk/evaluator.ex", :pattern_match_cov},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,46 @@ jobs:
       - name: Run Credo
         run: mix credo
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    env:
+      # ex_doc is a dev-only dependency, so this job overrides the
+      # workflow-level MIX_ENV: test.
+      MIX_ENV: dev
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "28"
+
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-docs-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-docs-
+
+      - name: Cache _build
+        uses: actions/cache@v4
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-docs-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-docs-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Generate docs
+        run: mix docs --warnings-as-errors
+
   dialyzer:
     name: Dialyzer
     runs-on: ubuntu-latest

--- a/lib/just_bash/commands/awk/ast.ex
+++ b/lib/just_bash/commands/awk/ast.ex
@@ -5,6 +5,114 @@ defmodule JustBash.Commands.Awk.AST do
   Produces AST in the format expected by the evaluator.
   """
 
+  @typedoc """
+  An AWK expression AST node.
+
+  Produced by `JustBash.Commands.Awk.Parser` expression parsing and consumed by
+  `JustBash.Commands.Awk.Evaluator.evaluate_expression/2`.
+  """
+  @type expr ::
+          {:literal, String.t()}
+          | {:number, number()}
+          | {:field, integer()}
+          | {:field_var, String.t()}
+          | {:field_expr, expr()}
+          | {:variable, String.t()}
+          | {:regex, String.t()}
+          | {:array_access, String.t(), expr()}
+          | {:add, expr(), expr()}
+          | {:sub, expr(), expr()}
+          | {:mul, expr(), expr()}
+          | {:div, expr(), expr()}
+          | {:mod, expr(), expr()}
+          | {:pow, expr(), expr()}
+          | {:==, expr(), expr()}
+          | {:!=, expr(), expr()}
+          | {:<, expr(), expr()}
+          | {:>, expr(), expr()}
+          | {:<=, expr(), expr()}
+          | {:>=, expr(), expr()}
+          | {:match, expr(), expr()}
+          | {:not_match, expr(), expr()}
+          | {:and, expr(), expr()}
+          | {:or, expr(), expr()}
+          | {:concat, expr(), expr()}
+          | {:not, expr()}
+          | {:negate, expr()}
+          | {:ternary, expr(), expr(), expr()}
+          | {:assign, String.t(), expr()}
+          | {:array_assign, String.t(), expr(), expr()}
+          | {:field_assign, expr(), expr()}
+          | {:add_assign, String.t(), expr()}
+          | {:array_add_assign, String.t(), expr(), expr()}
+          | {:sub_assign, String.t(), expr()}
+          | {:mul_assign, String.t(), expr()}
+          | {:div_assign, String.t(), expr()}
+          | {:mod_assign, String.t(), expr()}
+          | {:pow_assign, String.t(), expr()}
+          | {:pre_increment, String.t()}
+          | {:array_pre_increment, String.t(), expr()}
+          | {:increment, String.t()}
+          | {:array_increment, String.t(), expr()}
+          | {:pre_decrement, String.t()}
+          | {:array_pre_decrement, String.t(), expr()}
+          | {:decrement, String.t()}
+          | {:array_decrement, String.t(), expr()}
+          | {:call, String.t(), [expr()]}
+          | {:in, expr(), String.t()}
+          | {:getline, String.t() | nil, expr() | nil, term()}
+
+  @typedoc "A parsed `{ ... }` block: a list of statements."
+  @type block :: %{statements: [stmt()]}
+
+  @typedoc "The argument list to a `print`/`printf` statement."
+  @type print_args :: {:comma_sep, [expr()]} | {:concat, [expr()]} | [expr()]
+
+  @typedoc """
+  An AWK statement AST node.
+
+  Produced by `JustBash.Commands.Awk.Parser` statement parsing and consumed by
+  the (private) statement executor in `JustBash.Commands.Awk.Evaluator`.
+  """
+  @type stmt ::
+          block()
+          | {:print, print_args()}
+          | {:print_redirect, print_args(), expr()}
+          | {:print_append, print_args(), expr()}
+          | {:printf, {String.t(), [expr()]}}
+          | {:printf_redirect, {String.t(), [expr()]}, expr()}
+          | {:printf_append, {String.t(), [expr()]}, expr()}
+          | {:if, expr(), stmt(), stmt() | nil}
+          | {:while, expr(), [stmt()]}
+          | {:do_while, [stmt()], expr()}
+          | {:for, expr() | nil, expr() | nil, expr() | nil, [stmt()]}
+          | {:for_in, String.t(), String.t(), [stmt()]}
+          | {:break}
+          | {:continue}
+          | {:next}
+          | {:exit, expr() | non_neg_integer()}
+          | {:return, expr() | nil}
+          | {:delete_element, String.t(), expr()}
+          | {:delete_array, String.t()}
+          | expr()
+
+  @typedoc """
+  A rule pattern: unconditional (`nil`), a bare regex matched against `$0`,
+  a boolean condition expression, or a range between two patterns.
+  """
+  @type pattern ::
+          nil | {:regex, String.t()} | {:condition, expr()} | {:range, pattern(), pattern()}
+
+  @typedoc """
+  A parsed AWK program, as produced by `JustBash.Commands.Awk.Parser.parse/1`
+  and consumed by `JustBash.Commands.Awk.Evaluator.execute/2`.
+  """
+  @type program :: %{
+          begin_blocks: [[stmt()]],
+          end_blocks: [[stmt()]],
+          main_rules: [{pattern(), [stmt()]}]
+        }
+
   # ─── Program Structure ────────────────────────────────────────────
   # Evaluator expects: %{begin_blocks: [[stmt]], end_blocks: [[stmt]], main_rules: [{pattern, [stmt]}]}
 

--- a/lib/just_bash/commands/awk/evaluator.ex
+++ b/lib/just_bash/commands/awk/evaluator.ex
@@ -6,7 +6,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   and producing output.
   """
 
-  alias JustBash.Commands.Awk.{Formatter, Parser}
+  alias JustBash.Commands.Awk.{AST, Formatter}
   alias JustBash.FS
   alias JustBash.Limit
 
@@ -31,7 +31,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
 
   Returns {output, exit_code, file_outputs, bash}.
   """
-  @spec execute(Parser.program(), map()) ::
+  @spec execute(AST.program(), map()) ::
           {String.t(), non_neg_integer(), map(), JustBash.t() | nil}
   def execute(program, opts) do
     file_data = Map.get(opts, :files, [{"", ""}])
@@ -73,7 +73,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   end
 
   # Legacy 3-arity entry point for backward compatibility
-  @spec execute(String.t(), Parser.program(), map()) ::
+  @spec execute(String.t(), AST.program(), map()) ::
           {String.t(), non_neg_integer(), map(), JustBash.t() | nil}
   def execute(content, program, opts) do
     execute(program, Map.put(opts, :files, [{"", content}]))
@@ -1013,7 +1013,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   @doc """
   Evaluate an expression in the given state context.
   """
-  @spec evaluate_expression(Parser.expr(), state()) :: String.t() | number()
+  @spec evaluate_expression(AST.expr(), state()) :: String.t() | number()
   def evaluate_expression({:literal, value}, _state), do: value
   def evaluate_expression({:number, value}, _state), do: value
   def evaluate_expression({:field, n}, state), do: get_field(state, n)

--- a/mix.exs
+++ b/mix.exs
@@ -77,12 +77,82 @@ defmodule JustBash.MixProject do
       source_ref: "v#{@version}",
       source_url: @source_url,
       extras: ["README.md", "UPGRADING.md", "CHANGELOG.md", "CONTRIBUTING.md", "LICENSE"],
+      groups_for_extras: [
+        Guides: ["README.md", "UPGRADING.md"],
+        Project: ["CHANGELOG.md", "CONTRIBUTING.md", "LICENSE"]
+      ],
+      # The eval harness lives in `eval/` and is compiled for dev/test only — it is
+      # not part of the published Hex package (see `package/0`), so it must not be
+      # documented on HexDocs.
+      filter_modules: fn module, _metadata ->
+        not String.starts_with?(inspect(module), "JustBash.Eval.")
+      end,
+      # Groups are rendered in the order listed, so this sequence is the sidebar
+      # itself: consumer-facing API first, implementation long tails last.
+      # Patterns may be module atoms or regexes matched against the module name;
+      # the first matching group wins, so narrower patterns come first.
       groups_for_modules: [
-        Core: [JustBash],
-        Parser: [JustBash.Parser, JustBash.Parser.Lexer, JustBash.Parser.WordParts],
-        AST: [JustBash.AST],
-        Filesystem: [JustBash.FS, JustBash.FS.Memory, JustBash.FS.POSIX],
-        Utilities: [JustBash.Arithmetic]
+        Core: [
+          JustBash,
+          JustBash.Result,
+          JustBash.Sigil,
+          JustBash.Limit,
+          JustBash.Telemetry
+        ],
+        Exceptions: [
+          JustBash.Limit.ExceededError,
+          JustBash.Parser.ParseError,
+          JustBash.Parser.Lexer.Error,
+          JustBash.Interpreter.Expansion.UnsetVariableError
+        ],
+        Filesystem: [
+          JustBash.FS,
+          JustBash.FS.Memory,
+          JustBash.FS.POSIX
+        ],
+        "HTTP & Network": [
+          JustBash.Network,
+          JustBash.HttpClient,
+          JustBash.HttpClient.Default
+        ],
+        "Custom Commands": [
+          JustBash.Commands.Command,
+          JustBash.Commands.Registry,
+          JustBash.Commands.ArgParser,
+          JustBash.FlagParser
+        ],
+        "Declarative CLIs": [~r/^JustBash\.CLI($|\.)/],
+        "Parsing & Formatting": [
+          JustBash.Parser,
+          JustBash.Formatter
+        ],
+        "Command Internals": [~r/^JustBash\.Commands\.(Awk|Jq|Sed)\./],
+        "Built-in Commands": [~r/^JustBash\.Commands\./],
+        "Parser & Lexer": [~r/^JustBash\.Parser\./],
+        Interpreter: [~r/^JustBash\.Interpreter($|\.)/],
+        Arithmetic: [~r/^JustBash\.Arithmetic($|\.)/],
+        AST: [~r/^JustBash\.AST($|\.)/],
+        "Security Auditing": [JustBash.BannedCallTracer],
+        "Spec Test Harness": [~r/^JustBash\.SpecTest($|\.)/],
+        "Mix Tasks": [~r/^Mix\.Tasks\./]
+      ],
+      nest_modules_by_prefix: [
+        JustBash.Arithmetic,
+        JustBash.AST,
+        JustBash.CLI,
+        JustBash.Commands,
+        JustBash.Commands.Awk,
+        JustBash.Commands.Jq,
+        JustBash.Commands.Sed,
+        JustBash.FS,
+        JustBash.HttpClient,
+        JustBash.Interpreter,
+        JustBash.Interpreter.Executor,
+        JustBash.Interpreter.Expansion,
+        JustBash.Parser,
+        JustBash.Parser.Lexer,
+        JustBash.Parser.WordParts,
+        JustBash.SpecTest
       ]
     ]
   end


### PR DESCRIPTION
## Summary

`mix docs` emitted four warnings and produced an unusable sidebar (~200 ungrouped AST/command modules sorting above the core API). This PR fixes both.

### Fix awk type-reference warnings

- `Parser.parse/1` and the evaluator referenced `AST.program()` / `Parser.program()` / `Parser.expr()` — types that were never defined. Define public `program()`, `expr()`, `stmt()`, `pattern()`, `block()`, and `print_args()` in `JustBash.Commands.Awk.AST` as accurate recursive unions traced from what the parser's constructor functions actually build (no `term()` placeholders).
- Point the evaluator's specs at the canonical `AST` types.
- Remove two `.dialyzer_ignore.exs` entries that existed only to suppress the `:unknown_type` errors caused by the missing types, plus the `rm.ex` skip that went stale after the rm error-handling refactor (dffd5dd) — dialyzer now reports 0 unnecessary skips.

### Organize the ExDoc sidebar

- `groups_for_modules` previously covered ~10 modules; ExDoc sorts ungrouped modules *above* named groups, so the AST/command flood buried `JustBash` itself. It now covers all 208 documented modules, ordered consumer-first: Core → Exceptions → Filesystem → HTTP & Network → Custom Commands → Declarative CLIs → Parsing & Formatting → Command Internals → Built-in Commands (86) → Parser & Lexer → Interpreter → Arithmetic → AST (59) → Security Auditing → Spec Test Harness → Mix Tasks. Ungrouped: 0.
- `nest_modules_by_prefix` collapses the long tails (commands render as `.Echo`, `.Grep`, … under a `JustBash.Commands` header).
- `filter_modules` excludes the 15 `JustBash.Eval.*` modules — they compile from `eval/` for dev/test only and are not in the Hex package `files:` list, so documenting them on HexDocs was wrong. Nothing was hidden with `@moduledoc false`.
- `groups_for_extras` splits Guides (README, UPGRADING) from Project meta (CHANGELOG, CONTRIBUTING, LICENSE).

## Verification

- `mix docs` — **0 warnings** (was 4)
- `mix compile --warnings-as-errors` — clean
- `mix format --check-formatted` — clean
- `mix credo --strict` — only the pre-existing intentional test-fixture finding
- `mix test` — 56 properties, 3739 tests, 0 failures
- `mix dialyzer` — passed, 13/13 skips, 0 unnecessary

Known pre-existing quirk (not addressed here): `mix docs` logs `[error] Error loading module 'Elixir.JustBash.Fs'` from a case-mismatched `JustBash.Fs` autolink in `lib/mix/tasks/just_bash.audit.ex` hitting macOS's case-insensitive filesystem. Harmless; can be silenced with `skip_code_autolink_to` or by fixing the casing.