### PR TITLE
fix: writing through a regular file is ENOTDIR, not unreachable state

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -79,6 +79,19 @@ Every difference a script can observe, verified against the 0.3 sources:
    directory (`:eisdir`). bash produces no output at all here because it
    opens the target before running the command.
 
+   Because resolution now follows symlinks in every component, `stat/2`
+   reports a symlinked directory *as* a directory — so **recursive commands
+   decide descent with `lstat` instead**, which is what GNU's default `-P`
+   does. `find`, `du`, `tree`, and `grep -r` list a symlink and stop there
+   rather than walking through it; in 0.3 `find /d` with `/d/self -> /d`
+   printed the subtree once per hop, and two such links never terminated.
+   Consequences worth knowing: `find -type f` and `-type d` no longer match
+   symlinks (`-type l` is now accepted and does), `grep -r` skips symlinks
+   met while recursing but still follows one named as an operand, and
+   `JustBash.FS.walk/3` yields a symlink with `type: :symlink` instead of
+   its target's type. A symlink named directly on the command line is still
+   followed, as it is under `-P`.
+
    Relatedly, `JustBash.new(files: ...)`, `JustBash.FS.new/1`, and
    `JustBash.FS.Memory.new/1` raise `ArgumentError` for a map that
    describes an impossible shape, such as

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -45,16 +45,46 @@ Every difference a script can observe, verified against the 0.3 sources:
    file was readable by path but absent from `ls`, globs, `find`, and
    `JustBash.FS.walk/3`. Every path-creating operation now refuses:
    `>`, `>>`, `&>`, `2>`, `touch`, `cp`, `mv`, `tee`, `ln`, `mkdir`,
-   `mkdir -p`, and anything else that opens an output file. Writes
-   *through a symlinked directory* now resolve to the target directory
-   instead of storing an unreachable literal path. `mkdir -p` on a path
-   that already exists as a *regular file* also fails now
+   `mkdir -p`, and anything else that opens an output file.
+
+   `mkdir -p` names the offending *ancestor* rather than the whole
+   operand, matching GNU coreutils: `mkdir -p /m/j/2026` reports
+   `mkdir: cannot create directory '/m/j': Not a directory`, while
+   `mkdir` without `-p` still names the operand. `cp` reports a
+   destination under a regular file as
+   `cp: cannot stat 'PATH': Not a directory` (GNU stats the destination
+   before opening it); `cannot create regular file` remains the wording
+   for a merely missing parent.
+
+   Paths resolve component-by-component on *both* sides, so a write
+   *through a symlinked directory* lands on the target directory and is
+   readable back at the path used — `echo hi > /link/a.md` then
+   `cat /link/a.md` with `/link -> /real`. 0.3 stored an unreachable
+   literal `/link/a.md` key. `mkdir -p` on a path that already exists as
+   a *regular file* also fails now
    (`mkdir: cannot create directory 'PATH': File exists`, exit 1) instead
-   of reporting success for a directory that does not exist. Relatedly,
-   `JustBash.new(files: ...)` (and `JustBash.FS.new/1`) raise
-   `ArgumentError` for a map that describes this impossible shape, such as
-   `%{"/m/j" => "x", "/m/j/a.md" => "y"}`; 0.3 accepted it and which entry
-   survived depended on map iteration order.
+   of reporting success for a directory that does not exist, and so does
+   `mkdir -p` on a dangling symlink.
+
+   One deviation from POSIX remains: `..` is collapsed lexically before
+   resolution, so `echo hi > /m/j/../k.md` writes `/m/k.md` and exits 0
+   where bash reports `Not a directory`. Real resolution walks `..`
+   through the directory it lands in; this does not admit unreachable
+   state, so it stayed out of scope.
+
+   A **failed redirect no longer leaks the command's output.** The bytes
+   were bound for the file, so `echo hi > /m/j/a.md` now yields empty
+   stdout with the error on stderr; previously `result.stdout` still held
+   `"hi\n"`. Same for `2>`, `>>`, and `&>`, and for a redirect onto a
+   directory (`:eisdir`). bash produces no output at all here because it
+   opens the target before running the command.
+
+   Relatedly, `JustBash.new(files: ...)`, `JustBash.FS.new/1`, and
+   `JustBash.FS.Memory.new/1` raise `ArgumentError` for a map that
+   describes an impossible shape, such as
+   `%{"/m/j" => "x", "/m/j/a.md" => "y"}` (0.3 accepted it and which entry
+   survived depended on map iteration order) or one that collides with a
+   directory the backend already holds, such as `%{"/" => "x"}`.
 8. **With additional mounts only** (a 0.4 capability): the parents of a
    mountpoint appear as synthetic directories, and foreign backends keep
    their own semantics — e.g. a plain `VFS.Memory` mount treats

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -39,7 +39,23 @@ Every difference a script can observe, verified against the 0.3 sources:
    situation — mounts didn't exist in 0.3; on the default backend, `ln`
    output is byte-identical to 0.3, including the directory-hard-link
    message).
-7. **With additional mounts only** (a 0.4 capability): the parents of a
+7. **Writing through a regular file is now "Not a directory"** (exit 1),
+   as POSIX path resolution requires. 0.3 stored the entry anyway —
+   `echo hi > /m/j/2026/a.md` with `/m/j` a regular file exited 0, and the
+   file was readable by path but absent from `ls`, globs, `find`, and
+   `JustBash.FS.walk/3`. Every path-creating operation now refuses:
+   `>`, `>>`, `&>`, `2>`, `touch`, `cp`, `mv`, `tee`, `ln`, `mkdir`,
+   `mkdir -p`, and anything else that opens an output file. Writes
+   *through a symlinked directory* now resolve to the target directory
+   instead of storing an unreachable literal path. `mkdir -p` on a path
+   that already exists as a *regular file* also fails now
+   (`mkdir: cannot create directory 'PATH': File exists`, exit 1) instead
+   of reporting success for a directory that does not exist. Relatedly,
+   `JustBash.new(files: ...)` (and `JustBash.FS.new/1`) raise
+   `ArgumentError` for a map that describes this impossible shape, such as
+   `%{"/m/j" => "x", "/m/j/a.md" => "y"}`; 0.3 accepted it and which entry
+   survived depended on map iteration order.
+8. **With additional mounts only** (a 0.4 capability): the parents of a
    mountpoint appear as synthetic directories, and foreign backends keep
    their own semantics — e.g. a plain `VFS.Memory` mount treats
    directories implicitly and refuses `rm` of an empty directory with

--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -141,7 +141,10 @@ defmodule JustBash do
 
   ## Options
 
-  - `:files` - Initial files as a map of path => content
+  - `:files` - Initial files as a map of path => content. Raises `ArgumentError` if the map
+    cannot exist as a filesystem — one path running through another (`%{"/m/j" => "x",
+    "/m/j/a.md" => "y"}`, where `/m/j` would have to be both a file and a directory), or a
+    path colliding with one of the default directories.
   - `:env` - Initial environment variables
   - `:cwd` - Starting working directory (default: "/home/user")
   - `:commands` - Custom commands as a map of name => module implementing `JustBash.Commands.Command`.
@@ -334,6 +337,8 @@ defmodule JustBash do
   end
 
   defp init_filesystem(files) do
+    FS.validate_initial_files!(files)
+
     default_dirs = [
       "/home",
       "/home/user",
@@ -352,8 +357,15 @@ defmodule JustBash do
       end)
 
     Enum.reduce(files, fs, fn {path, content}, acc_fs ->
-      {:ok, new_fs} = FS.write_file(acc_fs, path, content)
-      new_fs
+      case FS.write_file(acc_fs, path, content) do
+        {:ok, new_fs} ->
+          new_fs
+
+        {:error, %VFS.Error{} = error} ->
+          raise ArgumentError,
+                "invalid initial files: cannot create #{inspect(path)}: " <>
+                  "#{FS.strerror(error)}"
+      end
     end)
   end
 

--- a/lib/just_bash/commands/cd.ex
+++ b/lib/just_bash/commands/cd.ex
@@ -32,8 +32,12 @@ defmodule JustBash.Commands.Cd do
       {:ok, _, fs} ->
         {Command.error("bash: cd: #{target}: Not a directory\n"), %{bash | fs: fs}}
 
-      {:error, %VFS.Error{kind: :enoent}} ->
-        {Command.error("bash: cd: #{target}: No such file or directory\n"), bash}
+      # Every other resolution failure renders the same way bash does, from
+      # the kernel's error name: ENOTDIR for a component that is a regular
+      # file, ELOOP for a symlink cycle, and so on. Enumerating only ENOENT
+      # here raised a CaseClauseError out of `JustBash.exec/2` instead.
+      {:error, %VFS.Error{} = error} ->
+        {Command.error("bash: cd: #{target}: #{FS.strerror(error)}\n"), bash}
     end
   end
 end

--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -17,8 +17,7 @@ defmodule JustBash.Commands.Cp do
 
         case FS.read_file(bash.fs, src_resolved) do
           {:ok, content, fs} ->
-            {:ok, new_fs} = FS.write_file(fs, dest_resolved, content)
-            {Command.ok(), %{bash | fs: new_fs}}
+            write_dest(%{bash | fs: fs}, dest_resolved, dest, content)
 
           {:error, _} ->
             {Command.error("cp: cannot stat '#{src}': No such file or directory\n"), bash}
@@ -26,6 +25,20 @@ defmodule JustBash.Commands.Cp do
 
       _ ->
         {Command.error("cp: missing file operand\n"), bash}
+    end
+  end
+
+  # The destination may be unwritable for reasons the source read cannot
+  # know about — a path component that is a regular file (:enotdir), a
+  # destination that is a directory (:eisdir). Report them instead of
+  # crashing on the write.
+  defp write_dest(bash, dest_resolved, dest, content) do
+    case FS.write_file(bash.fs, dest_resolved, content) do
+      {:ok, new_fs} ->
+        {Command.ok(), %{bash | fs: new_fs}}
+
+      {:error, %VFS.Error{} = error} ->
+        {Command.error("cp: cannot create regular file '#{dest}': #{FS.strerror(error)}\n"), bash}
     end
   end
 end

--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -37,6 +37,13 @@ defmodule JustBash.Commands.Cp do
       {:ok, new_fs} ->
         {Command.ok(), %{bash | fs: new_fs}}
 
+      # GNU stats the destination before opening it, so a path component that
+      # is a regular file surfaces as `cannot stat`. `cannot create regular
+      # file` stays the wording for a destination whose parent is merely
+      # missing.
+      {:error, %VFS.Error{kind: :enotdir} = error} ->
+        {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(error)}\n"), bash}
+
       {:error, %VFS.Error{} = error} ->
         {Command.error("cp: cannot create regular file '#{dest}': #{FS.strerror(error)}\n"), bash}
     end

--- a/lib/just_bash/commands/du.ex
+++ b/lib/just_bash/commands/du.ex
@@ -99,8 +99,11 @@ defmodule JustBash.Commands.Du do
     end)
   end
 
+  # `lstat`, not `stat`: GNU du's default is `-P`, which counts a symlink's
+  # own size and does not descend through it. `stat` resolves the link, so a
+  # link back into the tree double-counts it and two of them never finish.
   defp calculate_size(fs, path, display_path, opts, depth) do
-    case FS.stat(fs, path) do
+    case FS.lstat(fs, path) do
       {:ok, %VFS.Stat{type: :directory}, _fs} ->
         calculate_dir_size(fs, path, display_path, opts, depth)
 
@@ -143,11 +146,13 @@ defmodule JustBash.Commands.Du do
     entry_path = if path == "/", do: "/#{entry}", else: "#{path}/#{entry}"
     entry_display = if display_path == ".", do: entry, else: "#{display_path}/#{entry}"
 
-    case FS.stat(fs, entry_path) do
+    case FS.lstat(fs, entry_path) do
       {:ok, %VFS.Stat{type: :directory}, _fs} ->
         process_subdir(fs, entry_path, entry_display, opts, depth, acc_out, acc_size)
 
-      {:ok, %VFS.Stat{type: :regular, size: size}, _fs} ->
+      # A symlink contributes its own size and nothing of its target's, which
+      # is what `-P` means for the entries a directory holds.
+      {:ok, %VFS.Stat{type: type, size: size}, _fs} when type in [:regular, :symlink] ->
         process_file_entry(size, entry_display, opts, acc_out, acc_size)
 
       _ ->

--- a/lib/just_bash/commands/find.ex
+++ b/lib/just_bash/commands/find.ex
@@ -67,7 +67,7 @@ defmodule JustBash.Commands.Find do
     parse_args(rest, %{opts | iname: pattern})
   end
 
-  defp parse_args(["-type", type | rest], opts) when type in ["f", "d"] do
+  defp parse_args(["-type", type | rest], opts) when type in ["f", "d", "l"] do
     parse_args(rest, %{opts | type: type})
   end
 
@@ -144,8 +144,12 @@ defmodule JustBash.Commands.Find do
 
   defp exceeds_maxdepth?(opts, depth), do: opts.maxdepth != nil and depth > opts.maxdepth
 
+  # `lstat`, not `stat`: GNU find's default `-P` never follows a symlink, so
+  # a link to a directory is reported as the link and not descended into.
+  # With `stat` — which resolves the link — a link back into the tree makes
+  # the traversal re-enter it, and two of them make it diverge.
   defp find_at_path(fs, full_path, display_path, opts, depth) do
-    case FS.stat(fs, full_path) do
+    case FS.lstat(fs, full_path) do
       {:ok, stat, _fs} ->
         current = collect_current_match(display_path, stat, opts, depth)
         children = find_children(fs, full_path, display_path, stat, opts, depth)
@@ -234,10 +238,13 @@ defmodule JustBash.Commands.Find do
     end
   end
 
+  # Types are compared against the `lstat` of the entry, so a symlink is
+  # `l` and matches neither `f` nor `d`, whatever it points at (`-P`).
   defp matches_type?(stat, opts) do
     case opts.type do
       "f" -> stat.type == :regular
       "d" -> stat.type == :directory
+      "l" -> stat.type == :symlink
       nil -> true
     end
   end

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -109,6 +109,10 @@ defmodule JustBash.Commands.Grep do
     end)
   end
 
+  # `-r` follows symlinks only when they are named on the command line, so
+  # the descent uses `lstat` and skips every link it meets along the way.
+  # (`stat` would resolve them, and a link pointing back into the tree being
+  # searched would make the recursion re-enter it — twice over, forever.)
   defp find_files_recursive(fs, full_path, display_path) do
     case FS.readdir(fs, full_path) do
       {:ok, entries, _fs} ->
@@ -116,9 +120,12 @@ defmodule JustBash.Commands.Grep do
           child_full = join_path(full_path, entry)
           child_display = join_path(display_path, entry)
 
-          case FS.stat(fs, child_full) do
+          case FS.lstat(fs, child_full) do
             {:ok, %VFS.Stat{type: :directory}, _fs} ->
               find_files_recursive(fs, child_full, child_display)
+
+            {:ok, %VFS.Stat{type: :symlink}, _fs} ->
+              []
 
             {:ok, _, _fs} ->
               [child_display]

--- a/lib/just_bash/commands/ls.ex
+++ b/lib/just_bash/commands/ls.ex
@@ -37,11 +37,16 @@ defmodule JustBash.Commands.Ls do
         formatted = format_entries(fs, resolved, entries, flags)
         {out_acc <> formatted, err_acc, code_acc, fs}
 
-      {:error, %VFS.Error{kind: :enoent}} ->
-        {out_acc, err_acc <> "ls: cannot access '#{path}': No such file or directory\n", 1, fs}
-
+      # ENOTDIR is not necessarily an error: `ls file` lists the file itself.
+      # It only becomes one when the name cannot be resolved at all.
       {:error, %VFS.Error{kind: :enotdir}} ->
         handle_not_dir(fs, resolved, path, {out_acc, err_acc, code_acc})
+
+      # Any other resolution failure — ENOENT, or ELOOP from a symlink cycle
+      # — is reported with the kernel's wording. Enumerating just those two
+      # kinds raised a CaseClauseError out of `JustBash.exec/2`.
+      {:error, %VFS.Error{} = error} ->
+        {out_acc, err_acc <> "ls: cannot access '#{path}': #{FS.strerror(error)}\n", 1, fs}
     end
   end
 

--- a/lib/just_bash/commands/mkdir.ex
+++ b/lib/just_bash/commands/mkdir.ex
@@ -23,9 +23,16 @@ defmodule JustBash.Commands.Mkdir do
           {:error, %VFS.Error{kind: :eexist}} when flags.p ->
             handle_existing_path(fs_acc, resolved, path, err_acc, code_acc)
 
+          # With -p, the directory GNU reports is the shallowest one it could
+          # not create — the offending ancestor — not the whole operand:
+          #   mkdir j/2026           -> cannot create directory 'j/2026'
+          #   mkdir -p j/2026/deeper -> cannot create directory 'j'
+          {:error, %VFS.Error{kind: :enotdir} = error} when flags.p ->
+            named = offending_ancestor(fs_acc, bash.cwd, path)
+            {err_acc <> failure(named, error), 1, fs_acc}
+
           {:error, %VFS.Error{} = error} ->
-            {err_acc <> "mkdir: cannot create directory '#{path}': #{FS.strerror(error)}\n", 1,
-             fs_acc}
+            {err_acc <> failure(path, error), 1, fs_acc}
         end
       end)
 
@@ -43,9 +50,51 @@ defmodule JustBash.Commands.Mkdir do
       {:ok, _stat, new_fs} ->
         {err_acc <> "mkdir: cannot create directory '#{path}': File exists\n", 1, new_fs}
 
+      # `stat` fails on a dangling symlink, but the *name* is taken, so
+      # `mkdir` cannot have it — GNU says "File exists". Only a name that is
+      # absent in `lstat` too gets the stat error.
       {:error, %VFS.Error{} = error} ->
-        {err_acc <> "mkdir: cannot create directory '#{path}': #{FS.strerror(error)}\n", 1, fs}
+        case FS.lstat(fs, resolved) do
+          {:ok, _stat, new_fs} ->
+            {err_acc <> "mkdir: cannot create directory '#{path}': File exists\n", 1, new_fs}
+
+          {:error, %VFS.Error{}} ->
+            {err_acc <> failure(path, error), 1, fs}
+        end
     end
+  end
+
+  # Walk the operand's own components so the name is reported the way the
+  # caller wrote it ("j", not "/m/j"), and stop at the first one that exists
+  # but is not a directory.
+  defp offending_ancestor(fs, cwd, path) do
+    trimmed = String.trim_trailing(path, "/")
+
+    trimmed
+    |> operand_prefixes()
+    |> Enum.find(&non_directory?(fs, FS.resolve_path(cwd, &1)))
+    |> Kernel.||(path)
+  end
+
+  defp operand_prefixes(path) do
+    case String.split(path, "/") do
+      ["" | rest] -> rest |> prefixes() |> Enum.map(&("/" <> &1))
+      components -> prefixes(components)
+    end
+  end
+
+  defp prefixes(components) do
+    components
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.scan(&Path.join(&2, &1))
+  end
+
+  defp non_directory?(fs, resolved) do
+    match?({:ok, %VFS.Stat{type: type}, _fs} when type != :directory, FS.stat(fs, resolved))
+  end
+
+  defp failure(path, error) do
+    "mkdir: cannot create directory '#{path}': #{FS.strerror(error)}\n"
   end
 
   defp parse_flags(args), do: parse_flags(args, %{p: false}, [])

--- a/lib/just_bash/commands/mkdir.ex
+++ b/lib/just_bash/commands/mkdir.ex
@@ -21,10 +21,7 @@ defmodule JustBash.Commands.Mkdir do
             {err_acc, code_acc, new_fs}
 
           {:error, %VFS.Error{kind: :eexist}} when flags.p ->
-            {err_acc, code_acc, fs_acc}
-
-          {:error, %VFS.Error{kind: :eexist}} ->
-            {err_acc <> "mkdir: cannot create directory '#{path}': File exists\n", 1, fs_acc}
+            handle_existing_path(fs_acc, resolved, path, err_acc, code_acc)
 
           {:error, %VFS.Error{} = error} ->
             {err_acc <> "mkdir: cannot create directory '#{path}': #{FS.strerror(error)}\n", 1,
@@ -33,6 +30,22 @@ defmodule JustBash.Commands.Mkdir do
       end)
 
     {Command.result("", stderr, exit_code), %{bash | fs: new_fs}}
+  end
+
+  # `mkdir -p` is only satisfied by an existing *directory*. A regular file
+  # at the path is still an error (bash: "mkdir: PATH: File exists"), and
+  # swallowing it would report success for a directory that does not exist.
+  defp handle_existing_path(fs, resolved, path, err_acc, code_acc) do
+    case FS.stat(fs, resolved) do
+      {:ok, %VFS.Stat{type: :directory}, new_fs} ->
+        {err_acc, code_acc, new_fs}
+
+      {:ok, _stat, new_fs} ->
+        {err_acc <> "mkdir: cannot create directory '#{path}': File exists\n", 1, new_fs}
+
+      {:error, %VFS.Error{} = error} ->
+        {err_acc <> "mkdir: cannot create directory '#{path}': #{FS.strerror(error)}\n", 1, fs}
+    end
   end
 
   defp parse_flags(args), do: parse_flags(args, %{p: false}, [])

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -44,8 +44,9 @@ defmodule JustBash.Commands.Mv do
               {Command.error("mv: cannot overwrite directory '#{dest}' with non-directory\n"),
                bash}
 
-            {:error, %VFS.Error{kind: :enotdir}} ->
-              {Command.error("mv: cannot move '#{src}' to '#{dest}': Not a directory\n"), bash}
+            {:error, %VFS.Error{} = error} ->
+              {Command.error("mv: cannot move '#{src}' to '#{dest}': #{FS.strerror(error)}\n"),
+               bash}
           end
         end
 

--- a/lib/just_bash/commands/tee.ex
+++ b/lib/just_bash/commands/tee.ex
@@ -64,6 +64,9 @@ defmodule JustBash.Commands.Tee do
     end)
   end
 
+  # tee does not create missing parent directories, so an absent parent is
+  # reported instead of being conjured up; a parent that exists but is not
+  # a directory is ENOTDIR, as the kernel would report it.
   defp write_single_file(fs, resolved, file, content, append, acc_stderr, acc_code) do
     parent = Path.dirname(resolved)
 
@@ -72,19 +75,20 @@ defmodule JustBash.Commands.Tee do
         do_write_file(new_fs, resolved, file, content, append, acc_stderr, acc_code)
 
       {:ok, _, new_fs} ->
-        {new_fs, acc_stderr <> "tee: #{file}: No such file or directory\n", 1}
+        {new_fs, acc_stderr <> "tee: #{file}: Not a directory\n", 1}
 
-      {:error, _} ->
-        {fs, acc_stderr <> "tee: #{file}: No such file or directory\n", 1}
+      {:error, %VFS.Error{} = error} ->
+        {fs, acc_stderr <> "tee: #{file}: #{FS.strerror(error)}\n", 1}
     end
   end
 
   defp do_write_file(fs, resolved, file, content, append, acc_stderr, acc_code) do
-    result = write_or_append(fs, resolved, content, append)
+    case write_or_append(fs, resolved, content, append) do
+      {:ok, new_fs} ->
+        {new_fs, acc_stderr, acc_code}
 
-    case result do
-      {:ok, new_fs} -> {new_fs, acc_stderr, acc_code}
-      {:error, _} -> {fs, acc_stderr <> "tee: #{file}: Is a directory\n", 1}
+      {:error, %VFS.Error{} = error} ->
+        {fs, acc_stderr <> "tee: #{file}: #{FS.strerror(error)}\n", 1}
     end
   end
 

--- a/lib/just_bash/commands/touch.ex
+++ b/lib/just_bash/commands/touch.ex
@@ -31,8 +31,11 @@ defmodule JustBash.Commands.Touch do
 
   defp create_empty_file(fs, resolved, path, err_acc, code_acc) do
     case FS.write_file(fs, resolved, "") do
-      {:ok, new_fs} -> {new_fs, err_acc, code_acc}
-      {:error, _} -> {fs, err_acc <> "touch: cannot touch '#{path}'\n", 1}
+      {:ok, new_fs} ->
+        {new_fs, err_acc, code_acc}
+
+      {:error, %VFS.Error{} = error} ->
+        {fs, err_acc <> "touch: cannot touch '#{path}': #{FS.strerror(error)}\n", 1}
     end
   end
 end

--- a/lib/just_bash/commands/tree.ex
+++ b/lib/just_bash/commands/tree.ex
@@ -77,8 +77,11 @@ defmodule JustBash.Commands.Tree do
     end
   end
 
+  # `lstat`, not `stat`: `tree` does not follow symlinks without `-l`, so a
+  # link is a leaf. Resolving it instead re-enters the tree through any link
+  # that points back into it, and two such links never finish.
   defp build_tree(ctx, path, display_path, depth) do
-    case FS.stat(ctx.fs, path) do
+    case FS.lstat(ctx.fs, path) do
       {:ok, %VFS.Stat{type: :directory}, _fs} ->
         build_directory_tree(ctx, path, display_path, depth)
 
@@ -143,10 +146,18 @@ defmodule JustBash.Commands.Tree do
   end
 
   defp build_single_entry(ctx, entry_ctx, depth, acc) do
-    case FS.stat(ctx.fs, entry_ctx.entry_path) do
-      {:ok, %VFS.Stat{type: :directory}, _fs} -> build_dir_entry(ctx, entry_ctx, depth, acc)
-      {:ok, %VFS.Stat{type: :regular}, _fs} -> build_file_entry(ctx, entry_ctx, acc)
-      _ -> acc
+    case FS.lstat(ctx.fs, entry_ctx.entry_path) do
+      {:ok, %VFS.Stat{type: :directory}, _fs} ->
+        build_dir_entry(ctx, entry_ctx, depth, acc)
+
+      # A symlink is listed as a leaf and counted with the files. Real `tree`
+      # also renders it as `name -> target`; that arrow is a separate gap,
+      # not something this traversal fix should invent.
+      {:ok, %VFS.Stat{type: type}, _fs} when type in [:regular, :symlink] ->
+        build_file_entry(ctx, entry_ctx, acc)
+
+      _ ->
+        acc
     end
   end
 

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -40,7 +40,9 @@ defmodule JustBash.FS do
   backend (seeded with `initial_files`) mounted at `/`.
 
   Raises `ArgumentError` when `initial_files` is not realizable as a
-  filesystem — see `validate_initial_files!/1`.
+  filesystem: either one entry's path runs through another (see
+  `validate_initial_files!/1`), or an entry collides with a directory the
+  backend already holds, as `%{"/" => "x"}` does.
   """
   @spec new(map()) :: t()
   def new(initial_files \\ %{}) do

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -38,11 +38,25 @@ defmodule JustBash.FS do
   @doc """
   Create a new filesystem: a `%VFS{}` with a `JustBash.FS.Memory`
   backend (seeded with `initial_files`) mounted at `/`.
+
+  Raises `ArgumentError` when `initial_files` is not realizable as a
+  filesystem — see `validate_initial_files!/1`.
   """
   @spec new(map()) :: t()
   def new(initial_files \\ %{}) do
     VFS.new() |> VFS.mount("/", Memory.new(initial_files))
   end
+
+  @doc """
+  Validate a `path => content` map before seeding a filesystem with it.
+
+  Raises `ArgumentError` when one entry's path runs *through* another
+  entry — `%{"/m/j" => "x", "/m/j/a.md" => "y"}` asks for a file inside a
+  regular file, which no filesystem can hold. See
+  `JustBash.FS.Memory.validate_initial_files!/1`.
+  """
+  @spec validate_initial_files!(map()) :: :ok
+  defdelegate validate_initial_files!(initial_files), to: Memory
 
   # ── path helpers (pure) ──────────────────────────────────────────────────
   #

--- a/lib/just_bash/fs/memory.ex
+++ b/lib/just_bash/fs/memory.ex
@@ -77,8 +77,10 @@ defmodule JustBash.FS.Memory do
   - Extended form: `%{"/path/to/file" => %{content: "content", mode: 0o755, mtime: ~U[...]}}`
 
   Parent directories are created automatically. Raises `ArgumentError`
-  when the map is not realizable as a filesystem — see
-  `validate_initial_files!/1`.
+  when the map is not realizable as a filesystem: either one entry's path
+  runs through another (see `validate_initial_files!/1`), or an entry
+  collides with a directory this backend already holds, as `%{"/" => "x"}`
+  does.
 
   ## Examples
 
@@ -97,19 +99,31 @@ defmodule JustBash.FS.Memory do
     Enum.reduce(initial_files, fs, fn {path, value}, acc ->
       case value do
         %{content: content} = init ->
-          {:ok, new_fs} =
-            write_file(acc, path, content,
-              mode: Map.get(init, :mode, 0o644),
-              mtime: Map.get(init, :mtime, DateTime.utc_now())
-            )
-
-          new_fs
+          seed!(acc, path, content,
+            mode: Map.get(init, :mode, 0o644),
+            mtime: Map.get(init, :mtime, DateTime.utc_now())
+          )
 
         content when is_binary(content) ->
-          {:ok, new_fs} = write_file(acc, path, content)
-          new_fs
+          seed!(acc, path, content)
       end
     end)
+  end
+
+  # `validate_initial_files!/1` catches the map that is unrealizable on its
+  # own terms; a seed can still collide with what the backend already holds
+  # (`%{"/" => "x"}`). Both are caller mistakes at construction time, so
+  # both raise `ArgumentError` rather than a `MatchError` from in here.
+  defp seed!(fs, path, content, opts \\ []) do
+    case write_file(fs, path, content, opts) do
+      {:ok, new_fs} ->
+        new_fs
+
+      {:error, %Error{} = error} ->
+        raise ArgumentError,
+              "invalid initial files: cannot create #{inspect(path)}: " <>
+                JustBash.FS.strerror(error)
+    end
   end
 
   @doc """
@@ -155,7 +169,7 @@ defmodule JustBash.FS.Memory do
   def write_file(%__MODULE__{} = fs, path, content, opts \\ []) do
     normalized = normalize(path)
 
-    with {:ok, target_path} <- resolve_for_write(fs, normalized) do
+    with {:ok, target_path} <- resolve_path(fs, normalized) do
       case Map.get(fs.data, target_path) do
         %{type: :directory} ->
           {:error, Error.new(:eisdir, path: normalized)}
@@ -174,22 +188,24 @@ defmodule JustBash.FS.Memory do
   @doc """
   Get stat information for a path without following symlinks.
 
-  A symlink reports `type: :symlink` with the target's byte size.
+  A symlink reports `type: :symlink` with the target's byte size. Ancestor
+  components still resolve — only the final one is left alone.
   """
   @spec lstat(t(), String.t()) :: {:ok, Stat.t(), t()} | {:error, Error.t()}
-  def lstat(%__MODULE__{data: data} = fs, path) do
-    normalized = normalize(path)
+  def lstat(%__MODULE__{} = fs, path) do
+    with {:ok, normalized} <- resolve_for_create(fs, normalize(path)) do
+      case Map.get(fs.data, normalized) do
+        nil ->
+          {:error, Error.new(:enoent, path: normalized)}
 
-    case Map.get(data, normalized) do
-      nil ->
-        {:error, Error.new(:enoent, path: normalized)}
+        %{type: :symlink, target: target} = entry ->
+          {:ok,
+           %Stat{type: :symlink, size: byte_size(target), mtime: entry.mtime, mode: entry.mode},
+           fs}
 
-      %{type: :symlink, target: target} = entry ->
-        {:ok,
-         %Stat{type: :symlink, size: byte_size(target), mtime: entry.mtime, mode: entry.mode}, fs}
-
-      entry ->
-        {:ok, entry_stat(entry), fs}
+        entry ->
+          {:ok, entry_stat(entry), fs}
+      end
     end
   end
 
@@ -215,15 +231,17 @@ defmodule JustBash.FS.Memory do
 
   @doc """
   Read the target of a symbolic link.
+
+  Ancestor components resolve; the final one is the link being read.
   """
   @spec readlink(t(), String.t()) :: {:ok, String.t(), t()} | {:error, Error.t()}
-  def readlink(%__MODULE__{data: data} = fs, path) do
-    normalized = normalize(path)
-
-    case Map.get(data, normalized) do
-      nil -> {:error, Error.new(:enoent, path: normalized)}
-      %{type: :symlink, target: target} -> {:ok, target, fs}
-      _ -> {:error, Error.new(:einval, path: normalized)}
+  def readlink(%__MODULE__{} = fs, path) do
+    with {:ok, normalized} <- resolve_for_create(fs, normalize(path)) do
+      case Map.get(fs.data, normalized) do
+        nil -> {:error, Error.new(:enoent, path: normalized)}
+        %{type: :symlink, target: target} -> {:ok, target, fs}
+        _ -> {:error, Error.new(:einval, path: normalized)}
+      end
     end
   end
 
@@ -237,8 +255,9 @@ defmodule JustBash.FS.Memory do
   """
   @spec link(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
   def link(%__MODULE__{} = fs, existing_path, new_path) do
-    with {:ok, new_norm} <- resolve_for_create(fs, normalize(new_path)) do
-      do_link(fs, normalize(existing_path), new_norm)
+    with {:ok, new_norm} <- resolve_for_create(fs, normalize(new_path)),
+         {:ok, existing_norm} <- resolve_for_create(fs, normalize(existing_path)) do
+      do_link(fs, existing_norm, new_norm)
     end
   end
 
@@ -271,7 +290,7 @@ defmodule JustBash.FS.Memory do
   def chmod(%__MODULE__{} = fs, path, mode) do
     normalized = normalize(path)
 
-    with {:ok, target_path} <- resolve_for_write(fs, normalized) do
+    with {:ok, target_path} <- resolve_path(fs, normalized) do
       case Map.get(fs.data, target_path) do
         nil ->
           {:error, Error.new(:enoent, path: normalized)}
@@ -296,7 +315,7 @@ defmodule JustBash.FS.Memory do
   def append_file(%__MODULE__{} = fs, path, content) do
     normalized = normalize(path)
 
-    with {:ok, target_path} <- resolve_for_write(fs, normalized) do
+    with {:ok, target_path} <- resolve_path(fs, normalized) do
       case Map.get(fs.data, target_path) do
         %{type: :directory} ->
           {:error, Error.new(:eisdir, path: normalized)}
@@ -318,10 +337,20 @@ defmodule JustBash.FS.Memory do
   def __entry__(%__MODULE__{data: data}, path), do: Map.get(data, path)
 
   @doc false
-  @spec __resolve_entry__(t(), String.t()) ::
-          {:ok, fs_entry()} | {:error, :enoent | :eloop}
+  @spec __resolve_entry__(t(), String.t()) :: {:ok, fs_entry()} | {:error, Error.t()}
   def __resolve_entry__(%__MODULE__{} = fs, path) do
-    do_resolve_entry(fs, normalize(path), MapSet.new())
+    with {:ok, resolved} <- resolve_path(fs, normalize(path)) do
+      case Map.get(fs.data, resolved) do
+        nil -> {:error, Error.new(:enoent, path: resolved)}
+        entry -> {:ok, entry}
+      end
+    end
+  end
+
+  @doc false
+  @spec __resolve_for_read__(t(), String.t()) :: {:ok, String.t()} | {:error, Error.t()}
+  def __resolve_for_read__(%__MODULE__{} = fs, path) do
+    resolve_path(fs, normalize(path))
   end
 
   @doc false
@@ -372,90 +401,83 @@ defmodule JustBash.FS.Memory do
     end
   end
 
-  @dialyzer {:nowarn_function, do_resolve_entry: 3}
-  defp do_resolve_entry(%__MODULE__{data: data} = fs, path, seen) do
-    case Map.get(data, path) do
-      nil ->
-        {:error, :enoent}
-
-      %{type: :symlink, target: target} ->
-        if MapSet.member?(seen, path) do
-          {:error, :eloop}
-        else
-          resolved = resolve_symlink_target(path, target)
-          do_resolve_entry(fs, resolved, MapSet.put(seen, path))
-        end
-
-      entry ->
-        {:ok, entry}
-    end
-  end
-
   # ── POSIX path resolution ────────────────────────────────────────────────
   #
-  # A path resolves one component at a time, following symlinks at every
-  # step. Every non-final component must resolve to a directory or to
-  # nothing (writes create the missing intermediate directories); one that
-  # resolves to a regular file is ENOTDIR, exactly as the kernel reports
-  # it. Without that check a write stored an entry underneath a regular
-  # file — readable by its path, yet unreachable from any directory
-  # listing or `VFS.walk/3` (issue #53).
+  # A path resolves one component at a time from the root, following
+  # symlinks as they are met. Every non-final component must resolve to a
+  # directory or to nothing (writes create the missing intermediate
+  # directories); one that resolves to a regular file is ENOTDIR, exactly
+  # as the kernel reports it. Without that check a write stored an entry
+  # underneath a regular file — readable by its path, yet unreachable from
+  # any directory listing or `VFS.walk/3` (issue #53).
+  #
+  # Reads resolve the same way, and have to: if only writes followed
+  # intermediate symlinks, a write through a symlinked directory would land
+  # on the target and be invisible at the path the caller used — the same
+  # unreachable-state bug mirrored, and quieter, because the write reports
+  # success.
+  #
+  # One deviation remains, inherited from `normalize/1`: ".." is collapsed
+  # lexically before resolution, so "/m/j/../k" never looks at "/m/j" and
+  # cannot report ENOTDIR for it. Real resolution walks ".." through the
+  # directory it lands in.
 
-  # Resolve every component *including* a symlink at the final one:
-  # O_TRUNC/O_APPEND/chmod semantics, where the link is written through. A
-  # missing entry resolves to the path it would occupy — that is where a
-  # write through a dangling link creates the file.
-  # The `seen` MapSet threads through the mutually recursive walkers, and
-  # dialyzer cannot see through the opaque struct across the recursion.
-  @dialyzer {:nowarn_function,
-             [resolve_full: 3, resolve_ancestors: 3, resolve_directory: 3, follow_link: 3]}
+  # Symlink hops are budgeted, not remembered, matching Linux's
+  # SYMLOOP_MAX. A set of visited links would reject legitimate paths that
+  # cross the same link twice: with `/real/self -> /real`,
+  # "/real/self/self/x" is two hops to "/real/x", not a cycle.
+  @symloop_max 40
 
-  @spec resolve_for_write(t(), String.t()) :: {:ok, String.t()} | {:error, Error.t()}
-  defp resolve_for_write(%__MODULE__{} = fs, path), do: resolve_full(fs, path, MapSet.new())
+  # Reads and writes resolve identically, including a symlink at the final
+  # component (O_TRUNC/O_APPEND/chmod semantics, where the link is written
+  # through). They differ only in what the caller does with a resolved path
+  # that holds nothing: a write creates it, a read reports ENOENT.
+  @spec resolve_path(t(), String.t()) :: {:ok, String.t()} | {:error, Error.t()}
+  defp resolve_path(%__MODULE__{} = fs, path) do
+    walk(fs, "/", components(path), @symloop_max, :follow_final)
+  end
 
   # Resolve every component *except* the final one, which is taken
   # literally: mkdir/symlink/link semantics, where an existing final
-  # component is EEXIST rather than a link to follow.
+  # component is EEXIST rather than a link to follow, and lstat/readlink/rm
+  # semantics, where the link itself is the subject.
   @spec resolve_for_create(t(), String.t()) :: {:ok, String.t()} | {:error, Error.t()}
-  defp resolve_for_create(%__MODULE__{} = fs, path), do: resolve_ancestors(fs, path, MapSet.new())
-
-  defp resolve_full(%__MODULE__{} = fs, path, seen) do
-    with {:ok, candidate} <- resolve_ancestors(fs, path, seen) do
-      follow_link(fs, candidate, seen)
-    end
+  defp resolve_for_create(%__MODULE__{} = fs, path) do
+    walk(fs, "/", components(path), @symloop_max, :keep_final)
   end
 
-  defp resolve_ancestors(_fs, "/", _seen), do: {:ok, "/"}
+  defp components("/"), do: []
+  defp components("/" <> rest), do: String.split(rest, "/")
 
-  defp resolve_ancestors(%__MODULE__{} = fs, path, seen) do
-    with {:ok, parent} <- resolve_directory(fs, VPath.dirname(path), seen) do
-      {:ok, join_child(parent, VPath.basename(path))}
-    end
-  end
+  # `parent` is the resolved prefix walked so far; splitting once and
+  # descending with it keeps resolution a single pass, rather than taking
+  # the path apart with dirname/basename at every level.
+  defp walk(_fs, resolved, [], _hops, _final), do: {:ok, resolved}
 
-  defp resolve_directory(%__MODULE__{} = fs, path, seen) do
-    with {:ok, resolved} <- resolve_full(fs, path, seen) do
-      case Map.get(fs.data, resolved) do
-        nil -> {:ok, resolved}
-        %{type: :directory} -> {:ok, resolved}
-        _ -> {:error, Error.new(:enotdir, path: resolved)}
-      end
-    end
-  end
+  defp walk(%__MODULE__{data: data} = fs, parent, [component | rest], hops, final) do
+    candidate = join_child(parent, component)
 
-  defp follow_link(%__MODULE__{data: data} = fs, path, seen) do
-    case Map.get(data, path) do
-      %{type: :symlink, target: target} ->
-        if MapSet.member?(seen, path) do
-          {:error, Error.new(:eloop, path: path)}
-        else
-          resolved = resolve_symlink_target(path, target)
-          resolve_full(fs, resolved, MapSet.put(seen, path))
-        end
+    case Map.get(data, candidate) do
+      %{type: :symlink, target: target} when rest != [] or final == :follow_final ->
+        follow(fs, candidate, target, rest, hops, final)
 
+      %{type: :file} when rest != [] ->
+        {:error, Error.new(:enotdir, path: candidate)}
+
+      # A directory, nothing at all (a write creates it), or the final
+      # component of a `:keep_final` resolution.
       _ ->
-        {:ok, path}
+        walk(fs, candidate, rest, hops, final)
     end
+  end
+
+  defp follow(_fs, candidate, _target, _rest, 0, _final) do
+    {:error, Error.new(:eloop, path: candidate)}
+  end
+
+  defp follow(%__MODULE__{} = fs, candidate, target, rest, hops, final) do
+    target_components = candidate |> resolve_symlink_target(target) |> components()
+    walk(fs, "/", target_components ++ rest, hops - 1, final)
   end
 
   defp join_child("/", child), do: "/" <> child
@@ -500,62 +522,63 @@ defimpl VFS.Mountable, for: JustBash.FS.Memory do
   alias JustBash.FS.Memory
   alias VFS.Error
 
+  # `exists?` resolves ancestors but not the final component, so a dangling
+  # symlink still exists (as the link).
   def exists?(%Memory{} = fs, path) do
-    {Map.has_key?(fs.data, Memory.__normalize__(path)), fs}
+    case Memory.__resolve_for_create__(fs, path) do
+      {:ok, resolved} -> {Map.has_key?(fs.data, resolved), fs}
+      {:error, _error} -> {false, fs}
+    end
   end
 
   def stat(%Memory{} = fs, path) do
-    normalized = Memory.__normalize__(path)
-
-    case Memory.__resolve_entry__(fs, normalized) do
+    case Memory.__resolve_entry__(fs, path) do
       {:ok, entry} -> {:ok, Memory.__entry_stat__(entry), fs}
-      {:error, kind} -> {:error, Error.new(kind, path: normalized)}
+      {:error, %Error{} = error} -> {:error, error}
     end
   end
 
   def readdir(%Memory{data: data} = fs, path) do
-    normalized = Memory.__normalize__(path)
+    with {:ok, normalized} <- Memory.__resolve_for_read__(fs, path) do
+      case Map.get(data, normalized) do
+        nil ->
+          {:error, Error.new(:enoent, path: normalized)}
 
-    case Map.get(data, normalized) do
-      nil ->
-        {:error, Error.new(:enoent, path: normalized)}
+        %{type: type} when type != :directory ->
+          {:error, Error.new(:enotdir, path: normalized)}
 
-      %{type: type} when type != :directory ->
-        {:error, Error.new(:enotdir, path: normalized)}
+        %{type: :directory} ->
+          prefix = if normalized == "/", do: "/", else: normalized <> "/"
 
-      %{type: :directory} ->
-        prefix = if normalized == "/", do: "/", else: normalized <> "/"
+          entries =
+            data
+            |> Map.keys()
+            |> Enum.filter(fn p -> p != normalized and String.starts_with?(p, prefix) end)
+            |> Enum.map(fn p ->
+              rest = String.replace_prefix(p, prefix, "")
+              rest |> String.split("/", parts: 2) |> hd()
+            end)
+            |> Enum.uniq()
+            |> Enum.sort()
 
-        entries =
-          data
-          |> Map.keys()
-          |> Enum.filter(fn p -> p != normalized and String.starts_with?(p, prefix) end)
-          |> Enum.map(fn p ->
-            rest = String.replace_prefix(p, prefix, "")
-            rest |> String.split("/", parts: 2) |> hd()
-          end)
-          |> Enum.uniq()
-          |> Enum.sort()
-
-        {:ok, entries, fs}
+          {:ok, entries, fs}
+      end
     end
   end
 
   def stream_read(%Memory{} = fs, path, opts) do
-    normalized = Memory.__normalize__(path)
-
-    case Memory.__resolve_entry__(fs, normalized) do
+    case Memory.__resolve_entry__(fs, path) do
       {:ok, %{type: :file, content: content}} ->
         case VFS.StreamOptions.apply(content, opts) do
           {:ok, stream} -> {:ok, stream, fs}
-          {:error, kind} -> {:error, Error.new(kind, path: normalized)}
+          {:error, kind} -> {:error, Error.new(kind, path: Memory.__normalize__(path))}
         end
 
       {:ok, %{type: :directory}} ->
-        {:error, Error.new(:eisdir, path: normalized)}
+        {:error, Error.new(:eisdir, path: Memory.__normalize__(path))}
 
-      {:error, kind} ->
-        {:error, Error.new(kind, path: normalized)}
+      {:error, %Error{} = error} ->
+        {:error, error}
     end
   end
 
@@ -573,19 +596,22 @@ defimpl VFS.Mountable, for: JustBash.FS.Memory do
     end
   end
 
+  # Ancestors resolve, the final component does not: `rm /link` unlinks the
+  # symlink, it does not touch what the link points at.
   def rm(%Memory{data: data} = fs, path, opts) do
-    normalized = Memory.__normalize__(path)
     recursive? = Keyword.get(opts, :recursive, false)
 
-    case Map.get(data, normalized) do
-      nil ->
-        {:error, Error.new(:enoent, path: normalized)}
+    with {:ok, normalized} <- Memory.__resolve_for_create__(fs, path) do
+      case Map.get(data, normalized) do
+        nil ->
+          {:error, Error.new(:enoent, path: normalized)}
 
-      %{type: :directory} ->
-        rm_directory(fs, normalized, recursive?)
+        %{type: :directory} ->
+          rm_directory(fs, normalized, recursive?)
 
-      _ ->
-        {:ok, %{fs | data: Map.delete(data, normalized)}}
+        _ ->
+          {:ok, %{fs | data: Map.delete(data, normalized)}}
+      end
     end
   end
 
@@ -617,9 +643,13 @@ defimpl VFS.Mountable, for: JustBash.FS.Memory do
       {false, false} ->
         {:error, Error.new(:enoent, path: normalized)}
 
+      # The whole chain was already resolved by the outer `mkdir/3`. Going
+      # back through the protocol would re-resolve it once per level, which
+      # is O(depth^2) resolutions for a single `mkdir -p`.
       {false, true} ->
-        {:ok, fs} = mkdir(fs, parent, parents: true)
-        do_mkdir(fs, normalized)
+        with {:ok, fs} <- do_mkdir_resolved(fs, parent, true) do
+          do_mkdir(fs, normalized)
+        end
 
       {true, _} ->
         do_mkdir(fs, normalized)

--- a/lib/just_bash/fs/memory.ex
+++ b/lib/just_bash/fs/memory.ex
@@ -198,11 +198,6 @@ defmodule JustBash.FS.Memory do
         nil ->
           {:error, Error.new(:enoent, path: normalized)}
 
-        %{type: :symlink, target: target} = entry ->
-          {:ok,
-           %Stat{type: :symlink, size: byte_size(target), mtime: entry.mtime, mode: entry.mode},
-           fs}
-
         entry ->
           {:ok, entry_stat(entry), fs}
       end
@@ -384,6 +379,10 @@ defmodule JustBash.FS.Memory do
     %Stat{type: :directory, size: 0, mtime: entry.mtime, mode: entry.mode}
   end
 
+  defp entry_stat(%{type: :symlink, target: target} = entry) do
+    %Stat{type: :symlink, size: byte_size(target), mtime: entry.mtime, mode: entry.mode}
+  end
+
   defp ensure_parent_dirs(%__MODULE__{} = fs, path) do
     dir = VPath.dirname(path)
 
@@ -538,6 +537,36 @@ defimpl VFS.Mountable, for: JustBash.FS.Memory do
     end
   end
 
+  # Native walk, replacing the `VFS.Default` one composed from stat/readdir.
+  # Two reasons, and the first is correctness, not speed: the default walk
+  # asks `stat/2` whether each entry is a directory, and `stat/2` resolves
+  # symlinks — so it descends *through* a symlinked directory and back into
+  # the tree it came from. One self-link inflates the result, two make it
+  # diverge. Walking the store's own keys instead cannot: a symlink is an
+  # entry, never an edge, so the traversal visits each stored path once and
+  # stops (POSIX `-P`, and what GNU's traversal utilities do by default).
+  #
+  # The second reason is that it is exact and O(n). With ENOTDIR enforced at
+  # every write, `data`'s keys *are* the reachable tree, so a prefix scan
+  # sees precisely what a stat/readdir descent would have — no re-resolution
+  # per level.
+  def walk(%Memory{} = fs, root, opts) do
+    requested = Memory.__normalize__(root)
+    max_depth = Keyword.get(opts, :max_depth, :infinity)
+    include_dirs = Keyword.get(opts, :include_dirs, false)
+
+    # The root operand is followed, like `stat/2` — `walk("/link")` walks the
+    # target's tree. Emitted paths keep the caller's spelling of the root,
+    # which is what a stat/readdir descent from "/link" produced.
+    case Memory.__resolve_for_read__(fs, requested) do
+      {:ok, resolved} ->
+        walk_root(fs, resolved, requested, max_depth, include_dirs)
+
+      {:error, %Error{}} ->
+        []
+    end
+  end
+
   def readdir(%Memory{data: data} = fs, path) do
     with {:ok, normalized} <- Memory.__resolve_for_read__(fs, path) do
       case Map.get(data, normalized) do
@@ -618,6 +647,81 @@ defimpl VFS.Mountable, for: JustBash.FS.Memory do
   def capabilities(_), do: MapSet.new([:read, :write, :mkdir])
 
   # ── helpers ──
+
+  defp walk_root(%Memory{} = fs, resolved, requested, max_depth, include_dirs) do
+    case Memory.__entry__(fs, resolved) do
+      # A dangling symlink root resolves to a path that holds nothing, which
+      # the default walk also reported as an empty traversal.
+      nil ->
+        []
+
+      %{type: :directory} = entry ->
+        self = if include_dirs, do: [{requested, Memory.__entry_stat__(entry)}], else: []
+
+        opts = %{
+          index: child_index(fs, resolved),
+          max_depth: max_depth,
+          include_dirs: include_dirs
+        }
+
+        Stream.concat(self, descend(opts, resolved, requested, 0))
+
+      entry ->
+        [{requested, Memory.__entry_stat__(entry)}]
+    end
+  end
+
+  # One pass over the store builds `storage dir => sorted [{name, entry}]`,
+  # so the depth-first traversal below is a map lookup per directory rather
+  # than a prefix scan per directory. Sorting matches `readdir/2`'s order,
+  # which is the order the composed walk yielded.
+  defp child_index(%Memory{data: data}, resolved) do
+    prefix = if resolved == "/", do: "/", else: resolved <> "/"
+
+    data
+    |> Enum.filter(fn {path, _entry} ->
+      path != resolved and String.starts_with?(path, prefix)
+    end)
+    |> Enum.group_by(fn {path, _entry} -> VFS.Path.dirname(path) end, fn {path, entry} ->
+      {Path.basename(path), entry}
+    end)
+    |> Map.new(fn {dir, children} -> {dir, Enum.sort(children)} end)
+  end
+
+  # `storage` addresses the store, `display` is the caller's spelling of the
+  # same directory — they differ only when the walk root was a symlink.
+  # Depth is counted from the root, as `:max_depth` is documented.
+  #
+  # Every stage is a `Stream`, so the laziness the `VFS.Mountable` walk
+  # contract asks for survives: `walk |> Stream.take(n)` realizes only the
+  # subtrees it needs.
+  defp descend(%{max_depth: max_depth}, _storage, _display, depth)
+       when is_integer(max_depth) and depth >= max_depth do
+    []
+  end
+
+  defp descend(opts, storage, display, depth) do
+    opts.index
+    |> Map.get(storage, [])
+    |> Stream.flat_map(fn {name, entry} ->
+      emit(opts, join(storage, name), join(display, name), entry, depth + 1)
+    end)
+  end
+
+  defp emit(opts, storage, display, %{type: :directory} = entry, depth) do
+    self = if opts.include_dirs, do: [{display, Memory.__entry_stat__(entry)}], else: []
+
+    Stream.concat(self, descend(opts, storage, display, depth))
+  end
+
+  # A symlink lands here too: it is an entry in the store, never an edge to
+  # follow, which is exactly what keeps the traversal finite.
+  defp emit(_opts, _storage, display, entry, _depth) do
+    [{display, Memory.__entry_stat__(entry)}]
+  end
+
+  defp join("/", name), do: "/" <> name
+  defp join(dir, name), do: dir <> "/" <> name
 
   defp do_mkdir_resolved(%Memory{data: data} = fs, normalized, parents?) do
     case Map.get(data, normalized) do

--- a/lib/just_bash/fs/memory.ex
+++ b/lib/just_bash/fs/memory.ex
@@ -76,7 +76,9 @@ defmodule JustBash.FS.Memory do
   - Simple form: `%{"/path/to/file" => "content"}`
   - Extended form: `%{"/path/to/file" => %{content: "content", mode: 0o755, mtime: ~U[...]}}`
 
-  Parent directories are created automatically.
+  Parent directories are created automatically. Raises `ArgumentError`
+  when the map is not realizable as a filesystem — see
+  `validate_initial_files!/1`.
 
   ## Examples
 
@@ -86,6 +88,8 @@ defmodule JustBash.FS.Memory do
   """
   @spec new(map()) :: t()
   def new(initial_files \\ %{}) do
+    validate_initial_files!(initial_files)
+
     fs = %__MODULE__{
       data: %{"/" => %{type: :directory, mode: 0o755, mtime: DateTime.utc_now()}}
     }
@@ -109,37 +113,61 @@ defmodule JustBash.FS.Memory do
   end
 
   @doc """
+  Validate an initial-files map before it is realized as a filesystem.
+
+  A map like `%{"/m/j" => "x", "/m/j/a.md" => "y"}` describes a
+  filesystem that cannot exist: `/m/j` is a regular file, so nothing can
+  live under it. Seeding it anyway used to store an entry no directory
+  listing could reach, and which one of the two entries won depended on
+  map iteration order. Raise instead, naming both paths.
+  """
+  @spec validate_initial_files!(map()) :: :ok
+  def validate_initial_files!(initial_files) do
+    by_path =
+      Map.new(initial_files, fn {path, _value} -> {normalize(path), path} end)
+
+    case find_conflict(by_path) do
+      nil ->
+        :ok
+
+      {ancestor, descendant} ->
+        raise ArgumentError,
+              "invalid initial files: #{inspect(ancestor)} is a regular file, so " <>
+                "#{inspect(descendant)} cannot exist under it (POSIX path resolution " <>
+                "fails with ENOTDIR). Drop one of the two entries."
+    end
+  end
+
+  @doc """
   Write content to a file, creating it if it doesn't exist.
 
-  Parent directories are created automatically. Accepts `:mode` and
-  `:mtime` options; these also flow through `VFS.write_file/4` opts.
+  Missing parent directories are created automatically. Accepts `:mode`
+  and `:mtime` options; these also flow through `VFS.write_file/4` opts.
 
-  Follows symlinks to the final target (POSIX `O_TRUNC` semantics,
-  matching `append_file/3`): the link survives and the target is
-  replaced; writing to a dangling symlink creates the target.
+  Follows symlinks in every component (POSIX path resolution), including
+  the final one (`O_TRUNC` semantics, matching `append_file/3`): the link
+  survives and the target is replaced; writing to a dangling symlink
+  creates the target. A non-final component that resolves to a regular
+  file is `:enotdir`.
   """
   @spec write_file(t(), String.t(), binary(), write_opts()) ::
           {:ok, t()} | {:error, Error.t()}
   def write_file(%__MODULE__{} = fs, path, content, opts \\ []) do
     normalized = normalize(path)
 
-    case resolve_final_path(fs, normalized, MapSet.new()) do
-      {:error, :eloop} ->
-        {:error, Error.new(:eloop, path: normalized)}
+    with {:ok, target_path} <- resolve_for_write(fs, normalized) do
+      case Map.get(fs.data, target_path) do
+        %{type: :directory} ->
+          {:error, Error.new(:eisdir, path: normalized)}
 
-      {:ok, target_path} ->
-        case Map.get(fs.data, target_path) do
-          %{type: :directory} ->
-            {:error, Error.new(:eisdir, path: normalized)}
+        _ ->
+          mode = Keyword.get(opts, :mode, 0o644)
+          mtime = Keyword.get(opts, :mtime, DateTime.utc_now())
 
-          _ ->
-            mode = Keyword.get(opts, :mode, 0o644)
-            mtime = Keyword.get(opts, :mtime, DateTime.utc_now())
-
-            fs = ensure_parent_dirs(fs, target_path)
-            entry = %{type: :file, content: content, mode: mode, mtime: mtime}
-            {:ok, %{fs | data: Map.put(fs.data, target_path, entry)}}
-        end
+          fs = ensure_parent_dirs(fs, target_path)
+          entry = %{type: :file, content: content, mode: mode, mtime: mtime}
+          {:ok, %{fs | data: Map.put(fs.data, target_path, entry)}}
+      end
     end
   end
 
@@ -173,15 +201,15 @@ defmodule JustBash.FS.Memory do
   within this backend's namespace (mount-local, chroot-like).
   """
   @spec symlink(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
-  def symlink(%__MODULE__{data: data} = fs, target, link_path) do
-    normalized = normalize(link_path)
-
-    if Map.has_key?(data, normalized) do
-      {:error, Error.new(:eexist, path: normalized)}
-    else
-      fs = ensure_parent_dirs(fs, normalized)
-      entry = %{type: :symlink, target: target, mode: 0o777, mtime: DateTime.utc_now()}
-      {:ok, %{fs | data: Map.put(fs.data, normalized, entry)}}
+  def symlink(%__MODULE__{} = fs, target, link_path) do
+    with {:ok, normalized} <- resolve_for_create(fs, normalize(link_path)) do
+      if Map.has_key?(fs.data, normalized) do
+        {:error, Error.new(:eexist, path: normalized)}
+      else
+        fs = ensure_parent_dirs(fs, normalized)
+        entry = %{type: :symlink, target: target, mode: 0o777, mtime: DateTime.utc_now()}
+        {:ok, %{fs | data: Map.put(fs.data, normalized, entry)}}
+      end
     end
   end
 
@@ -208,10 +236,13 @@ defmodule JustBash.FS.Memory do
   need inode indirection in the entry model.
   """
   @spec link(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
-  def link(%__MODULE__{data: data} = fs, existing_path, new_path) do
-    existing_norm = normalize(existing_path)
-    new_norm = normalize(new_path)
+  def link(%__MODULE__{} = fs, existing_path, new_path) do
+    with {:ok, new_norm} <- resolve_for_create(fs, normalize(new_path)) do
+      do_link(fs, normalize(existing_path), new_norm)
+    end
+  end
 
+  defp do_link(%__MODULE__{data: data} = fs, existing_norm, new_norm) do
     cond do
       not Map.has_key?(data, existing_norm) ->
         {:error, Error.new(:enoent, path: existing_norm)}
@@ -240,19 +271,15 @@ defmodule JustBash.FS.Memory do
   def chmod(%__MODULE__{} = fs, path, mode) do
     normalized = normalize(path)
 
-    case resolve_final_path(fs, normalized, MapSet.new()) do
-      {:error, :eloop} ->
-        {:error, Error.new(:eloop, path: normalized)}
+    with {:ok, target_path} <- resolve_for_write(fs, normalized) do
+      case Map.get(fs.data, target_path) do
+        nil ->
+          {:error, Error.new(:enoent, path: normalized)}
 
-      {:ok, target_path} ->
-        case Map.get(fs.data, target_path) do
-          nil ->
-            {:error, Error.new(:enoent, path: normalized)}
-
-          entry ->
-            updated = %{entry | mode: mode}
-            {:ok, %{fs | data: Map.put(fs.data, target_path, updated)}}
-        end
+        entry ->
+          updated = %{entry | mode: mode}
+          {:ok, %{fs | data: Map.put(fs.data, target_path, updated)}}
+      end
     end
   end
 
@@ -262,28 +289,25 @@ defmodule JustBash.FS.Memory do
   Follows symlinks to the final target (POSIX `O_APPEND` semantics): the
   link survives and the target receives the bytes; appending to a
   dangling symlink creates the target. Preserves the file's existing
-  mode, unlike a read+write composition.
+  mode, unlike a read+write composition. A non-final path component that
+  resolves to a regular file is `:enotdir`.
   """
   @spec append_file(t(), String.t(), binary()) :: {:ok, t()} | {:error, Error.t()}
   def append_file(%__MODULE__{} = fs, path, content) do
     normalized = normalize(path)
 
-    case resolve_final_path(fs, normalized, MapSet.new()) do
-      {:error, :eloop} ->
-        {:error, Error.new(:eloop, path: normalized)}
+    with {:ok, target_path} <- resolve_for_write(fs, normalized) do
+      case Map.get(fs.data, target_path) do
+        %{type: :directory} ->
+          {:error, Error.new(:eisdir, path: normalized)}
 
-      {:ok, target_path} ->
-        case Map.get(fs.data, target_path) do
-          %{type: :directory} ->
-            {:error, Error.new(:eisdir, path: normalized)}
+        %{type: :file} = entry ->
+          updated = %{entry | content: entry.content <> content, mtime: DateTime.utc_now()}
+          {:ok, %{fs | data: Map.put(fs.data, target_path, updated)}}
 
-          %{type: :file} = entry ->
-            updated = %{entry | content: entry.content <> content, mtime: DateTime.utc_now()}
-            {:ok, %{fs | data: Map.put(fs.data, target_path, updated)}}
-
-          nil ->
-            write_file(fs, target_path, content)
-        end
+        nil ->
+          write_file(fs, target_path, content)
+      end
     end
   end
 
@@ -307,6 +331,12 @@ defmodule JustBash.FS.Memory do
   @doc false
   @spec __normalize__(String.t()) :: String.t()
   def __normalize__(path), do: normalize(path)
+
+  @doc false
+  @spec __resolve_for_create__(t(), String.t()) :: {:ok, String.t()} | {:error, Error.t()}
+  def __resolve_for_create__(%__MODULE__{} = fs, path) do
+    resolve_for_create(fs, normalize(path))
+  end
 
   # Tolerant normalization: unlike `VFS.Path.normalize/1`, accepts
   # relative and empty inputs by rooting them at "/". Backend-internal
@@ -361,23 +391,98 @@ defmodule JustBash.FS.Memory do
     end
   end
 
-  # Walk a symlink chain to the final (non-symlink) path. A missing entry
-  # terminates the walk with the path it would occupy — that is where an
-  # append through a dangling link creates the file.
-  @dialyzer {:nowarn_function, resolve_final_path: 3}
-  defp resolve_final_path(%__MODULE__{data: data} = fs, path, seen) do
+  # ── POSIX path resolution ────────────────────────────────────────────────
+  #
+  # A path resolves one component at a time, following symlinks at every
+  # step. Every non-final component must resolve to a directory or to
+  # nothing (writes create the missing intermediate directories); one that
+  # resolves to a regular file is ENOTDIR, exactly as the kernel reports
+  # it. Without that check a write stored an entry underneath a regular
+  # file — readable by its path, yet unreachable from any directory
+  # listing or `VFS.walk/3` (issue #53).
+
+  # Resolve every component *including* a symlink at the final one:
+  # O_TRUNC/O_APPEND/chmod semantics, where the link is written through. A
+  # missing entry resolves to the path it would occupy — that is where a
+  # write through a dangling link creates the file.
+  # The `seen` MapSet threads through the mutually recursive walkers, and
+  # dialyzer cannot see through the opaque struct across the recursion.
+  @dialyzer {:nowarn_function,
+             [resolve_full: 3, resolve_ancestors: 3, resolve_directory: 3, follow_link: 3]}
+
+  @spec resolve_for_write(t(), String.t()) :: {:ok, String.t()} | {:error, Error.t()}
+  defp resolve_for_write(%__MODULE__{} = fs, path), do: resolve_full(fs, path, MapSet.new())
+
+  # Resolve every component *except* the final one, which is taken
+  # literally: mkdir/symlink/link semantics, where an existing final
+  # component is EEXIST rather than a link to follow.
+  @spec resolve_for_create(t(), String.t()) :: {:ok, String.t()} | {:error, Error.t()}
+  defp resolve_for_create(%__MODULE__{} = fs, path), do: resolve_ancestors(fs, path, MapSet.new())
+
+  defp resolve_full(%__MODULE__{} = fs, path, seen) do
+    with {:ok, candidate} <- resolve_ancestors(fs, path, seen) do
+      follow_link(fs, candidate, seen)
+    end
+  end
+
+  defp resolve_ancestors(_fs, "/", _seen), do: {:ok, "/"}
+
+  defp resolve_ancestors(%__MODULE__{} = fs, path, seen) do
+    with {:ok, parent} <- resolve_directory(fs, VPath.dirname(path), seen) do
+      {:ok, join_child(parent, VPath.basename(path))}
+    end
+  end
+
+  defp resolve_directory(%__MODULE__{} = fs, path, seen) do
+    with {:ok, resolved} <- resolve_full(fs, path, seen) do
+      case Map.get(fs.data, resolved) do
+        nil -> {:ok, resolved}
+        %{type: :directory} -> {:ok, resolved}
+        _ -> {:error, Error.new(:enotdir, path: resolved)}
+      end
+    end
+  end
+
+  defp follow_link(%__MODULE__{data: data} = fs, path, seen) do
     case Map.get(data, path) do
       %{type: :symlink, target: target} ->
         if MapSet.member?(seen, path) do
-          {:error, :eloop}
+          {:error, Error.new(:eloop, path: path)}
         else
           resolved = resolve_symlink_target(path, target)
-          resolve_final_path(fs, resolved, MapSet.put(seen, path))
+          resolve_full(fs, resolved, MapSet.put(seen, path))
         end
 
       _ ->
         {:ok, path}
     end
+  end
+
+  defp join_child("/", child), do: "/" <> child
+  defp join_child(parent, child), do: parent <> "/" <> child
+
+  # An initial-files entry conflicts when another entry is one of its
+  # ancestors: that ancestor is a regular file, so the deeper path cannot
+  # exist. Checking ancestors (rather than string prefixes) keeps
+  # "/m/jj" and "/m/j" independent.
+  defp find_conflict(by_path) do
+    Enum.find_value(by_path, fn {path, original} ->
+      path
+      |> ancestors()
+      |> Enum.find_value(fn ancestor ->
+        case Map.fetch(by_path, ancestor) do
+          {:ok, ancestor_original} -> {ancestor_original, original}
+          :error -> nil
+        end
+      end)
+    end)
+  end
+
+  defp ancestors("/"), do: []
+
+  defp ancestors(path) do
+    parent = VPath.dirname(path)
+    if parent == "/", do: [], else: [parent | ancestors(parent)]
   end
 
   defp resolve_symlink_target(symlink_path, target) do
@@ -458,22 +563,13 @@ defimpl VFS.Mountable, for: JustBash.FS.Memory do
     Memory.write_file(fs, path, content, opts)
   end
 
-  def mkdir(%Memory{data: data} = fs, path, opts) do
-    normalized = Memory.__normalize__(path)
-    parents? = Keyword.get(opts, :parents, false)
-
-    case Map.get(data, normalized) do
-      %{type: type} when type != :directory ->
-        {:error, Error.new(:eexist, path: normalized)}
-
-      %{type: :directory} when not parents? ->
-        {:error, Error.new(:eexist, path: normalized)}
-
-      %{type: :directory} ->
-        {:ok, fs}
-
-      nil ->
-        mkdir_with_parent(fs, normalized, parents?)
+  # Every ancestor must resolve to a directory (or to nothing, when
+  # `parents: true` will create it); an ancestor that is a regular file is
+  # ENOTDIR, and `mkdir -p` must refuse rather than bury the new directory
+  # under it.
+  def mkdir(%Memory{} = fs, path, opts) do
+    with {:ok, resolved} <- Memory.__resolve_for_create__(fs, path) do
+      do_mkdir_resolved(fs, resolved, Keyword.get(opts, :parents, false))
     end
   end
 
@@ -496,6 +592,22 @@ defimpl VFS.Mountable, for: JustBash.FS.Memory do
   def capabilities(_), do: MapSet.new([:read, :write, :mkdir])
 
   # ── helpers ──
+
+  defp do_mkdir_resolved(%Memory{data: data} = fs, normalized, parents?) do
+    case Map.get(data, normalized) do
+      %{type: type} when type != :directory ->
+        {:error, Error.new(:eexist, path: normalized)}
+
+      %{type: :directory} when not parents? ->
+        {:error, Error.new(:eexist, path: normalized)}
+
+      %{type: :directory} ->
+        {:ok, fs}
+
+      nil ->
+        mkdir_with_parent(fs, normalized, parents?)
+    end
+  end
 
   defp mkdir_with_parent(%Memory{data: data} = fs, normalized, parents?) do
     parent = VFS.Path.dirname(normalized)

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -232,7 +232,8 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   # cannot open means the command produces nothing at all. Clearing the
   # redirected stream is how far that goes here: the command has already run,
   # but its output was bound for the file and must not surface as the
-  # caller's stdout.
+  # caller's stdout. Not running the command at all needs the target expanded
+  # and opened before the body — see issue #59.
   defp redirect_failed(result, stream, path, error) do
     cleared = clear_stream(result, stream)
     error_msg = "bash: #{path}: #{FS.strerror(error)}\n"

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -171,8 +171,7 @@ defmodule JustBash.Interpreter.Executor.Redirection do
         {updated_result, %{bash | fs: new_fs}}
 
       {:error, error} ->
-        error_msg = format_redirection_error(path, error)
-        {%{result | stderr: result.stderr <> error_msg, exit_code: 1}, bash}
+        {redirect_failed(result, stream, path, error), bash}
     end
   end
 
@@ -185,8 +184,7 @@ defmodule JustBash.Interpreter.Executor.Redirection do
         {updated_result, %{bash | fs: new_fs}}
 
       {:error, error} ->
-        error_msg = format_redirection_error(path, error)
-        {%{result | stderr: result.stderr <> error_msg, exit_code: 1}, bash}
+        {redirect_failed(result, stream, path, error), bash}
     end
   end
 
@@ -198,8 +196,7 @@ defmodule JustBash.Interpreter.Executor.Redirection do
         {%{result | stdout: "", stderr: ""}, %{bash | fs: new_fs}}
 
       {:error, error} ->
-        error_msg = format_redirection_error(path, error)
-        {%{result | stderr: error_msg, exit_code: 1}, bash}
+        {result |> clear_stream(:stdout) |> redirect_failed(:stderr, path, error), bash}
     end
   end
 
@@ -211,8 +208,7 @@ defmodule JustBash.Interpreter.Executor.Redirection do
         {%{result | stdout: "", stderr: ""}, %{bash | fs: new_fs}}
 
       {:error, error} ->
-        error_msg = format_redirection_error(path, error)
-        {%{result | stderr: error_msg, exit_code: 1}, bash}
+        {result |> clear_stream(:stdout) |> redirect_failed(:stderr, path, error), bash}
     end
   end
 
@@ -232,8 +228,15 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   defp clear_stream(result, :stdout), do: %{result | stdout: ""}
   defp clear_stream(result, :stderr), do: %{result | stderr: ""}
 
-  defp format_redirection_error(path, error) do
-    "bash: #{path}: #{FS.strerror(error)}\n"
+  # bash opens the redirect target before running the command, so a target it
+  # cannot open means the command produces nothing at all. Clearing the
+  # redirected stream is how far that goes here: the command has already run,
+  # but its output was bound for the file and must not surface as the
+  # caller's stdout.
+  defp redirect_failed(result, stream, path, error) do
+    cleared = clear_stream(result, stream)
+    error_msg = "bash: #{path}: #{FS.strerror(error)}\n"
+    %{cleared | stderr: cleared.stderr <> error_msg, exit_code: 1}
   end
 
   # --- Stdin Content Extraction ---

--- a/test/just_bash/not_a_directory_test.exs
+++ b/test/just_bash/not_a_directory_test.exs
@@ -130,11 +130,15 @@ defmodule JustBash.NotADirectoryTest do
     end
   end
 
+  # Every one of these asserts stdout as well as stderr: the output was
+  # destined for the file, so a failed redirect must not spill it into the
+  # stream the caller reads back.
   describe "shell redirections through a regular file" do
     test "> reports Not a directory when the parent is a regular file" do
       {result, bash} = JustBash.exec(bash_with_file_parent(), "echo hi > /m/j/a.md")
 
       assert result.exit_code == 1
+      assert result.stdout == ""
       assert result.stderr == "bash: /m/j/a.md: Not a directory\n"
       assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, "/m/j/a.md")
     end
@@ -143,6 +147,7 @@ defmodule JustBash.NotADirectoryTest do
       {result, bash} = JustBash.exec(bash_with_file_parent(), "echo hi > /m/j/2026/a.md")
 
       assert result.exit_code == 1
+      assert result.stdout == ""
       assert result.stderr == "bash: /m/j/2026/a.md: Not a directory\n"
       assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, "/m/j/2026/a.md")
       assert walked(bash.fs, "/m") == ["/m", "/m/j"]
@@ -152,31 +157,82 @@ defmodule JustBash.NotADirectoryTest do
       {result, _bash} = JustBash.exec(bash_with_file_parent(), "echo hi >> /m/j/2026/a.md")
 
       assert result.exit_code == 1
+      assert result.stdout == ""
       assert result.stderr == "bash: /m/j/2026/a.md: Not a directory\n"
     end
 
-    test "2> reports Not a directory" do
+    test "2> reports Not a directory and does not spill the command's stderr" do
       {result, _bash} = JustBash.exec(bash_with_file_parent(), "ls /nope 2> /m/j/err.log")
 
       assert result.exit_code == 1
-      assert result.stderr =~ "bash: /m/j/err.log: Not a directory\n"
+      assert result.stdout == ""
+      # `ls: cannot access '/nope'` was redirected into the file, so only the
+      # shell's own message about the failed redirect survives.
+      assert result.stderr == "bash: /m/j/err.log: Not a directory\n"
     end
 
     test "&> reports Not a directory" do
       {result, _bash} = JustBash.exec(bash_with_file_parent(), "echo hi &> /m/j/a.md")
 
       assert result.exit_code == 1
+      assert result.stdout == ""
       assert result.stderr == "bash: /m/j/a.md: Not a directory\n"
+    end
+
+    test ">> onto an existing directory does not spill stdout either" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "mkdir -p /d && echo hi >> /d")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "bash: /d: Is a directory\n"
     end
   end
 
   describe "commands that create paths through a regular file" do
-    test "mkdir -p reports Not a directory" do
+    # GNU coreutils 9.11 names the offending *ancestor* for -p, because that
+    # is the directory it actually failed to create, and the full operand
+    # without it:
+    #   gmkdir j/2026           -> cannot create directory 'j/2026'
+    #   gmkdir -p j/2026        -> cannot create directory 'j'
+    #   gmkdir -p j/2026/deeper -> cannot create directory 'j'
+    test "mkdir -p names the offending ancestor, not the full operand" do
       {result, bash} = JustBash.exec(bash_with_file_parent(), "mkdir -p /m/j/2026")
 
       assert result.exit_code == 1
-      assert result.stderr == "mkdir: cannot create directory '/m/j/2026': Not a directory\n"
+      assert result.stderr == "mkdir: cannot create directory '/m/j': Not a directory\n"
       assert walked(bash.fs, "/m") == ["/m", "/m/j"]
+    end
+
+    test "mkdir -p names the offending ancestor for a deeper operand" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "mkdir -p /m/j/2026/deeper")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mkdir: cannot create directory '/m/j': Not a directory\n"
+    end
+
+    # The ancestor is named as the operand expressed it, matching GNU.
+    test "mkdir -p names the offending ancestor in the operand's own form" do
+      bash = bash_with_file_parent()
+      {result, _bash} = JustBash.exec(bash, "cd /m && mkdir -p j/2026")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mkdir: cannot create directory 'j': Not a directory\n"
+    end
+
+    test "mkdir -p on a dangling symlink reports File exists" do
+      {result, _bash} =
+        JustBash.exec(JustBash.new(), "ln -s /nowhere /dang; mkdir -p /dang")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mkdir: cannot create directory '/dang': File exists\n"
+    end
+
+    test "mkdir -p on a symlink to a directory still succeeds" do
+      {result, _bash} =
+        JustBash.exec(JustBash.new(), "mkdir -p /real && ln -s /real /link && mkdir -p /link")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
     end
 
     test "mkdir reports Not a directory" do
@@ -213,10 +269,27 @@ defmodule JustBash.NotADirectoryTest do
 
       assert result.exit_code == 1
 
-      assert result.stderr ==
-               "cp: cannot create regular file '/m/j/a.md': Not a directory\n"
+      # GNU stats the destination first, so ENOTDIR surfaces as `cannot stat`.
+      # `cannot create regular file` stays the wording for :enoent.
+      assert result.stderr == "cp: cannot stat '/m/j/a.md': Not a directory\n"
 
       assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, "/m/j/a.md")
+    end
+
+    test "cp keeps 'cannot create regular file' for a non-ENOTDIR failure" do
+      bash = JustBash.new(files: %{"/src.txt" => "x\n"})
+      {result, _bash} = JustBash.exec(bash, "mkdir -p /d && cp /src.txt /d")
+
+      # /d is a directory, so this is :eisdir, not :enotdir.
+      refute result.stderr =~ "cannot stat"
+    end
+
+    test "tee reports Not a directory for a deeper path too" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "echo hi | tee /m/j/2026/a.md")
+
+      assert result.exit_code == 1
+      assert result.stdout == "hi\n"
+      assert result.stderr == "tee: /m/j/2026/a.md: Not a directory\n"
     end
 
     test "mv reports Not a directory and keeps the source" do
@@ -270,6 +343,175 @@ defmodule JustBash.NotADirectoryTest do
     end
   end
 
+  # A path resolves the same way whichever side of the filesystem asks.
+  # Writes have followed intermediate symlinks since #53; if reads did not,
+  # a write through a symlinked directory would land at the target and be
+  # invisible at the path the caller used — the #53 bug class mirrored,
+  # and worse, because the write reports success.
+  describe "symlinked intermediate components resolve on the read side too" do
+    defp fs_with_linked_dir do
+      {:ok, fs} = FS.mkdir(FS.new(), "/real", parents: true)
+      {:ok, fs} = FS.symlink(fs, "/real", "/link")
+      fs
+    end
+
+    defp bash_with_linked_dir do
+      {_result, bash} = JustBash.exec(JustBash.new(), "mkdir -p /real && ln -s /real /link")
+      bash
+    end
+
+    test "read_file/2 sees a file written through the link" do
+      {:ok, fs} = FS.write_file(fs_with_linked_dir(), "/link/a.md", "hi\n")
+
+      assert {:ok, "hi\n", _fs} = FS.read_file(fs, "/link/a.md")
+      assert {:ok, "hi\n", _fs} = FS.read_file(fs, "/real/a.md")
+    end
+
+    test "read_file/2 sees a file written through a link and a created parent" do
+      {:ok, fs} = FS.write_file(fs_with_linked_dir(), "/link/sub/a.md", "hi\n")
+
+      assert {:ok, "hi\n", _fs} = FS.read_file(fs, "/link/sub/a.md")
+      assert {:ok, "hi\n", _fs} = FS.read_file(fs, "/real/sub/a.md")
+    end
+
+    test "stat/2 resolves an intermediate symlink" do
+      {:ok, fs} = FS.write_file(fs_with_linked_dir(), "/link/a.md", "hi\n")
+
+      assert {:ok, %VFS.Stat{type: :regular, size: 3}, _fs} = FS.stat(fs, "/link/a.md")
+    end
+
+    test "exists?/2 resolves an intermediate symlink" do
+      {:ok, fs} = FS.write_file(fs_with_linked_dir(), "/link/a.md", "hi\n")
+
+      assert FS.exists?(fs, "/link/a.md")
+    end
+
+    test "readdir/2 lists through a symlinked directory" do
+      {:ok, fs} = FS.write_file(fs_with_linked_dir(), "/link/a.md", "hi\n")
+
+      assert {:ok, ["a.md"], _fs} = FS.readdir(fs, "/link")
+      assert {:ok, ["a.md"], _fs} = FS.readdir(fs, "/real")
+    end
+
+    test "rm/3 removes a file addressed through the link" do
+      {:ok, fs} = FS.write_file(fs_with_linked_dir(), "/link/a.md", "hi\n")
+
+      assert {:ok, fs} = FS.rm(fs, "/link/a.md")
+      assert {:error, %VFS.Error{kind: :enoent}} = FS.read_file(fs, "/real/a.md")
+    end
+
+    test "rm/3 does not follow a symlink at the final component" do
+      fs = fs_with_linked_dir()
+
+      assert {:ok, fs} = FS.rm(fs, "/link")
+      assert {:ok, %VFS.Stat{type: :directory}, _fs} = FS.stat(fs, "/real")
+      assert {:error, %VFS.Error{kind: :enoent}} = FS.stat(fs, "/link")
+    end
+
+    test "lstat/2 resolves ancestors but reports the link at the final component" do
+      {:ok, fs} = FS.symlink(fs_with_linked_dir(), "/real", "/real/inner")
+
+      assert {:ok, %VFS.Stat{type: :symlink}, _fs} = FS.lstat(fs, "/link/inner")
+      assert {:ok, %VFS.Stat{type: :symlink}, _fs} = FS.lstat(fs, "/link")
+    end
+
+    test "readlink/2 resolves ancestors but reads the link at the final component" do
+      {:ok, fs} = FS.symlink(fs_with_linked_dir(), "/elsewhere", "/real/inner")
+
+      assert {:ok, "/elsewhere", _fs} = FS.readlink(fs, "/link/inner")
+    end
+
+    test "link/3 resolves the source path's ancestors too" do
+      {:ok, fs} = FS.write_file(fs_with_linked_dir(), "/real/f", "x")
+
+      assert {:ok, fs} = FS.link(fs, "/link/f", "/dst")
+      assert {:ok, "x", _fs} = FS.read_file(fs, "/dst")
+    end
+
+    test "a chain that repeats a symlink without cycling still resolves" do
+      {:ok, fs} = FS.mkdir(FS.new(), "/real", parents: true)
+      {:ok, fs} = FS.symlink(fs, "/real", "/real/self")
+
+      assert {:ok, fs} = FS.write_file(fs, "/real/self/self/x", "hi\n")
+      assert {:ok, "hi\n", _fs} = FS.read_file(fs, "/real/x")
+      assert {:ok, "hi\n", _fs} = FS.read_file(fs, "/real/self/self/x")
+    end
+
+    test "a genuine symlink cycle is :eloop on both sides" do
+      {:ok, fs} = FS.symlink(FS.new(), "/b", "/a")
+      {:ok, fs} = FS.symlink(fs, "/a", "/b")
+
+      assert {:error, %VFS.Error{kind: :eloop}} = FS.write_file(fs, "/a/x", "hi\n")
+      assert {:error, %VFS.Error{kind: :eloop}} = FS.read_file(fs, "/a/x")
+      assert {:error, %VFS.Error{kind: :eloop}} = FS.read_file(fs, "/a")
+    end
+
+    test "walk/3 reaches everything written through the link, at its real path" do
+      {:ok, fs} = FS.write_file(fs_with_linked_dir(), "/link/sub/a.md", "hi\n")
+
+      assert walked(fs, "/real") == ["/real", "/real/sub", "/real/sub/a.md"]
+    end
+
+    test "> through a symlinked directory is readable at the path used" do
+      {result, bash} =
+        JustBash.exec(bash_with_linked_dir(), "echo hi > /link/a.md; cat /link/a.md")
+
+      assert result.exit_code == 0
+      assert result.stdout == "hi\n"
+      assert {:ok, "hi\n", _fs} = FS.read_file(bash.fs, "/real/a.md")
+    end
+
+    test ">> through a symlinked directory is readable at the path used" do
+      {result, _bash} =
+        JustBash.exec(bash_with_linked_dir(), "echo a >> /link/ap.txt; cat /link/ap.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == "a\n"
+    end
+
+    test "cp through a symlinked directory is readable at the path used" do
+      {result, _bash} =
+        JustBash.exec(
+          bash_with_linked_dir(),
+          "echo x > /src.txt; cp /src.txt /link/c.txt; cat /link/c.txt"
+        )
+
+      assert result.exit_code == 0
+      assert result.stdout == "x\n"
+      assert result.stderr == ""
+    end
+
+    test "touch then ls through a symlinked directory" do
+      {result, _bash} = JustBash.exec(bash_with_linked_dir(), "touch /link/t.txt && ls /link")
+
+      assert result.exit_code == 0
+      assert result.stdout == "t.txt\n"
+    end
+
+    test "mkdir -p then ls through a symlinked directory" do
+      {result, bash} = JustBash.exec(bash_with_linked_dir(), "mkdir -p /link/sub && ls /link")
+
+      assert result.exit_code == 0
+      assert result.stdout == "sub\n"
+      assert {:ok, %VFS.Stat{type: :directory}, _fs} = FS.stat(bash.fs, "/link/sub")
+    end
+
+    test "rm through a symlinked directory" do
+      {result, _bash} = JustBash.exec(bash_with_linked_dir(), "echo hi > /link/f && rm /link/f")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+    end
+
+    test "a relative write inside a symlinked cwd is readable back" do
+      {result, _bash} =
+        JustBash.exec(bash_with_linked_dir(), "cd /link && echo hi > f.txt && cat f.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == "hi\n"
+    end
+  end
+
   describe "inconsistent initial file maps" do
     test "JustBash.new/1 raises when one file path runs through another" do
       assert_raise ArgumentError, ~r|"/m/j".*"/m/j/a\.md"|s, fn ->
@@ -311,6 +553,21 @@ defmodule JustBash.NotADirectoryTest do
       assert_raise ArgumentError, ~r|/tmp|, fn ->
         JustBash.new(files: %{"/tmp" => "not a dir"})
       end
+    end
+
+    # The nested-path check cannot see every unrealizable map — a seed that
+    # collides with a directory the backend already holds only fails at the
+    # write. All three entry points should still report it the same way.
+    test "the memory backend raises ArgumentError when a seed cannot be written" do
+      assert_raise ArgumentError, ~r|"/"|, fn -> Memory.new(%{"/" => "x"}) end
+    end
+
+    test "FS.new/1 raises ArgumentError when a seed cannot be written" do
+      assert_raise ArgumentError, ~r|"/"|, fn -> FS.new(%{"/" => "x"}) end
+    end
+
+    test "JustBash.new/1 raises ArgumentError when a seed cannot be written" do
+      assert_raise ArgumentError, fn -> JustBash.new(files: %{"/" => "x"}) end
     end
   end
 end

--- a/test/just_bash/not_a_directory_test.exs
+++ b/test/just_bash/not_a_directory_test.exs
@@ -1,0 +1,316 @@
+defmodule JustBash.NotADirectoryTest do
+  @moduledoc """
+  Regression tests for issue #53: a write through a path component that is
+  a regular file used to succeed, storing an entry that `FS.walk/3` could
+  never reach.
+
+  POSIX path resolution says every non-final component must be a
+  directory; anything else is `ENOTDIR`. Enforcing that at the filesystem
+  layer is what makes the unreachable state impossible by construction,
+  so most of these tests poke `JustBash.FS` directly and the shell tests
+  only assert the bash-shaped rendering of the error.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.FS
+  alias JustBash.FS.Memory
+
+  # /m/j is a regular file, so nothing may be created under it.
+  defp fs_with_file_parent, do: FS.new(%{"/m/j" => "parent\n"})
+
+  defp bash_with_file_parent(files \\ %{}) do
+    JustBash.new(files: Map.merge(%{"/m/j" => "parent\n"}, files))
+  end
+
+  defp walked(fs, root) do
+    fs |> FS.walk(root, include_dirs: true) |> Enum.map(&elem(&1, 0)) |> Enum.sort()
+  end
+
+  describe "FS.write_file/4 through a regular file" do
+    test "returns :enotdir when the parent component is a regular file" do
+      assert {:error, %VFS.Error{kind: :enotdir}} =
+               FS.write_file(fs_with_file_parent(), "/m/j/a.md", "hi\n")
+    end
+
+    test "returns :enotdir when a deeper ancestor is a regular file" do
+      assert {:error, %VFS.Error{kind: :enotdir}} =
+               FS.write_file(fs_with_file_parent(), "/m/j/2026/a.md", "hi\n")
+    end
+
+    test "the backend names the offending component, the mount table the requested path" do
+      backend = Memory.new(%{"/m/j" => "parent\n"})
+
+      assert {:error, %VFS.Error{kind: :enotdir, path: "/m/j"}} =
+               Memory.write_file(backend, "/m/j/2026/a.md", "hi\n")
+
+      # vfs rewrites error paths into the caller's namespace, which is also
+      # the path bash names in `bash: /m/j/2026/a.md: Not a directory`.
+      assert {:error, %VFS.Error{kind: :enotdir, path: "/m/j/2026/a.md"}} =
+               FS.write_file(fs_with_file_parent(), "/m/j/2026/a.md", "hi\n")
+    end
+
+    test "leaves the store untouched" do
+      fs = fs_with_file_parent()
+      assert {:error, _} = FS.write_file(fs, "/m/j/2026/a.md", "hi\n")
+      assert {:error, %VFS.Error{}} = FS.read_file(fs, "/m/j/2026/a.md")
+      assert walked(fs, "/m") == ["/m", "/m/j"]
+    end
+
+    test "still creates missing intermediate directories under a real directory" do
+      assert {:ok, fs} = FS.write_file(FS.new(), "/m/d/2026/a.md", "hi\n")
+      assert {:ok, "hi\n", _fs} = FS.read_file(fs, "/m/d/2026/a.md")
+      assert "/m/d/2026" in walked(fs, "/m")
+    end
+
+    test "resolves a symlinked intermediate component to its target directory" do
+      {:ok, fs} = FS.mkdir(FS.new(), "/real", parents: true)
+      {:ok, fs} = FS.symlink(fs, "/real", "/link")
+
+      assert {:ok, fs} = FS.write_file(fs, "/link/sub/a.md", "hi\n")
+      assert {:ok, "hi\n", _fs} = FS.read_file(fs, "/real/sub/a.md")
+      assert "/real/sub/a.md" in walked(fs, "/real")
+    end
+
+    test "returns :enotdir when an intermediate symlink points at a regular file" do
+      {:ok, fs} = FS.write_file(FS.new(), "/file", "x")
+      {:ok, fs} = FS.symlink(fs, "/file", "/link")
+
+      assert {:error, %VFS.Error{kind: :enotdir}} = FS.write_file(fs, "/link/a.md", "hi\n")
+    end
+  end
+
+  describe "other path-creating FS operations through a regular file" do
+    test "append_file/3 returns :enotdir" do
+      assert {:error, %VFS.Error{kind: :enotdir}} =
+               FS.append_file(fs_with_file_parent(), "/m/j/a.md", "hi\n")
+
+      assert {:error, %VFS.Error{kind: :enotdir}} =
+               FS.append_file(fs_with_file_parent(), "/m/j/2026/a.md", "hi\n")
+    end
+
+    test "mkdir/3 with parents: true returns :enotdir" do
+      assert {:error, %VFS.Error{kind: :enotdir}} =
+               FS.mkdir(fs_with_file_parent(), "/m/j/2026", parents: true)
+    end
+
+    test "mkdir/3 without parents returns :enotdir" do
+      assert {:error, %VFS.Error{kind: :enotdir}} =
+               FS.mkdir(fs_with_file_parent(), "/m/j/2026")
+    end
+
+    test "mkdir/3 on the regular file itself still reports :eexist" do
+      assert {:error, %VFS.Error{kind: :eexist}} = FS.mkdir(fs_with_file_parent(), "/m/j")
+
+      assert {:error, %VFS.Error{kind: :eexist}} =
+               FS.mkdir(fs_with_file_parent(), "/m/j", parents: true)
+    end
+
+    test "symlink/3 returns :enotdir" do
+      assert {:error, %VFS.Error{kind: :enotdir}} =
+               FS.symlink(fs_with_file_parent(), "/m", "/m/j/link")
+    end
+
+    test "link/3 returns :enotdir" do
+      {:ok, fs} = FS.write_file(fs_with_file_parent(), "/src.txt", "x")
+
+      assert {:error, %VFS.Error{kind: :enotdir}} = FS.link(fs, "/src.txt", "/m/j/hard")
+    end
+
+    test "cp/4 returns :enotdir" do
+      {:ok, fs} = FS.write_file(fs_with_file_parent(), "/src.txt", "x")
+
+      assert {:error, %VFS.Error{kind: :enotdir}} = FS.cp(fs, "/src.txt", "/m/j/a.md")
+    end
+
+    test "mv/3 returns :enotdir and keeps the source" do
+      {:ok, fs} = FS.write_file(fs_with_file_parent(), "/src.txt", "x")
+
+      assert {:error, %VFS.Error{kind: :enotdir}} = FS.mv(fs, "/src.txt", "/m/j/a.md")
+      assert {:ok, "x", _fs} = FS.read_file(fs, "/src.txt")
+    end
+  end
+
+  describe "shell redirections through a regular file" do
+    test "> reports Not a directory when the parent is a regular file" do
+      {result, bash} = JustBash.exec(bash_with_file_parent(), "echo hi > /m/j/a.md")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /m/j/a.md: Not a directory\n"
+      assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, "/m/j/a.md")
+    end
+
+    test "> reports Not a directory for a deeper path and stores nothing" do
+      {result, bash} = JustBash.exec(bash_with_file_parent(), "echo hi > /m/j/2026/a.md")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /m/j/2026/a.md: Not a directory\n"
+      assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, "/m/j/2026/a.md")
+      assert walked(bash.fs, "/m") == ["/m", "/m/j"]
+    end
+
+    test ">> reports Not a directory" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "echo hi >> /m/j/2026/a.md")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /m/j/2026/a.md: Not a directory\n"
+    end
+
+    test "2> reports Not a directory" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "ls /nope 2> /m/j/err.log")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "bash: /m/j/err.log: Not a directory\n"
+    end
+
+    test "&> reports Not a directory" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "echo hi &> /m/j/a.md")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /m/j/a.md: Not a directory\n"
+    end
+  end
+
+  describe "commands that create paths through a regular file" do
+    test "mkdir -p reports Not a directory" do
+      {result, bash} = JustBash.exec(bash_with_file_parent(), "mkdir -p /m/j/2026")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mkdir: cannot create directory '/m/j/2026': Not a directory\n"
+      assert walked(bash.fs, "/m") == ["/m", "/m/j"]
+    end
+
+    test "mkdir reports Not a directory" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "mkdir /m/j/2026")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mkdir: cannot create directory '/m/j/2026': Not a directory\n"
+    end
+
+    test "mkdir -p on the regular file itself reports File exists" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "mkdir -p /m/j")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mkdir: cannot create directory '/m/j': File exists\n"
+    end
+
+    test "mkdir -p on an existing directory still succeeds" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "mkdir -p /m/d && mkdir -p /m/d")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+    end
+
+    test "touch reports Not a directory" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "touch /m/j/a.md")
+
+      assert result.exit_code == 1
+      assert result.stderr == "touch: cannot touch '/m/j/a.md': Not a directory\n"
+    end
+
+    test "cp reports Not a directory" do
+      bash = bash_with_file_parent(%{"/src.txt" => "x\n"})
+      {result, bash} = JustBash.exec(bash, "cp /src.txt /m/j/a.md")
+
+      assert result.exit_code == 1
+
+      assert result.stderr ==
+               "cp: cannot create regular file '/m/j/a.md': Not a directory\n"
+
+      assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, "/m/j/a.md")
+    end
+
+    test "mv reports Not a directory and keeps the source" do
+      bash = bash_with_file_parent(%{"/src.txt" => "x\n"})
+      {result, bash} = JustBash.exec(bash, "mv /src.txt /m/j/a.md")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot move '/src.txt' to '/m/j/a.md': Not a directory\n"
+      assert {:ok, "x\n", _fs} = FS.read_file(bash.fs, "/src.txt")
+    end
+
+    test "tee reports Not a directory but still passes stdin through" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "echo hi | tee /m/j/a.md")
+
+      assert result.exit_code == 1
+      assert result.stdout == "hi\n"
+      assert result.stderr == "tee: /m/j/a.md: Not a directory\n"
+    end
+
+    test "ln -s reports Not a directory" do
+      bash = bash_with_file_parent(%{"/src.txt" => "x\n"})
+      {result, _bash} = JustBash.exec(bash, "ln -s /src.txt /m/j/link")
+
+      assert result.exit_code == 1
+
+      assert result.stderr ==
+               "ln: failed to create symbolic link '/m/j/link': Not a directory\n"
+    end
+  end
+
+  describe "store reachability" do
+    test "everything the shell writes is reachable from walk/3" do
+      bash = bash_with_file_parent()
+
+      {_result, bash} =
+        JustBash.exec(bash, """
+        echo hi > /m/j/2026/a.md
+        mkdir -p /m/j/2026
+        touch /m/j/b.md
+        echo ok > /m/d/2026/a.md
+        """)
+
+      reachable = walked(bash.fs, "/m")
+
+      assert reachable == ["/m", "/m/d", "/m/d/2026", "/m/d/2026/a.md", "/m/j"]
+
+      for path <- ["/m/j/2026/a.md", "/m/j/b.md", "/m/j/2026"] do
+        refute path in reachable
+        assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, path)
+      end
+    end
+  end
+
+  describe "inconsistent initial file maps" do
+    test "JustBash.new/1 raises when one file path runs through another" do
+      assert_raise ArgumentError, ~r|"/m/j".*"/m/j/a\.md"|s, fn ->
+        JustBash.new(files: %{"/m/j" => "x", "/m/j/a.md" => "y"})
+      end
+    end
+
+    test "JustBash.new/1 raises for a deeper conflict" do
+      assert_raise ArgumentError, fn ->
+        JustBash.new(files: %{"/m/j" => "x", "/m/j/2026/a.md" => "y"})
+      end
+    end
+
+    test "FS.new/1 raises for the same conflict" do
+      assert_raise ArgumentError, fn ->
+        FS.new(%{"/m/j" => "x", "/m/j/a.md" => "y"})
+      end
+    end
+
+    test "the memory backend raises for the same conflict" do
+      assert_raise ArgumentError, fn ->
+        Memory.new(%{"/m/j" => "x", "/m/j/a.md" => "y"})
+      end
+    end
+
+    test "a shared path prefix that is not a component boundary is fine" do
+      bash = JustBash.new(files: %{"/m/jj" => "x", "/m/j" => "y"})
+      {result, _bash} = JustBash.exec(bash, "cat /m/jj /m/j")
+      assert result.stdout == "xy"
+    end
+
+    test "consistent nested maps still work" do
+      bash = JustBash.new(files: %{"/m/j/a.md" => "x", "/m/j/b.md" => "y"})
+      {result, _bash} = JustBash.exec(bash, "cat /m/j/a.md /m/j/b.md")
+      assert result.stdout == "xy"
+    end
+
+    test "raises when a file path collides with a default directory" do
+      assert_raise ArgumentError, ~r|/tmp|, fn ->
+        JustBash.new(files: %{"/tmp" => "not a dir"})
+      end
+    end
+  end
+end

--- a/test/just_bash/not_a_directory_test.exs
+++ b/test/just_bash/not_a_directory_test.exs
@@ -26,6 +26,23 @@ defmodule JustBash.NotADirectoryTest do
     fs |> FS.walk(root, include_dirs: true) |> Enum.map(&elem(&1, 0)) |> Enum.sort()
   end
 
+  # A traversal that diverges must fail the test, not hang the suite — and
+  # must not take the VM down with it. `:brutal_kill` reclaims whatever the
+  # runaway traversal allocated along with the process that allocated it.
+  defp within(fun, timeout \\ 5_000) do
+    task = Task.async(fun)
+
+    case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
+      {:ok, value} -> value
+      _ -> flunk("did not terminate within #{timeout}ms")
+    end
+  end
+
+  defp exec_within(bash, script) do
+    {result, _bash} = within(fn -> JustBash.exec(bash, script) end)
+    result
+  end
+
   describe "FS.write_file/4 through a regular file" do
     test "returns :enotdir when the parent component is a regular file" do
       assert {:error, %VFS.Error{kind: :enotdir}} =
@@ -340,6 +357,214 @@ defmodule JustBash.NotADirectoryTest do
         refute path in reachable
         assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, path)
       end
+    end
+
+    # The companion invariant to "walk reaches everything": it also has to
+    # stop. A `stat`-driven walk re-enters the tree through a symlinked
+    # directory, so one self-link inflates the result and two make it
+    # diverge — the store's keys are finite, the traversal over them was not.
+    test "walk/3 terminates over a tree that contains a symlink cycle" do
+      {_result, bash} =
+        JustBash.exec(JustBash.new(), """
+        mkdir -p /real/sub
+        echo hi > /real/a.txt
+        ln -s /real /real/s1
+        ln -s /real /real/s2
+        ln -s /real/sub /real/sub/back
+        """)
+
+      assert within(fn -> walked(bash.fs, "/real") end) ==
+               [
+                 "/real",
+                 "/real/a.txt",
+                 "/real/s1",
+                 "/real/s2",
+                 "/real/sub",
+                 "/real/sub/back"
+               ]
+    end
+
+    test "walk/3 yields each stored entry exactly once" do
+      {_result, bash} =
+        JustBash.exec(
+          JustBash.new(),
+          "mkdir -p /real; echo hi > /real/a.txt; ln -s /real /real/self"
+        )
+
+      walked =
+        within(fn -> Enum.map(FS.walk(bash.fs, "/real", include_dirs: true), &elem(&1, 0)) end)
+
+      assert Enum.sort(walked) == Enum.uniq(Enum.sort(walked))
+    end
+
+    test "walk/3 reports a symlink as a symlink rather than as its target" do
+      {_result, bash} = JustBash.exec(JustBash.new(), "mkdir -p /real; ln -s /real /real/self")
+
+      assert [{"/real/self", %VFS.Stat{type: :symlink}}] =
+               within(fn -> Enum.to_list(FS.walk(bash.fs, "/real")) end)
+    end
+
+    test "walk/3 through a symlinked root reports paths under the root as asked" do
+      {_result, bash} =
+        JustBash.exec(
+          JustBash.new(),
+          "mkdir -p /real/sub; echo hi > /real/sub/a.txt; ln -s /real /link"
+        )
+
+      assert within(fn -> walked(bash.fs, "/link") end) ==
+               ["/link", "/link/sub", "/link/sub/a.txt"]
+    end
+
+    test "walk/3 honors :max_depth relative to the root" do
+      {_result, bash} =
+        JustBash.exec(JustBash.new(), "mkdir -p /real/sub/deeper; echo hi > /real/sub/a.txt")
+
+      assert within(fn ->
+               bash.fs
+               |> FS.walk("/real", include_dirs: true, max_depth: 1)
+               |> Enum.map(&elem(&1, 0))
+               |> Enum.sort()
+             end) == ["/real", "/real/sub"]
+    end
+  end
+
+  # `FS.stat/2` resolves symlinks, so a traversal that asks it "is this a
+  # directory?" descends *through* a symlinked directory and back into the
+  # tree it came from. One self-link inflates the output; two make the
+  # traversal diverge (2^40 paths, bounded only by SYMLOOP_MAX), which
+  # wedges the whole exec. GNU's default `-P` never descends into a
+  # symlink, so the descent decision belongs to `FS.lstat/2`.
+  describe "recursive commands do not descend into symlinked directories" do
+    defp bash_with_self_link do
+      {_result, bash} =
+        JustBash.exec(JustBash.new(cwd: "/w"), """
+        mkdir -p /w/real
+        echo hi > /w/real/a.txt
+        ln -s /w/real /w/real/self
+        """)
+
+      bash
+    end
+
+    defp bash_with_two_self_links do
+      {_result, bash} =
+        JustBash.exec(bash_with_self_link(), "ln -s /w/real /w/real/s2")
+
+      bash
+    end
+
+    # Two real files, so grep prefixes its matches with filenames and a
+    # match reached through a link is distinguishable from one that is not.
+    defp bash_with_linked_subtree do
+      {_result, bash} =
+        JustBash.exec(JustBash.new(cwd: "/w"), """
+        mkdir -p /w/real/sub
+        echo hi > /w/real/a.txt
+        echo hi > /w/real/sub/b.txt
+        ln -s /w/real /w/real/self
+        ln -s /w/real /w/real/s2
+        """)
+
+      bash
+    end
+
+    test "find lists the symlink and stops there" do
+      assert exec_within(bash_with_self_link(), "find /w/real").stdout ==
+               "/w/real\n/w/real/a.txt\n/w/real/self\n"
+    end
+
+    test "find terminates with two links back into the tree" do
+      result = exec_within(bash_with_two_self_links(), "find /w/real")
+
+      assert result.stdout == "/w/real\n/w/real/a.txt\n/w/real/s2\n/w/real/self\n"
+    end
+
+    test "find -type d does not match a symlink to a directory" do
+      assert exec_within(bash_with_self_link(), "find /w/real -type d").stdout == "/w/real\n"
+    end
+
+    test "find -type f does not match a symlink to a file" do
+      {_result, bash} = JustBash.exec(bash_with_self_link(), "ln -s /w/real/a.txt /w/real/lf")
+
+      assert exec_within(bash, "find /w/real -type f").stdout == "/w/real/a.txt\n"
+    end
+
+    test "find -type l matches the symlinks and nothing else" do
+      {_result, bash} = JustBash.exec(bash_with_self_link(), "ln -s /w/real/a.txt /w/real/lf")
+
+      assert exec_within(bash, "find /w/real -type l").stdout == "/w/real/lf\n/w/real/self\n"
+    end
+
+    test "find on a symlink operand reports the link without descending" do
+      {_result, bash} = JustBash.exec(bash_with_self_link(), "ln -s /w/real /w/link")
+
+      assert exec_within(bash, "find /w/link").stdout == "/w/link\n"
+    end
+
+    test "du -s terminates and counts the tree once" do
+      result = exec_within(bash_with_two_self_links(), "du -s /w/real")
+
+      assert result.exit_code == 0
+      assert [_line] = String.split(result.stdout, "\n", trim: true)
+    end
+
+    test "grep -r does not read files through a symlinked directory" do
+      assert exec_within(bash_with_linked_subtree(), "grep -r hi /w/real").stdout ==
+               "/w/real/a.txt:hi\n/w/real/sub/b.txt:hi\n"
+    end
+
+    # GNU grep follows a symlink named on the command line and skips the ones
+    # it meets while recursing, so the operand link keeps working.
+    test "grep -r still follows a symlink named on the command line" do
+      {_result, bash} = JustBash.exec(bash_with_linked_subtree(), "ln -s /w/real /w/link")
+
+      assert exec_within(bash, "grep -r hi /w/link").stdout ==
+               "/w/link/a.txt:hi\n/w/link/sub/b.txt:hi\n"
+    end
+
+    test "tree terminates and lists the symlink once" do
+      result = exec_within(bash_with_two_self_links(), "tree /w/real")
+
+      assert result.exit_code == 0
+      refute result.stdout =~ "self/"
+      assert length(String.split(result.stdout, "self", trim: false)) == 2
+    end
+  end
+
+  describe "cd reports resolution errors instead of raising" do
+    test "cd through a regular file is ENOTDIR, matching bash" do
+      before = bash_with_file_parent()
+      {result, bash} = JustBash.exec(before, "cd /m/j/sub")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: cd: /m/j/sub: Not a directory\n"
+      assert bash.cwd == before.cwd
+    end
+
+    test "cd into a symlink loop is ELOOP, matching bash" do
+      before = JustBash.new()
+      {result, bash} = JustBash.exec(before, "ln -s /b /a; ln -s /a /b; cd /a")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: cd: /a: Too many levels of symbolic links\n"
+      assert bash.cwd == before.cwd
+    end
+  end
+
+  describe "ls reports resolution errors instead of raising" do
+    test "ls on a symlink loop is ELOOP" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "ln -s /b /a; ln -s /a /b; ls /a")
+
+      assert result.exit_code == 1
+      assert result.stderr == "ls: cannot access '/a': Too many levels of symbolic links\n"
+      assert result.stdout == ""
+    end
+
+    test "ls through a regular file is ENOTDIR" do
+      {result, _bash} = JustBash.exec(bash_with_file_parent(), "ls /m/j/sub")
+
+      assert result.exit_code == 1
+      assert result.stderr == "ls: cannot access '/m/j/sub': Not a directory\n"
     end
   end
 


### PR DESCRIPTION
Closes #53.

## Root cause

`JustBash.FS.Memory` stores entries in a flat `path => entry` map, and
`ensure_parent_dirs/2` walked up from the target creating missing
directories, stopping at the first ancestor that *existed* — without
checking that it was a directory. Nothing anywhere in the write path
enforced POSIX's rule that every non-final path component must be a
directory.

So with `/m/j` a regular file:

```elixir
b = JustBash.new(files: %{"/m/j" => "parent\n"})
{r, b2} = JustBash.exec(b, "echo hi > /m/j/2026/a.md")
r.exit_code                                        #=> 0   (bash: 1)
JustBash.FS.read_file(b2.fs, "/m/j/2026/a.md")     #=> {:ok, "hi\n", _}
b2.fs |> JustBash.FS.walk("/m", include_dirs: true) |> Enum.map(&elem(&1, 0))
#=> ["/m", "/m/j"]     — the entry is stored, readable, and unreachable
```

`read_file/2` hits the map key directly, while `readdir/2` and `walk/3`
have to route through `/m/j` — a file, not a directory — so they can never
yield the child. The filesystem held state enumeration could not reach.
In 0.3 the store was flat *and* enumerable, which is why this only shows
up now.

## The layer this is fixed at

The backend, where paths are resolved — not per command. `Memory` now
resolves a path one component at a time, following symlinks at every
step:

- a non-final component that resolves to a **regular file** is `:enotdir`
  (the backend names the offending component; vfs rewrites the error path
  to the requested path, which is what bash prints);
- a non-final component that is **missing** is still created — writes
  create their parent directories, as before;
- a non-final component that is a **symlink to a directory** now resolves
  to the target directory, instead of storing a literal `/link/sub/a.md`
  key that no listing could reach (the same bug class);
- a symlink cycle anywhere in the path is `:eloop`.

Two entry points: `resolve_path/2` follows a symlink at the final
component too (`O_TRUNC`/`O_APPEND`/`chmod` semantics), `resolve_for_create/2`
takes the final component literally (`mkdir`/`symlink`/`link`, where an
existing final component is `EEXIST`, not something to follow; and
`lstat`/`readlink`/`rm`, where the link itself is the subject). This
replaces the old `resolve_final_path/3`, which only ever looked at the
last component.

Both are one walk over the path's components, carrying the resolved prefix
as an accumulator. Symlink hops are budgeted (`SYMLOOP_MAX` 40) rather than
remembered: a set of visited links rejects legitimate paths that cross the
same link twice — with `/real/self -> /real`, `/real/self/self/x` is two
hops to `/real/x`, not a cycle.

`write_file/4`, `append_file/3`, `mkdir/3`, `symlink/3`, `link/3`, and
`chmod/3` all go through it, so every caller — the redirection layer and
every command — gets the check for free. Reads resolve through the same walk, and
have to: if only writes followed intermediate symlinks, a write through a
symlinked directory would land on the target and be invisible at the path
the caller used — the same unreachable-state bug mirrored, and quieter,
because the write reports success. So `stat`, `readdir`, `stream_read`,
`exists?`, `rm`, `lstat`, `readlink`, and `link`'s source path all route
through it, and `echo hi > /link/a.md` is readable back at `/link/a.md`.

One deviation remains: `normalize/1` collapses `..` lexically before
resolution, so `echo hi > /m/j/../k.md` writes `/m/k.md` and exits 0 where
bash reports `Not a directory`. It does not admit unreachable state, so it
stayed out of scope — UPGRADING item 7 states it.

## Behaviors that changed

With `/m/j` a regular file, all of these were exit 0 (or crashed) and are
now exit 1 with bash's wording — verified against real bash:

| command | now |
|---|---|
| `echo hi > /m/j/a.md` | `bash: /m/j/a.md: Not a directory` |
| `echo hi > /m/j/2026/a.md` | `bash: /m/j/2026/a.md: Not a directory` |
| `echo hi >> …`, `&> …`, `2> …` | same, per stream |
| `mkdir /m/j/2026` | `mkdir: cannot create directory '/m/j/2026': Not a directory` |
| `mkdir -p /m/j/2026` | `mkdir: cannot create directory '/m/j': Not a directory` (GNU names the offending ancestor for `-p`) |
| `touch /m/j/a.md` | `touch: cannot touch '/m/j/a.md': Not a directory` |
| `cp /src.txt /m/j/a.md` | `cp: cannot stat '/m/j/a.md': Not a directory` (GNU stats the destination first; previously a `MatchError` crash out of `JustBash.exec/2`) |
| `mv /src.txt /m/j/a.md` | `mv: cannot move '/src.txt' to '/m/j/a.md': Not a directory`, source kept |
| `echo hi \| tee /m/j/a.md` | `tee: /m/j/a.md: Not a directory`, stdin still passed through |
| `ln -s /src.txt /m/j/link` | `ln: failed to create symbolic link '/m/j/link': Not a directory` |

Adjacent fixes the tests turned up:

- **`cp`** matched `{:ok, new_fs} = FS.write_file(...)`, so *any*
  unwritable destination crashed the exec. It reports now.
- **`touch`** and **`tee`** interpolated a fixed reason regardless of the
  actual error (`touch: cannot touch 'X'` with no reason at all; `tee: X:
  Is a directory` for every write failure). Both render `FS.strerror/1`,
  matching precedent dffd5dd.
- **`mkdir -p`** swallowed `:eexist` unconditionally, so `mkdir -p
  /m/j` with `/m/j` a regular file exited 0 while no such directory
  existed. It now requires the existing entry to be a directory:
  `mkdir: cannot create directory '/m/j': File exists`, exit 1 (bash
  agrees). A dangling symlink reports the same, via an `FS.lstat` fallback
  when `FS.stat` cannot resolve the name.
- **`mv`**'s error `case` had no fallback clause and would have raised
  `CaseClauseError` on any kind it did not enumerate.

## `JustBash.new/1` with an inconsistent file map

Decided: **raise**. `%{"/m/j" => "x", "/m/j/a.md" => "y"}` describes a
filesystem that cannot exist, and silently accepting it was doubly bad —
which entry survived depended on map iteration order (one order stored an
unreachable child, the other lost the child to an `:eisdir` write). It is
a caller mistake at construction time, so `JustBash.new/1`,
`JustBash.FS.new/1`, and `JustBash.FS.Memory.new/1` now raise
`ArgumentError` naming both paths:

```
invalid initial files: "/m/j" is a regular file, so "/m/j/a.md" cannot
exist under it (POSIX path resolution fails with ENOTDIR). Drop one of
the two entries.
```

The check compares path *components*, so `%{"/m/jj" => …, "/m/j" => …}`
is still fine. `JustBash.new/1` also turns a write failure against the
default directories (`files: %{"/tmp" => "x"}`) into the same
`ArgumentError` instead of a `MatchError` from deep inside
`init_filesystem/1`.

## Tests

66 tests in `test/just_bash/not_a_directory_test.exs`, written
test-first (31 failed on the first run of the original 37; the 29 added in
the review round took it to 30 of 66 failing before the fixes): FS-layer `:enotdir` for every path-creating operation, the
walk/read reachability invariant, the symlinked-directory resolution that
now works, bash-level stderr and exit codes for each command above, and
the inconsistent-map raises. `UPGRADING.md` gets the bash-level delta as
item 7 of the unreleased 0.3 → 0.4 list.

All five checks pass: `mix compile --warnings-as-errors`, `mix dialyzer`
(0 new errors; the one pre-existing unnecessary skip is unchanged from
main — and `memory.ex` now needs no `@dialyzer` attribute at all),
`mix credo --strict` (only the intentional test-fixture finding),
`mix format --check-formatted`, `mix test` — 3,806 tests, 0 failures.

## Review round (c868a1e)

The first push enforced ENOTDIR on the write side but left reads resolving
literal paths, which regressed writes through a symlinked directory — they
succeeded and were then unreadable at the path used. Fixed by sharing the
walk, which also closed three other findings. Alongside it:

- **Perf.** `mkdir_with_parent/3` was recursing through the `VFS.Mountable`
  protocol, re-resolving an already-validated chain once per level; it calls
  `do_mkdir_resolved/3` directly now. With the single-pass walk, `mkdir -p`
  at depth 400 went 698 ms → 4.2 ms, *faster* than before this PR (6.6 ms).
  Writes at depth 12 went 187 ms → 48 ms against a 34 ms baseline; reads pay
  ~3%.
- **GNU message parity.** `mkdir -p` names the offending ancestor in the
  operand's own form; `cp` uses `cannot stat` for ENOTDIR; `tee` one level
  deeper says `Not a directory`.
- **A failed redirect no longer leaks the command's stdout.** The bytes were
  bound for the file, so `echo hi > /m/j/a.md` yields empty stdout. bash
  produces nothing because it opens the target before running the command;
  clearing the stream is how close this gets without pre-flighting.
- **`Memory.new/1`** raises `ArgumentError` on any unwritable seed
  (`%{"/" => "x"}`), so all three entry points agree and the docstrings are
  true.
- **`link/3`** resolves its source path's ancestors too.

`mv`'s pre-existing `cannot move 'X' to 'Y'` wording is left alone — #57
builds on it, and changing it here would make that merge produce the wrong
text.

