### PR TITLE
fix: cp into a directory, and make cp -r actually copy

### DIFF
--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -2,14 +2,25 @@ defmodule JustBash.Commands.Cp do
   @moduledoc """
   The `cp` command - copy files and directory trees.
 
-  Flags: `-r`/`-R`/`--recursive` and `-a`/`--archive` (which implies
-  `--recursive`) copy directories. `-f`/`--force` and `-p`/`--preserve`
-  are accepted and do nothing: a copy always overwrites its destination,
-  and always carries the source's mode and mtime across.
+  Flags:
 
-  As in bash, a destination that is an existing directory receives the
-  source under its own basename, and any number of sources may be copied
-  into a trailing directory operand.
+    * `-r`/`-R`/`--recursive`, and `-a`/`--archive` (which implies
+      `--recursive`) — copy directory trees.
+    * `-n`/`--no-clobber` — leave an existing destination alone. Bash decides
+      this per file inside a tree; here it is decided per operand.
+    * `-P`/`--no-dereference` (and `-d`) / `-L`/`--dereference` — copy a
+      command-line symlink as a link, or follow it. As in bash, a shallow copy
+      follows the link and a recursive copy preserves it; `-L` and `-P`
+      override that. Links *inside* a copied tree are always preserved.
+    * `-v`/`--verbose` — print `'src' -> 'dest'` for every copied entry.
+    * `-f`/`--force`, `-p`/`--preserve` and `-i`/`--interactive` — accepted,
+      with nothing to do: a copy always overwrites, always carries the
+      source's mode and mtime across, and a sandbox has no terminal to prompt
+      on (so `-i` proceeds as if the prompt were answered yes).
+
+  As in bash, a destination that is an existing directory receives the source
+  under its own basename, and any number of sources may be copied into a
+  trailing directory operand.
   """
   @behaviour JustBash.Commands.Command
 
@@ -17,19 +28,49 @@ defmodule JustBash.Commands.Cp do
   alias JustBash.FlagParser
   alias JustBash.FS
 
-  # `-R` and the long forms are aliases of `-r`; FlagParser sees `--recursive`
-  # as the flag string "-recursive".
+  defmodule Options do
+    @moduledoc false
+
+    @enforce_keys [:mode, :links, :clobber, :verbose?]
+    defstruct [:mode, :links, :clobber, :verbose?]
+
+    @type t :: %__MODULE__{
+            mode: :recursive | :shallow,
+            links: :follow | :preserve,
+            clobber: :always | :never,
+            verbose?: boolean()
+          }
+  end
+
+  # `-R` and the long forms are aliases of their short flags; FlagParser sees
+  # `--recursive` as the flag string "-recursive".
   @flag_spec %{
-    boolean: [:r, :a, :f, :p],
+    boolean: [:r, :a, :f, :p, :n, :i, :v, :P, :L, :d],
     aliases: %{
       "R" => :r,
       "-recursive" => :r,
       "-archive" => :a,
       "-force" => :f,
-      "-preserve" => :p
+      "-preserve" => :p,
+      "-no-clobber" => :n,
+      "-interactive" => :i,
+      "-verbose" => :v,
+      "-no-dereference" => :P,
+      "-dereference" => :L
     },
     value: [],
-    defaults: %{r: false, a: false, f: false, p: false}
+    defaults: %{
+      r: false,
+      a: false,
+      f: false,
+      p: false,
+      n: false,
+      i: false,
+      v: false,
+      P: false,
+      L: false,
+      d: false
+    }
   }
 
   @try_help "Try 'cp --help' for more information.\n"
@@ -40,102 +81,192 @@ defmodule JustBash.Commands.Cp do
   @impl true
   def execute(bash, args, _stdin) do
     {flags, operands} = FlagParser.parse(args, @flag_spec)
-    copy(bash, operands, flags.r or flags.a)
+    copy(bash, operands, options(flags))
   end
 
-  defp copy(bash, [], _recursive?),
+  defp options(flags) do
+    mode = if flags.r or flags.a, do: :recursive, else: :shallow
+
+    %Options{
+      mode: mode,
+      links: link_mode(flags, mode),
+      clobber: if(flags.n, do: :never, else: :always),
+      verbose?: flags.v
+    }
+  end
+
+  # Bash dereferences a command-line symlink for a shallow copy only: `-r` and
+  # `-a` imply `-d`. `-L` forces the link to be followed, `-P`/`-d` to be kept.
+  defp link_mode(%{L: true}, _mode), do: :follow
+  defp link_mode(%{P: true}, _mode), do: :preserve
+  defp link_mode(%{d: true}, _mode), do: :preserve
+  defp link_mode(_flags, :recursive), do: :preserve
+  defp link_mode(_flags, :shallow), do: :follow
+
+  defp copy(bash, [], _opts),
     do: {Command.error("cp: missing file operand\n" <> @try_help), bash}
 
-  defp copy(bash, [src], _recursive?),
+  defp copy(bash, [src], _opts),
     do:
       {Command.error("cp: missing destination file operand after '#{src}'\n" <> @try_help), bash}
 
   # Two operands: the destination names the copy, unless it already exists as a
   # directory — then the copy lands inside it under the source's basename.
-  defp copy(bash, [src, dest], recursive?) do
+  defp copy(bash, [src, dest], opts) do
     case dest_kind(bash, dest) do
-      {:directory, bash} -> copy_one(bash, src, dest_in_dir(dest, src), recursive?)
-      {_kind, bash} -> copy_one(bash, src, dest, recursive?)
+      {:ok, :directory, bash} -> copy_one(bash, src, dest_in_dir(dest, src), opts)
+      {:ok, :other, bash} -> copy_one(bash, src, dest, opts)
+      {:error, _error, bash} -> copy_one(bash, src, dest, opts)
     end
   end
 
   # Three or more operands: the last one has to be an existing directory.
-  defp copy(bash, operands, recursive?) do
+  defp copy(bash, operands, opts) do
     {sources, [dest]} = Enum.split(operands, -1)
 
     case dest_kind(bash, dest) do
-      {:directory, bash} ->
-        copy_each(bash, sources, dest, recursive?)
+      {:ok, :directory, bash} ->
+        copy_each(bash, sources, dest, opts)
 
-      {{:error, error}, bash} ->
-        {Command.error("cp: target '#{dest}': #{FS.strerror(error)}\n"), bash}
-
-      {_kind, bash} ->
+      {:ok, :other, bash} ->
         {Command.error("cp: target '#{dest}': Not a directory\n"), bash}
+
+      {:error, error, bash} ->
+        {Command.error("cp: target '#{dest}': #{FS.strerror(error)}\n"), bash}
     end
   end
 
+  # An empty operand names no file. Resolving it would produce the cwd, which is
+  # not what bash does with it.
+  defp dest_kind(bash, ""), do: {:error, VFS.Error.new(:enoent, path: ""), bash}
+
   defp dest_kind(bash, dest) do
     case FS.stat(bash.fs, FS.resolve_path(bash.cwd, dest)) do
-      {:ok, %VFS.Stat{type: :directory}, fs} -> {:directory, %{bash | fs: fs}}
-      {:ok, %VFS.Stat{}, fs} -> {:other, %{bash | fs: fs}}
-      {:error, %VFS.Error{} = error} -> {{:error, error}, bash}
+      {:ok, %VFS.Stat{type: :directory}, fs} -> {:ok, :directory, %{bash | fs: fs}}
+      {:ok, %VFS.Stat{}, fs} -> {:ok, :other, %{bash | fs: fs}}
+      {:error, %VFS.Error{} = error} -> {:error, error, bash}
     end
   end
 
   # A failing source does not abort the run: bash copies what it can, reports
   # every failure, and exits 1.
-  defp copy_each(bash, sources, dest, recursive?) do
-    {stderr, exit_code, bash} =
-      Enum.reduce(sources, {[], 0, bash}, fn src, {err_acc, code_acc, bash_acc} ->
-        {result, bash_acc} = copy_one(bash_acc, src, dest_in_dir(dest, src), recursive?)
-        {[err_acc, result.stderr], max(code_acc, result.exit_code), bash_acc}
+  defp copy_each(bash, sources, dest, opts) do
+    {stdout, stderr, exit_code, bash} =
+      Enum.reduce(sources, {[], [], 0, bash}, fn src, {out_acc, err_acc, code_acc, bash_acc} ->
+        {result, bash_acc} = copy_one(bash_acc, src, dest_in_dir(dest, src), opts)
+
+        {[out_acc, result.stdout], [err_acc, result.stderr], max(code_acc, result.exit_code),
+         bash_acc}
       end)
 
-    {Command.result("", IO.iodata_to_binary(stderr), exit_code), bash}
+    {Command.result(IO.iodata_to_binary(stdout), IO.iodata_to_binary(stderr), exit_code), bash}
   end
 
-  defp copy_one(bash, src, dest, recursive?) do
+  defp copy_one(bash, "", _dest, _opts),
+    do: {Command.error("cp: cannot stat '': No such file or directory\n"), bash}
+
+  defp copy_one(bash, src, "", opts), do: empty_dest(bash, src, opts)
+
+  defp copy_one(bash, src, dest, opts) do
     src_path = FS.resolve_path(bash.cwd, src)
     dest_path = FS.resolve_path(bash.cwd, dest)
 
     if src_path == dest_path do
       {Command.error("cp: '#{src}' and '#{dest}' are the same file\n"), bash}
     else
-      copy_resolved(bash, {src, src_path}, {dest, dest_path}, recursive?)
+      keep_or_copy(bash, {src, src_path}, {dest, dest_path}, opts)
     end
   end
 
-  defp copy_resolved(bash, {src, src_path}, {dest, dest_path}, recursive?) do
+  # `-n` leaves an existing destination alone, and says nothing about it.
+  defp keep_or_copy(bash, src, {_dest, dest_path} = dest, %Options{clobber: :never} = opts) do
+    case FS.exists?(bash.fs, dest_path) do
+      {true, fs} -> {Command.ok(), %{bash | fs: fs}}
+      {false, fs} -> copy_resolved(%{bash | fs: fs}, src, dest, opts)
+    end
+  end
+
+  defp keep_or_copy(bash, src, dest, %Options{clobber: :always} = opts),
+    do: copy_resolved(bash, src, dest, opts)
+
+  defp copy_resolved(bash, {src, src_path}, {dest, dest_path}, opts) do
     case FS.lstat(bash.fs, src_path) do
       {:ok, %VFS.Stat{type: :directory}, fs} ->
-        copy_dir(%{bash | fs: fs}, {src, src_path}, {dest, dest_path}, recursive?)
+        copy_dir(%{bash | fs: fs}, {src, src_path}, {dest, dest_path}, opts)
 
-      # Without `-d`/`-P`, bash copies what a link points at, not the link.
       {:ok, %VFS.Stat{type: :symlink}, fs} ->
-        copy_dereferenced(%{bash | fs: fs}, {src, src_path}, {dest, dest_path})
+        copy_link(%{bash | fs: fs}, {src, src_path}, {dest, dest_path}, opts)
 
       {:ok, %VFS.Stat{}, fs} ->
         fs
         |> FS.cp(src_path, dest_path)
-        |> file_result(%{bash | fs: fs}, dest)
+        |> file_result(%{bash | fs: fs}, {src, src_path}, dest, opts)
 
       {:error, %VFS.Error{} = error} ->
         {Command.error("cp: cannot stat '#{src}': #{FS.strerror(error)}\n"), bash}
     end
   end
 
-  defp copy_dir(bash, {src, _src_path}, {_dest, _dest_path}, false),
+  # A preserved link is copied as a link — dangling or not, directory or not.
+  defp copy_link(bash, {src, src_path}, {dest, dest_path}, %Options{links: :preserve} = opts) do
+    bash.fs
+    |> FS.cp(src_path, dest_path)
+    |> file_result(bash, {src, src_path}, dest, opts)
+  end
+
+  # A followed link copies whatever it names, under the link's own name: a link
+  # to a directory therefore needs `-r`, exactly like a directory does.
+  defp copy_link(bash, {src, src_path}, dest, %Options{links: :follow} = opts) do
+    case link_target(bash.fs, src_path, 0) do
+      {:ok, target_path, fs} ->
+        copy_resolved(%{bash | fs: fs}, {src, target_path}, dest, opts)
+
+      {:error, %VFS.Error{} = error} ->
+        {Command.error("cp: cannot stat '#{src}': #{FS.strerror(error)}\n"), bash}
+    end
+  end
+
+  @max_link_hops 32
+
+  # The path a symlink chain ends at, so a followed copy can hand `FS.cp/4` a
+  # real file or directory instead of a link.
+  defp link_target(_fs, path, hops) when hops >= @max_link_hops,
+    do: {:error, VFS.Error.new(:eloop, path: path)}
+
+  defp link_target(fs, path, hops) do
+    case FS.lstat(fs, path) do
+      {:ok, %VFS.Stat{type: :symlink}, fs} -> follow_link(fs, path, hops)
+      {:ok, %VFS.Stat{}, fs} -> {:ok, path, fs}
+      {:error, %VFS.Error{} = error} -> {:error, error}
+    end
+  end
+
+  defp follow_link(fs, path, hops) do
+    case FS.readlink(fs, path) do
+      {:ok, target, fs} ->
+        link_target(fs, FS.resolve_path(FS.dirname(path), target), hops + 1)
+
+      {:error, %VFS.Error{} = error} ->
+        {:error, error}
+    end
+  end
+
+  defp copy_dir(bash, {src, _src_path}, {_dest, _dest_path}, %Options{mode: :shallow}),
     do: {Command.error("cp: -r not specified; omitting directory '#{src}'\n"), bash}
 
-  defp copy_dir(bash, {src, src_path}, {dest, dest_path}, true) do
+  defp copy_dir(bash, {src, src_path}, {dest, dest_path}, %Options{mode: :recursive} = opts) do
     case FS.cp(bash.fs, src_path, dest_path, recursive: true) do
       {:ok, fs} ->
-        {Command.ok(), %{bash | fs: fs}}
+        report(%{bash | fs: fs}, {src, src_path}, dest, opts)
 
       {:error, %VFS.Error{kind: :einval}} ->
         {Command.error("cp: cannot copy a directory, '#{src}', into itself, '#{dest}'\n"), bash}
 
+      # Verified against bash for a destination that already exists as a regular
+      # file. A destination whose *ancestor* is a regular file surfaces the same
+      # kind, and bash words that one "cannot stat '<dest>': Not a directory" —
+      # telling the two apart needs an lstat of the destination first, so read
+      # this wording as unverified for that case.
       {:error, %VFS.Error{kind: :enotdir}} ->
         {Command.error("cp: cannot overwrite non-directory '#{dest}' with directory '#{src}'\n"),
          bash}
@@ -145,42 +276,86 @@ defmodule JustBash.Commands.Cp do
     end
   end
 
-  defp copy_dereferenced(bash, {src, src_path}, {dest, dest_path}) do
-    case FS.read_file(bash.fs, src_path) do
-      {:ok, content, fs} ->
-        fs
-        |> FS.write_file(dest_path, content)
-        |> file_result(%{bash | fs: fs}, dest)
+  defp file_result({:ok, fs}, bash, src, dest, opts),
+    do: report(%{bash | fs: fs}, src, dest, opts)
+
+  defp file_result({:error, %VFS.Error{kind: :eisdir}}, bash, _src, dest, _opts),
+    do: {Command.error("cp: cannot overwrite directory '#{dest}' with non-directory\n"), bash}
+
+  # GNU stats the destination before opening it, so a path component that is a
+  # regular file surfaces as `cannot stat`. `cannot create regular file` stays
+  # the wording for a destination whose parent is merely missing. See also the
+  # `:enotdir` note in copy_dir/4, where the two cases are not separable.
+  defp file_result({:error, %VFS.Error{kind: :enotdir} = error}, bash, _src, dest, _opts),
+    do: {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(error)}\n"), bash}
+
+  defp file_result({:error, %VFS.Error{} = error}, bash, _src, dest, _opts),
+    do: {Command.error("cp: cannot create regular file '#{dest}': #{FS.strerror(error)}\n"), bash}
+
+  defp report(bash, _src, _dest, %Options{verbose?: false}), do: {Command.ok(), bash}
+
+  # `-v` names every copied entry, parents before children, in the order bash
+  # walks the source.
+  defp report(bash, {src, src_path}, dest, %Options{verbose?: true}) do
+    {lines, fs} = report_entry(bash.fs, {src, src_path}, dest, [])
+    {Command.ok(IO.iodata_to_binary(lines)), %{bash | fs: fs}}
+  end
+
+  defp report_entry(fs, {src, src_path}, dest, acc) do
+    acc = [acc, "'", src, "' -> '", dest, "'\n"]
+
+    case FS.lstat(fs, src_path) do
+      {:ok, %VFS.Stat{type: :directory}, fs} -> report_children(fs, {src, src_path}, dest, acc)
+      {:ok, %VFS.Stat{}, fs} -> {acc, fs}
+      {:error, %VFS.Error{}} -> {acc, fs}
+    end
+  end
+
+  defp report_children(fs, {src, src_path}, dest, acc) do
+    case FS.readdir(fs, src_path) do
+      {:ok, children, fs} ->
+        Enum.reduce(children, {acc, fs}, fn child, {acc, fs} ->
+          child_src = {join(src, child), FS.resolve_path(src_path, child)}
+          report_entry(fs, child_src, join(dest, child), acc)
+        end)
+
+      {:error, %VFS.Error{}} ->
+        {acc, fs}
+    end
+  end
+
+  # Bash rejects an empty destination operand outright, naming the kind of thing
+  # it could not create.
+  defp empty_dest(bash, src, opts) do
+    case FS.lstat(bash.fs, FS.resolve_path(bash.cwd, src)) do
+      {:ok, %VFS.Stat{type: :directory}, fs} ->
+        {empty_dest_error(:directory, opts), %{bash | fs: fs}}
+
+      {:ok, %VFS.Stat{}, fs} ->
+        {empty_dest_error(:file, opts), %{bash | fs: fs}}
 
       {:error, %VFS.Error{} = error} ->
         {Command.error("cp: cannot stat '#{src}': #{FS.strerror(error)}\n"), bash}
     end
   end
 
-  defp file_result({:ok, fs}, bash, _dest), do: {Command.ok(), %{bash | fs: fs}}
+  defp empty_dest_error(:directory, %Options{mode: :recursive}),
+    do: Command.error("cp: cannot create directory '': No such file or directory\n")
 
-  defp file_result({:error, %VFS.Error{kind: :eisdir}}, bash, dest),
-    do: {Command.error("cp: cannot overwrite directory '#{dest}' with non-directory\n"), bash}
+  defp empty_dest_error(:directory, %Options{mode: :shallow}),
+    do: Command.error("cp: -r not specified; omitting directory ''\n")
 
-  # GNU stats the destination before opening it, so a path component that is a
-  # regular file surfaces as `cannot stat`. `cannot create regular file` stays
-  # the wording for a destination whose parent is merely missing.
-  defp file_result({:error, %VFS.Error{kind: :enotdir} = error}, bash, dest),
-    do: {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(error)}\n"), bash}
-
-  defp file_result({:error, %VFS.Error{} = error}, bash, dest),
-    do: {Command.error("cp: cannot create regular file '#{dest}': #{FS.strerror(error)}\n"), bash}
+  defp empty_dest_error(:file, _opts),
+    do: Command.error("cp: cannot create regular file '': No such file or directory\n")
 
   # The destination of a copy into a directory, spelled the way bash spells it
   # in messages: the directory operand with the source's basename appended. The
   # `dir/.` idiom copies the source's *contents*, so it keeps the destination.
   defp dest_in_dir(dest, src) do
-    if dot_segment?(src) do
-      dest
-    else
-      String.trim_trailing(dest, "/") <> "/" <> FS.basename(src)
-    end
+    if dot_segment?(src), do: dest, else: join(dest, FS.basename(src))
   end
 
   defp dot_segment?(src), do: List.last(String.split(src, "/")) in [".", ".."]
+
+  defp join(parent, child), do: String.trim_trailing(parent, "/") <> "/" <> child
 end

--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -1,51 +1,186 @@
 defmodule JustBash.Commands.Cp do
-  @moduledoc "The `cp` command - copy files."
+  @moduledoc """
+  The `cp` command - copy files and directory trees.
+
+  Flags: `-r`/`-R`/`--recursive` and `-a`/`--archive` (which implies
+  `--recursive`) copy directories. `-f`/`--force` and `-p`/`--preserve`
+  are accepted and do nothing: a copy always overwrites its destination,
+  and always carries the source's mode and mtime across.
+
+  As in bash, a destination that is an existing directory receives the
+  source under its own basename, and any number of sources may be copied
+  into a trailing directory operand.
+  """
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.FlagParser
   alias JustBash.FS
+
+  # `-R` and the long forms are aliases of `-r`; FlagParser sees `--recursive`
+  # as the flag string "-recursive".
+  @flag_spec %{
+    boolean: [:r, :a, :f, :p],
+    aliases: %{
+      "R" => :r,
+      "-recursive" => :r,
+      "-archive" => :a,
+      "-force" => :f,
+      "-preserve" => :p
+    },
+    value: [],
+    defaults: %{r: false, a: false, f: false, p: false}
+  }
+
+  @try_help "Try 'cp --help' for more information.\n"
 
   @impl true
   def names, do: ["cp"]
 
   @impl true
   def execute(bash, args, _stdin) do
-    case args do
-      [src, dest] ->
-        src_resolved = FS.resolve_path(bash.cwd, src)
-        dest_resolved = FS.resolve_path(bash.cwd, dest)
+    {flags, operands} = FlagParser.parse(args, @flag_spec)
+    copy(bash, operands, flags.r or flags.a)
+  end
 
-        case FS.read_file(bash.fs, src_resolved) do
-          {:ok, content, fs} ->
-            write_dest(%{bash | fs: fs}, dest_resolved, dest, content)
+  defp copy(bash, [], _recursive?),
+    do: {Command.error("cp: missing file operand\n" <> @try_help), bash}
 
-          {:error, _} ->
-            {Command.error("cp: cannot stat '#{src}': No such file or directory\n"), bash}
-        end
+  defp copy(bash, [src], _recursive?),
+    do:
+      {Command.error("cp: missing destination file operand after '#{src}'\n" <> @try_help), bash}
 
-      _ ->
-        {Command.error("cp: missing file operand\n"), bash}
+  # Two operands: the destination names the copy, unless it already exists as a
+  # directory — then the copy lands inside it under the source's basename.
+  defp copy(bash, [src, dest], recursive?) do
+    case dest_kind(bash, dest) do
+      {:directory, bash} -> copy_one(bash, src, dest_in_dir(dest, src), recursive?)
+      {_kind, bash} -> copy_one(bash, src, dest, recursive?)
     end
   end
 
-  # The destination may be unwritable for reasons the source read cannot
-  # know about — a path component that is a regular file (:enotdir), a
-  # destination that is a directory (:eisdir). Report them instead of
-  # crashing on the write.
-  defp write_dest(bash, dest_resolved, dest, content) do
-    case FS.write_file(bash.fs, dest_resolved, content) do
-      {:ok, new_fs} ->
-        {Command.ok(), %{bash | fs: new_fs}}
+  # Three or more operands: the last one has to be an existing directory.
+  defp copy(bash, operands, recursive?) do
+    {sources, [dest]} = Enum.split(operands, -1)
 
-      # GNU stats the destination before opening it, so a path component that
-      # is a regular file surfaces as `cannot stat`. `cannot create regular
-      # file` stays the wording for a destination whose parent is merely
-      # missing.
-      {:error, %VFS.Error{kind: :enotdir} = error} ->
-        {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(error)}\n"), bash}
+    case dest_kind(bash, dest) do
+      {:directory, bash} ->
+        copy_each(bash, sources, dest, recursive?)
+
+      {{:error, error}, bash} ->
+        {Command.error("cp: target '#{dest}': #{FS.strerror(error)}\n"), bash}
+
+      {_kind, bash} ->
+        {Command.error("cp: target '#{dest}': Not a directory\n"), bash}
+    end
+  end
+
+  defp dest_kind(bash, dest) do
+    case FS.stat(bash.fs, FS.resolve_path(bash.cwd, dest)) do
+      {:ok, %VFS.Stat{type: :directory}, fs} -> {:directory, %{bash | fs: fs}}
+      {:ok, %VFS.Stat{}, fs} -> {:other, %{bash | fs: fs}}
+      {:error, %VFS.Error{} = error} -> {{:error, error}, bash}
+    end
+  end
+
+  # A failing source does not abort the run: bash copies what it can, reports
+  # every failure, and exits 1.
+  defp copy_each(bash, sources, dest, recursive?) do
+    {stderr, exit_code, bash} =
+      Enum.reduce(sources, {[], 0, bash}, fn src, {err_acc, code_acc, bash_acc} ->
+        {result, bash_acc} = copy_one(bash_acc, src, dest_in_dir(dest, src), recursive?)
+        {[err_acc, result.stderr], max(code_acc, result.exit_code), bash_acc}
+      end)
+
+    {Command.result("", IO.iodata_to_binary(stderr), exit_code), bash}
+  end
+
+  defp copy_one(bash, src, dest, recursive?) do
+    src_path = FS.resolve_path(bash.cwd, src)
+    dest_path = FS.resolve_path(bash.cwd, dest)
+
+    if src_path == dest_path do
+      {Command.error("cp: '#{src}' and '#{dest}' are the same file\n"), bash}
+    else
+      copy_resolved(bash, {src, src_path}, {dest, dest_path}, recursive?)
+    end
+  end
+
+  defp copy_resolved(bash, {src, src_path}, {dest, dest_path}, recursive?) do
+    case FS.lstat(bash.fs, src_path) do
+      {:ok, %VFS.Stat{type: :directory}, fs} ->
+        copy_dir(%{bash | fs: fs}, {src, src_path}, {dest, dest_path}, recursive?)
+
+      # Without `-d`/`-P`, bash copies what a link points at, not the link.
+      {:ok, %VFS.Stat{type: :symlink}, fs} ->
+        copy_dereferenced(%{bash | fs: fs}, {src, src_path}, {dest, dest_path})
+
+      {:ok, %VFS.Stat{}, fs} ->
+        fs
+        |> FS.cp(src_path, dest_path)
+        |> file_result(%{bash | fs: fs}, dest)
 
       {:error, %VFS.Error{} = error} ->
-        {Command.error("cp: cannot create regular file '#{dest}': #{FS.strerror(error)}\n"), bash}
+        {Command.error("cp: cannot stat '#{src}': #{FS.strerror(error)}\n"), bash}
     end
   end
+
+  defp copy_dir(bash, {src, _src_path}, {_dest, _dest_path}, false),
+    do: {Command.error("cp: -r not specified; omitting directory '#{src}'\n"), bash}
+
+  defp copy_dir(bash, {src, src_path}, {dest, dest_path}, true) do
+    case FS.cp(bash.fs, src_path, dest_path, recursive: true) do
+      {:ok, fs} ->
+        {Command.ok(), %{bash | fs: fs}}
+
+      {:error, %VFS.Error{kind: :einval}} ->
+        {Command.error("cp: cannot copy a directory, '#{src}', into itself, '#{dest}'\n"), bash}
+
+      {:error, %VFS.Error{kind: :enotdir}} ->
+        {Command.error("cp: cannot overwrite non-directory '#{dest}' with directory '#{src}'\n"),
+         bash}
+
+      {:error, %VFS.Error{} = error} ->
+        {Command.error("cp: cannot create directory '#{dest}': #{FS.strerror(error)}\n"), bash}
+    end
+  end
+
+  defp copy_dereferenced(bash, {src, src_path}, {dest, dest_path}) do
+    case FS.read_file(bash.fs, src_path) do
+      {:ok, content, fs} ->
+        fs
+        |> FS.write_file(dest_path, content)
+        |> file_result(%{bash | fs: fs}, dest)
+
+      {:error, %VFS.Error{} = error} ->
+        {Command.error("cp: cannot stat '#{src}': #{FS.strerror(error)}\n"), bash}
+    end
+  end
+
+  defp file_result({:ok, fs}, bash, _dest), do: {Command.ok(), %{bash | fs: fs}}
+
+  defp file_result({:error, %VFS.Error{kind: :eisdir}}, bash, dest),
+    do: {Command.error("cp: cannot overwrite directory '#{dest}' with non-directory\n"), bash}
+
+  # GNU stats the destination before opening it, so a path component that is a
+  # regular file surfaces as `cannot stat`. `cannot create regular file` stays
+  # the wording for a destination whose parent is merely missing.
+  defp file_result({:error, %VFS.Error{kind: :enotdir} = error}, bash, dest),
+    do: {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(error)}\n"), bash}
+
+  defp file_result({:error, %VFS.Error{} = error}, bash, dest),
+    do: {Command.error("cp: cannot create regular file '#{dest}': #{FS.strerror(error)}\n"), bash}
+
+  # The destination of a copy into a directory, spelled the way bash spells it
+  # in messages: the directory operand with the source's basename appended. The
+  # `dir/.` idiom copies the source's *contents*, so it keeps the destination.
+  defp dest_in_dir(dest, src) do
+    if dot_segment?(src) do
+      dest
+    else
+      String.trim_trailing(dest, "/") <> "/" <> FS.basename(src)
+    end
+  end
+
+  defp dot_segment?(src), do: List.last(String.split(src, "/")) in [".", ".."]
 end

--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -21,6 +21,14 @@ defmodule JustBash.Commands.Cp do
   As in bash, a destination that is an existing directory receives the source
   under its own basename, and any number of sources may be copied into a
   trailing directory operand.
+
+  A recursive copy refuses a destination inside the source, including one that
+  only reaches it through a symlink (`FS.cp/4` resolves both operands first).
+  One wording diverges there: for a destination that does not exist yet, such
+  as `cp -r a l/x` with `l -> a`, bash reaches the case through its
+  inode-based self-detection mid-walk and reports `will not create hard link`,
+  while the path check here gets there first and reports `cannot copy a
+  directory, 'a', into itself`. Same exit code, same untouched source.
   """
   @behaviour JustBash.Commands.Command
 
@@ -262,14 +270,21 @@ defmodule JustBash.Commands.Cp do
       {:error, %VFS.Error{kind: :einval}} ->
         {Command.error("cp: cannot copy a directory, '#{src}', into itself, '#{dest}'\n"), bash}
 
-      # Verified against bash for a destination that already exists as a regular
-      # file. A destination whose *ancestor* is a regular file surfaces the same
-      # kind, and bash words that one "cannot stat '<dest>': Not a directory" —
-      # telling the two apart needs an lstat of the destination first, so read
-      # this wording as unverified for that case.
+      # Two different failures arrive as :enotdir, and bash words them
+      # differently, so an lstat of the destination tells them apart: a
+      # destination that exists is one we would be overwriting, while one that
+      # does not resolve means an ancestor component is a regular file — which
+      # bash reports as a failed stat. Both verified against GNU coreutils 9.11.
       {:error, %VFS.Error{kind: :enotdir}} ->
-        {Command.error("cp: cannot overwrite non-directory '#{dest}' with directory '#{src}'\n"),
-         bash}
+        case FS.lstat(bash.fs, dest_path) do
+          {:ok, %VFS.Stat{}, fs} ->
+            {Command.error(
+               "cp: cannot overwrite non-directory '#{dest}' with directory '#{src}'\n"
+             ), %{bash | fs: fs}}
+
+          {:error, %VFS.Error{}} ->
+            {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(:enotdir)}\n"), bash}
+        end
 
       {:error, %VFS.Error{} = error} ->
         {Command.error("cp: cannot create directory '#{dest}': #{FS.strerror(error)}\n"), bash}
@@ -282,10 +297,9 @@ defmodule JustBash.Commands.Cp do
   defp file_result({:error, %VFS.Error{kind: :eisdir}}, bash, _src, dest, _opts),
     do: {Command.error("cp: cannot overwrite directory '#{dest}' with non-directory\n"), bash}
 
-  # GNU stats the destination before opening it, so a path component that is a
-  # regular file surfaces as `cannot stat`. `cannot create regular file` stays
-  # the wording for a destination whose parent is merely missing. See also the
-  # `:enotdir` note in copy_dir/4, where the two cases are not separable.
+  # Unambiguous here, unlike in copy_dir/4: a destination that exists as a
+  # regular file is a plain overwrite, so :enotdir can only mean an ancestor
+  # component is one — which bash words as a failed stat of the destination.
   defp file_result({:error, %VFS.Error{kind: :enotdir} = error}, bash, _src, dest, _opts),
     do: {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(error)}\n"), bash}
 

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -44,6 +44,14 @@ defmodule JustBash.Commands.Mv do
               {Command.error("mv: cannot overwrite directory '#{dest}' with non-directory\n"),
                bash}
 
+            {:error, %VFS.Error{kind: :einval}} ->
+              {Command.error(
+                 "mv: cannot move '#{src}' to a subdirectory of itself, '#{dest_final}'\n"
+               ), bash}
+
+            # :enotdir needs no clause of its own — the catch-all below already
+            # spells it "cannot move 'src' to 'dest': Not a directory", which is
+            # why #56 removed the explicit one.
             {:error, %VFS.Error{} = error} ->
               {Command.error("mv: cannot move '#{src}' to '#{dest}': #{FS.strerror(error)}\n"),
                bash}

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -15,16 +15,22 @@ defmodule JustBash.Commands.Mv do
         src_resolved = FS.resolve_path(bash.cwd, src)
         dest_resolved = FS.resolve_path(bash.cwd, dest)
 
-        {dest_final, fs} =
+        # `dest_final` is where the move lands; `dest_shown` is the same place
+        # spelled the way the operand was, which is how bash names it in
+        # messages ("a/b/a", not "/tmp/x/a/b/a").
+        {dest_final, dest_shown, fs} =
           case FS.stat(bash.fs, dest_resolved) do
             {:ok, %VFS.Stat{type: :directory}, fs} ->
-              {FS.normalize_path(dest_resolved <> "/" <> FS.basename(src_resolved)), fs}
+              basename = FS.basename(src_resolved)
+
+              {FS.normalize_path(dest_resolved <> "/" <> basename),
+               String.trim_trailing(dest, "/") <> "/" <> basename, fs}
 
             {:ok, _stat, fs} ->
-              {dest_resolved, fs}
+              {dest_resolved, dest, fs}
 
             {:error, _} ->
-              {dest_resolved, bash.fs}
+              {dest_resolved, dest, bash.fs}
           end
 
         bash = %{bash | fs: fs}
@@ -46,7 +52,7 @@ defmodule JustBash.Commands.Mv do
 
             {:error, %VFS.Error{kind: :einval}} ->
               {Command.error(
-                 "mv: cannot move '#{src}' to a subdirectory of itself, '#{dest_final}'\n"
+                 "mv: cannot move '#{src}' to a subdirectory of itself, '#{dest_shown}'\n"
                ), bash}
 
             # :enotdir needs no clause of its own — the catch-all below already

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -193,6 +193,10 @@ defmodule JustBash.FS do
   works across mounts: regular files copy content, mode, and mtime;
   symlinks copy the link itself when the destination backend supports
   symlinks.
+
+  A recursive copy whose destination lies inside the source fails with
+  `:einval` instead of recursing forever — every pass would add new
+  children under the source it is still walking.
   """
   @spec cp(t(), String.t(), String.t(), cp_opts()) :: {:ok, t()} | {:error, Error.t()}
   def cp(fs, src, dest, opts \\ []) do
@@ -205,7 +209,11 @@ defmodule JustBash.FS do
         {:error, Error.new(:eisdir, path: src_norm)}
 
       {:ok, %VFS.Stat{type: :directory}, fs} ->
-        cp_directory(fs, src_norm, dest_norm, opts)
+        if within?(dest_norm, src_norm) do
+          {:error, Error.new(:einval, path: dest_norm)}
+        else
+          cp_directory(fs, src_norm, dest_norm, opts)
+        end
 
       {:ok, %VFS.Stat{type: :symlink}, fs} ->
         cp_symlink(fs, src_norm, dest_norm)
@@ -225,6 +233,9 @@ defmodule JustBash.FS do
 
   A destination symlink is replaced, not followed (POSIX `rename/2`
   semantics) — the opposite of `cp/4`, which writes through it.
+
+  Moving a directory into its own subtree fails with `:einval` (see
+  `cp/4`) rather than looping.
   """
   @spec mv(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
   def mv(fs, src, dest) do
@@ -264,6 +275,11 @@ defmodule JustBash.FS do
   def strerror(kind) when is_atom(kind), do: to_string(kind)
 
   # ── private ──────────────────────────────────────────────────────────────
+
+  # Is `dest` the same path as `src`, or nested inside it? Everything is
+  # inside the root, so a recursive copy of "/" never has a safe destination.
+  defp within?(_dest, "/"), do: true
+  defp within?(dest, src), do: dest == src or String.starts_with?(dest, src <> "/")
 
   # rename(2) replaces a destination symlink rather than writing through
   # it (unlike cp, whose write_file follows the link). Remove the link

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -196,7 +196,10 @@ defmodule JustBash.FS do
 
   A recursive copy whose destination lies inside the source fails with
   `:einval` instead of recursing forever — every pass would add new
-  children under the source it is still walking.
+  children under the source it is still walking. Both operands are
+  resolved through any symlinked components before that test, so a
+  destination that only *reaches* the source through a link is caught
+  too.
   """
   @spec cp(t(), String.t(), String.t(), cp_opts()) :: {:ok, t()} | {:error, Error.t()}
   def cp(fs, src, dest, opts \\ []) do
@@ -209,7 +212,10 @@ defmodule JustBash.FS do
         {:error, Error.new(:eisdir, path: src_norm)}
 
       {:ok, %VFS.Stat{type: :directory}, fs} ->
-        if within?(dest_norm, src_norm) do
+        {src_real, fs} = resolve_links(fs, src_norm)
+        {dest_real, fs} = resolve_links(fs, dest_norm)
+
+        if within?(dest_real, src_real) do
           {:error, Error.new(:einval, path: dest_norm)}
         else
           cp_directory(fs, src_norm, dest_norm, opts)
@@ -278,8 +284,69 @@ defmodule JustBash.FS do
 
   # Is `dest` the same path as `src`, or nested inside it? Everything is
   # inside the root, so a recursive copy of "/" never has a safe destination.
+  #
+  # Callers pass paths already resolved by `resolve_links/2`: this is a prefix
+  # test on spellings, and a symlink makes a spelling lie.
   defp within?(_dest, "/"), do: true
   defp within?(dest, src), do: dest == src or String.starts_with?(dest, src <> "/")
+
+  # How many links a single path may traverse before we stop resolving it.
+  @symlink_hops 32
+
+  # Resolve a path one component at a time, following symlinks as they are
+  # met, so `within?/2` compares where paths land rather than how they are
+  # spelled. With `/l -> /a`, "/l/x" names a place inside "/a" while sharing
+  # no prefix with it; without this the recursive copy created children under
+  # the tree it was still walking and never terminated, and `mv` — which
+  # composes copy-then-remove — deleted the source after copying nothing.
+  #
+  # Best effort on purpose. A path that cannot be resolved (a link cycle, a
+  # component that is a regular file) falls back to its lexical form: the
+  # guard stays conservative and the copy that follows reports the real error
+  # in its own words, rather than this helper inventing one.
+  defp resolve_links(fs, path) do
+    resolve_components(fs, split_path(path), "/", 0, path)
+  end
+
+  defp resolve_components(fs, [], resolved, _hops, _lexical), do: {resolved, fs}
+
+  defp resolve_components(fs, _rest, _resolved, hops, lexical) when hops >= @symlink_hops,
+    do: {lexical, fs}
+
+  defp resolve_components(fs, [component | rest], parent, hops, lexical) do
+    candidate = join_component(parent, component)
+
+    case lstat(fs, candidate) do
+      # A link replaces everything resolved so far: its target is re-resolved
+      # from the root, with the components after it still to walk. A relative
+      # target resolves against the directory holding the link.
+      {:ok, %VFS.Stat{type: :symlink}, fs} ->
+        case readlink(fs, candidate) do
+          {:ok, target, fs} ->
+            target_components = parent |> resolve_path(target) |> split_path()
+            resolve_components(fs, target_components ++ rest, "/", hops + 1, lexical)
+
+          {:error, %Error{}} ->
+            {lexical, fs}
+        end
+
+      {:ok, %VFS.Stat{}, fs} ->
+        resolve_components(fs, rest, candidate, hops, lexical)
+
+      # Nothing here yet — a copy destination usually does not exist. Nothing
+      # missing can be a symlink, so the rest of the path joins on literally.
+      {:error, %Error{kind: :enoent}} ->
+        {Enum.reduce(rest, candidate, &join_component(&2, &1)), fs}
+
+      {:error, %Error{}} ->
+        {lexical, fs}
+    end
+  end
+
+  defp split_path(path), do: String.split(path, "/", trim: true)
+
+  defp join_component("/", component), do: "/" <> component
+  defp join_component(parent, component), do: parent <> "/" <> component
 
   # rename(2) replaces a destination symlink rather than writing through
   # it (unlike cp, whose write_file follows the link). Remove the link

--- a/test/commands/file_operations_test.exs
+++ b/test/commands/file_operations_test.exs
@@ -487,6 +487,222 @@ defmodule JustBash.Commands.FileOperationsTest do
       {cat, _} = JustBash.exec(bash, "cat /d/a.md")
       assert cat.stdout == "A\n"
     end
+
+    test "cp of a symlink to a directory needs -r, like a directory" do
+      bash = JustBash.new(files: %{"/sd/x.md" => "X\n"})
+      {_, bash} = JustBash.exec(bash, "ln -s /sd /sdlink")
+
+      {result, bash} = JustBash.exec(bash, "cp /sdlink /outdir")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: -r not specified; omitting directory '/sdlink'\n"
+
+      {test_result, _} = JustBash.exec(bash, "[ -e /outdir ] || echo absent")
+      assert test_result.stdout == "absent\n"
+    end
+
+    test "cp -r of a symlink to a directory copies the link" do
+      bash = JustBash.new(files: %{"/sd/x.md" => "X\n"})
+      {_, bash} = JustBash.exec(bash, "ln -s /sd /sdlink")
+
+      {result, bash} = JustBash.exec(bash, "cp -r /sdlink /outdir")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      # The link itself is what gets copied, so the copy points at the same
+      # directory. (Reading *through* a directory symlink is a separate
+      # filesystem limitation: `cat /sdlink/x.md` does not resolve either.)
+      {readlink, bash} = JustBash.exec(bash, "readlink /outdir")
+      assert readlink.stdout == "/sd\n"
+
+      {test_result, _} = JustBash.exec(bash, "[ -L /outdir ] && echo link")
+      assert test_result.stdout == "link\n"
+    end
+
+    test "cp -r of a symlink to a file copies the link" do
+      bash = JustBash.new(files: %{"/target.md" => "T\n"})
+      {_, bash} = JustBash.exec(bash, "ln -s /target.md /alink")
+
+      {result, bash} = JustBash.exec(bash, "cp -r /alink /rcopy")
+      assert result.exit_code == 0
+
+      {readlink, _} = JustBash.exec(bash, "readlink /rcopy")
+      assert readlink.stdout == "/target.md\n"
+    end
+
+    test "cp -a of a symlink copies the link" do
+      bash = JustBash.new(files: %{"/target.md" => "T\n"})
+      {_, bash} = JustBash.exec(bash, "ln -s /target.md /alink")
+
+      {result, bash} = JustBash.exec(bash, "cp -a /alink /acopy")
+      assert result.exit_code == 0
+
+      {readlink, _} = JustBash.exec(bash, "readlink /acopy")
+      assert readlink.stdout == "/target.md\n"
+    end
+
+    test "cp -P copies the link instead of dereferencing it" do
+      bash = JustBash.new(files: %{"/target.md" => "T\n"})
+      {_, bash} = JustBash.exec(bash, "ln -s /target.md /alink")
+
+      {result, bash} = JustBash.exec(bash, "cp -P /alink /pcopy")
+      assert result.exit_code == 0
+
+      {readlink, _} = JustBash.exec(bash, "readlink /pcopy")
+      assert readlink.stdout == "/target.md\n"
+    end
+
+    test "cp -d copies the link instead of dereferencing it" do
+      bash = JustBash.new(files: %{"/target.md" => "T\n"})
+      {_, bash} = JustBash.exec(bash, "ln -s /target.md /alink")
+
+      {result, bash} = JustBash.exec(bash, "cp -d /alink /dcopy")
+      assert result.exit_code == 0
+
+      {readlink, _} = JustBash.exec(bash, "readlink /dcopy")
+      assert readlink.stdout == "/target.md\n"
+    end
+
+    test "cp -L dereferences the link even with -r" do
+      bash = JustBash.new(files: %{"/sd/x.md" => "X\n"})
+      {_, bash} = JustBash.exec(bash, "ln -s /sd /sdlink")
+
+      {result, bash} = JustBash.exec(bash, "cp -rL /sdlink /ldir")
+      assert result.exit_code == 0
+
+      {readlink, bash} = JustBash.exec(bash, "readlink /ldir")
+      assert readlink.exit_code == 1
+
+      {cat, _} = JustBash.exec(bash, "cat /ldir/x.md")
+      assert cat.stdout == "X\n"
+    end
+
+    test "cp -r of a dangling symlink copies the link" do
+      bash = JustBash.new()
+      {_, bash} = JustBash.exec(bash, "ln -s /nope.md /dangling")
+
+      {result, bash} = JustBash.exec(bash, "cp -r /dangling /dcopy")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {readlink, _} = JustBash.exec(bash, "readlink /dcopy")
+      assert readlink.stdout == "/nope.md\n"
+    end
+
+    test "cp through a symlink keeps the target's mode" do
+      bash = JustBash.new()
+      {:ok, fs} = FS.write_file(bash.fs, "/src.sh", "echo hi\n", mode: 0o755)
+      bash = %{bash | fs: fs}
+      {_, bash} = JustBash.exec(bash, "ln -s /src.sh /mlink")
+
+      {result, bash} = JustBash.exec(bash, "cp /mlink /mcopy")
+      assert result.exit_code == 0
+
+      {:ok, stat, _fs} = FS.stat(bash.fs, "/mcopy")
+      assert stat.mode == 0o755
+    end
+
+    test "cp rejects an empty destination operand" do
+      bash = JustBash.new(files: %{"/x/a.md" => "A\n"})
+
+      {result, bash} = JustBash.exec(bash, "mkdir -p /work && cd /work && cp /x/a.md ''")
+      assert result.exit_code == 1
+
+      assert result.stderr ==
+               "cp: cannot create regular file '': No such file or directory\n"
+
+      {test_result, _} = JustBash.exec(bash, "[ -e /a.md ] || echo absent")
+      assert test_result.stdout == "absent\n"
+    end
+
+    test "cp rejects an empty source operand" do
+      bash = JustBash.new(files: %{"/d/k.md" => "K\n"})
+
+      {result, _} = JustBash.exec(bash, "cp '' /d")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '': No such file or directory\n"
+    end
+
+    test "cp rejects an empty target operand with several sources" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/b.md" => "B\n"})
+
+      {result, _} = JustBash.exec(bash, "cp /a.md /b.md ''")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: target '': No such file or directory\n"
+    end
+
+    # Divergence from bash, which exits 0 and copies nothing here.
+    test "cp -r rejects an empty destination operand" do
+      bash = JustBash.new(files: %{"/s/x.md" => "X\n"})
+
+      {result, _} = JustBash.exec(bash, "cp -r /s ''")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot create directory '': No such file or directory\n"
+    end
+
+    test "cp -v reports the copy it made" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/d/k.md" => "K\n"})
+
+      {result, _} = JustBash.exec(bash, "cp -v /a.md /d")
+      assert result.exit_code == 0
+      assert result.stdout == "'/a.md' -> '/d/a.md'\n"
+      assert result.stderr == ""
+    end
+
+    test "cp -rv reports every copied entry, parents first" do
+      bash =
+        JustBash.new(files: %{"/s/n/n.md" => "N\n", "/s/y.md" => "Y\n", "/d/k.md" => "K\n"})
+
+      {result, _} = JustBash.exec(bash, "cp -rv /s /d")
+      assert result.exit_code == 0
+
+      assert result.stdout == """
+             '/s' -> '/d/s'
+             '/s/n' -> '/d/s/n'
+             '/s/n/n.md' -> '/d/s/n/n.md'
+             '/s/y.md' -> '/d/s/y.md'
+             """
+    end
+
+    test "cp -v reports each source copied into a directory" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/b.md" => "B\n", "/d/k.md" => "K\n"})
+
+      {result, _} = JustBash.exec(bash, "cp -v /a.md /b.md /d")
+      assert result.exit_code == 0
+      assert result.stdout == "'/a.md' -> '/d/a.md'\n'/b.md' -> '/d/b.md'\n"
+    end
+
+    test "cp -n keeps an existing destination" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/d/a.md" => "OLD\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -n /a.md /d")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, _} = JustBash.exec(bash, "cat /d/a.md")
+      assert cat.stdout == "OLD\n"
+    end
+
+    test "cp -n still copies a destination that does not exist" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -n /a.md /d")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /d/a.md")
+      assert cat.stdout == "A\n"
+    end
+
+    # A sandbox has no terminal to prompt on, so `-i` proceeds as if the prompt
+    # were answered yes. Bash with no stdin refuses the overwrite and exits 1.
+    test "cp -i overwrites without prompting" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/b.md" => "B\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -i /a.md /b.md")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /b.md")
+      assert cat.stdout == "A\n"
+    end
   end
 
   describe "mv command" do

--- a/test/commands/file_operations_test.exs
+++ b/test/commands/file_operations_test.exs
@@ -97,6 +97,84 @@ defmodule JustBash.Commands.FileOperationsTest do
     end
   end
 
+  describe "cp/mv self-copy through a symlink" do
+    # A symlinked destination used to walk around the subtree guard, which
+    # compares path spellings: with `l -> /w/a`, "/w/l/x" is inside "/w/a" but
+    # shares no prefix with it, so each pass created children under the tree it
+    # was still walking. These four hung; `mv /w/a /w/l` destroyed the source.
+    # Wording checked against GNU coreutils 9.11.
+    setup do
+      bash =
+        JustBash.new(files: %{"/w/a/f" => "hi\n"}, cwd: "/w")
+        |> then(&elem(JustBash.exec(&1, "ln -s /w/a /w/l"), 1))
+
+      {:ok, bash: bash}
+    end
+
+    @tag timeout: 10_000
+    test "cp -r into a symlink to the source reports copying into itself", %{bash: bash} do
+      {result, bash} = JustBash.exec(bash, "cp -r a l")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot copy a directory, 'a', into itself, 'l/a'\n"
+
+      {cat, _} = JustBash.exec(bash, "cat /w/a/f")
+      assert cat.stdout == "hi\n"
+    end
+
+    @tag timeout: 10_000
+    test "cp -r beneath a symlink to the source is refused", %{bash: bash} do
+      {result, bash} = JustBash.exec(bash, "cp -r a l/x")
+
+      # GNU reaches this through its inode-based self-detection mid-walk and
+      # words it "will not create hard link 'l/x/x' to directory 'l/x'". The
+      # upfront path check gets here first, so the wording differs; exit code
+      # and the untouched source match. Deliberately not fixtured.
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot copy a directory, 'a', into itself, 'l/x'\n"
+
+      {cat, _} = JustBash.exec(bash, "cat /w/a/f")
+      assert cat.stdout == "hi\n"
+    end
+
+    @tag timeout: 10_000
+    test "mv into a symlink to the source leaves the source intact", %{bash: bash} do
+      {result, bash} = JustBash.exec(bash, "mv a l")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot move 'a' to a subdirectory of itself, 'l/a'\n"
+
+      # The regression this guards: the copy silently did nothing and the
+      # recursive remove then deleted the original.
+      {cat, _} = JustBash.exec(bash, "cat /w/a/f")
+      assert cat.stdout == "hi\n"
+    end
+
+    @tag timeout: 10_000
+    test "mv beneath a symlink to the source leaves the source intact", %{bash: bash} do
+      {result, bash} = JustBash.exec(bash, "mv a l/x")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot move 'a' to a subdirectory of itself, 'l/x'\n"
+
+      {cat, _} = JustBash.exec(bash, "cat /w/a/f")
+      assert cat.stdout == "hi\n"
+    end
+
+    @tag timeout: 10_000
+    test "a symlinked destination outside the source still copies", %{bash: bash} do
+      {mk, bash} = JustBash.exec(bash, "mkdir /other && ln -s /other /w/out")
+      assert mk.exit_code == 0
+
+      {result, bash} = JustBash.exec(bash, "cp -r a out/copy")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, _} = JustBash.exec(bash, "cat /other/copy/f")
+      assert cat.stdout == "hi\n"
+    end
+  end
+
   describe "cp command" do
     test "cp copies file" do
       bash = JustBash.new(files: %{"/src.txt" => "content"})

--- a/test/commands/file_operations_test.exs
+++ b/test/commands/file_operations_test.exs
@@ -3,6 +3,8 @@ defmodule JustBash.Commands.FileOperationsTest do
 
   alias JustBash.FS
 
+  defp try_help, do: "Try 'cp --help' for more information.\n"
+
   describe "ls command" do
     test "ls nonexistent directory fails" do
       bash = JustBash.new()
@@ -118,6 +120,373 @@ defmodule JustBash.Commands.FileOperationsTest do
       assert result.exit_code == 1
       assert result.stderr =~ "missing file operand"
     end
+
+    test "cp with only a source reports the missing destination operand" do
+      bash = JustBash.new(files: %{"/src.txt" => "content"})
+      {result, _} = JustBash.exec(bash, "cp /src.txt")
+      assert result.exit_code == 1
+
+      assert result.stderr ==
+               "cp: missing destination file operand after '/src.txt'\n" <> try_help()
+    end
+
+    test "cp into an existing directory uses the source basename" do
+      bash = JustBash.new(files: %{"/m/a.md" => "A\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp /m/a.md /m/d")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, _} = JustBash.exec(bash, "cat /m/d/a.md")
+      assert cat.stdout == "A\n"
+    end
+
+    test "cp into an existing directory with a trailing slash" do
+      bash = JustBash.new(files: %{"/m/a.md" => "A\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp /m/a.md /m/d/")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, _} = JustBash.exec(bash, "cat /m/d/a.md")
+      assert cat.stdout == "A\n"
+
+      {cat2, _} = JustBash.exec(bash, "cat /m/d/k.md")
+      assert cat2.stdout == "K\n"
+    end
+
+    test "cp into a relative directory resolves against the cwd" do
+      bash = JustBash.new(files: %{"/work/a.md" => "A\n"})
+      {_, bash} = JustBash.exec(bash, "mkdir /work/d")
+
+      {result, bash} = JustBash.exec(bash, "cd /work && cp a.md d")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /work/d/a.md")
+      assert cat.stdout == "A\n"
+    end
+
+    test "cp preserves the source file mode" do
+      bash = JustBash.new()
+      {:ok, fs} = FS.write_file(bash.fs, "/src.sh", "echo hi\n", mode: 0o755)
+      bash = %{bash | fs: fs}
+
+      {result, bash} = JustBash.exec(bash, "cp /src.sh /dest.sh")
+      assert result.exit_code == 0
+
+      {:ok, stat, _fs} = FS.stat(bash.fs, "/dest.sh")
+      assert stat.mode == 0o755
+    end
+
+    test "cp -p is accepted and keeps the source mode" do
+      bash = JustBash.new()
+      {:ok, fs} = FS.write_file(bash.fs, "/src.sh", "echo hi\n", mode: 0o755)
+      bash = %{bash | fs: fs}
+
+      {result, bash} = JustBash.exec(bash, "cp -p /src.sh /dest.sh")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {:ok, stat, _fs} = FS.stat(bash.fs, "/dest.sh")
+      assert stat.mode == 0o755
+    end
+
+    test "cp of a dangling symlink reports the source" do
+      bash = JustBash.new()
+      {_, bash} = JustBash.exec(bash, "ln -s /nope.md /dangling")
+
+      {result, _} = JustBash.exec(bash, "cp /dangling /out.md")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/dangling': No such file or directory\n"
+    end
+
+    test "cp dereferences a symlink source" do
+      bash = JustBash.new(files: %{"/target.txt" => "hello\n"})
+      {_, bash} = JustBash.exec(bash, "ln -s /target.txt /link.txt")
+
+      {result, bash} = JustBash.exec(bash, "cp /link.txt /copy.txt")
+      assert result.exit_code == 0
+
+      {cat, bash} = JustBash.exec(bash, "cat /copy.txt")
+      assert cat.stdout == "hello\n"
+
+      {readlink, _} = JustBash.exec(bash, "readlink /copy.txt")
+      assert readlink.exit_code == 1
+    end
+
+    test "cp of a directory without -r omits the directory" do
+      bash = JustBash.new(files: %{"/s/x.md" => "X\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp /s /d")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: -r not specified; omitting directory '/s'\n"
+
+      {test_result, _} = JustBash.exec(bash, "[ -e /d ] || echo absent")
+      assert test_result.stdout == "absent\n"
+    end
+
+    # Divergence from bash, shared with `mv`: this filesystem creates missing
+    # destination parents instead of failing with ENOENT.
+    test "cp creates missing destination parent directories" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp /a.md /nodir/b.md")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, _} = JustBash.exec(bash, "cat /nodir/b.md")
+      assert cat.stdout == "A\n"
+    end
+
+    test "cp of a file onto itself reports the same file" do
+      bash = JustBash.new(files: %{"/m/a.md" => "A\n"})
+
+      {result, _} = JustBash.exec(bash, "cp /m/a.md /m/")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: '/m/a.md' and '/m/a.md' are the same file\n"
+    end
+
+    test "cp -r copies a directory into an existing directory" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /m/s /m/d")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, bash} = JustBash.exec(bash, "cat /m/d/s/x.md")
+      assert cat.stdout == "X\n"
+
+      {cat2, _} = JustBash.exec(bash, "cat /m/s/x.md")
+      assert cat2.stdout == "X\n"
+    end
+
+    test "cp -R copies a directory into an existing directory" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -R /m/s /m/d")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /m/d/s/x.md")
+      assert cat.stdout == "X\n"
+    end
+
+    test "cp --recursive copies a directory into an existing directory" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp --recursive /m/s /m/d")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /m/d/s/x.md")
+      assert cat.stdout == "X\n"
+    end
+
+    test "cp -rf combines flags" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -rf /m/s /m/d")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /m/d/s/x.md")
+      assert cat.stdout == "X\n"
+    end
+
+    test "cp -a copies a directory tree" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -a /m/s /m/d")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /m/d/s/x.md")
+      assert cat.stdout == "X\n"
+    end
+
+    test "cp -r copies the source as the destination when the destination does not exist" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /m/s /m/newdir")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, bash} = JustBash.exec(bash, "cat /m/newdir/x.md")
+      assert cat.stdout == "X\n"
+
+      {test_result, _} = JustBash.exec(bash, "[ -e /m/newdir/s ] || echo absent")
+      assert test_result.stdout == "absent\n"
+    end
+
+    test "cp -r with a trailing slash on the source still uses the source basename" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /m/s/ /m/d")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /m/d/s/x.md")
+      assert cat.stdout == "X\n"
+    end
+
+    test "cp -r with a trailing slash on the destination" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /m/s /m/d/")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /m/d/s/x.md")
+      assert cat.stdout == "X\n"
+    end
+
+    test "cp -r with a trailing slash on both operands and a new destination" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /m/s/ /m/newdir/")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /m/newdir/x.md")
+      assert cat.stdout == "X\n"
+    end
+
+    test "cp -r of a dot-suffixed source copies the contents" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /m/s/. /m/d")
+      assert result.exit_code == 0
+
+      {cat, bash} = JustBash.exec(bash, "cat /m/d/x.md")
+      assert cat.stdout == "X\n"
+
+      {cat2, _} = JustBash.exec(bash, "cat /m/d/k.md")
+      assert cat2.stdout == "K\n"
+    end
+
+    test "cp -r merges into an existing destination subtree" do
+      bash = JustBash.new(files: %{"/m/s/x.md" => "X\n", "/m/d/s/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /m/s /m/d")
+      assert result.exit_code == 0
+
+      {cat, bash} = JustBash.exec(bash, "cat /m/d/s/x.md")
+      assert cat.stdout == "X\n"
+
+      {cat2, _} = JustBash.exec(bash, "cat /m/d/s/k.md")
+      assert cat2.stdout == "K\n"
+    end
+
+    test "cp -r copies nested directories" do
+      bash = JustBash.new(files: %{"/s/n/x.md" => "X\n", "/s/y.md" => "Y\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /s /d")
+      assert result.exit_code == 0
+
+      {cat, bash} = JustBash.exec(bash, "cat /d/n/x.md")
+      assert cat.stdout == "X\n"
+
+      {cat2, _} = JustBash.exec(bash, "cat /d/y.md")
+      assert cat2.stdout == "Y\n"
+    end
+
+    test "cp -r refuses to copy a directory into itself" do
+      bash = JustBash.new(files: %{"/a/b/c.md" => "C\n"})
+
+      {result, _} = JustBash.exec(bash, "cp -r /a /a/b")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot copy a directory, '/a', into itself, '/a/b/a'\n"
+    end
+
+    test "cp -r of a directory onto itself reports the same file" do
+      bash = JustBash.new(files: %{"/a/b/c.md" => "C\n"})
+
+      {result, _} = JustBash.exec(bash, "cp -r /a/b /a")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: '/a/b' and '/a/b' are the same file\n"
+    end
+
+    test "cp -r cannot overwrite a non-directory with a directory" do
+      bash = JustBash.new(files: %{"/s/x.md" => "X\n", "/f" => "F\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /s /f")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot overwrite non-directory '/f' with directory '/s'\n"
+
+      {cat, _} = JustBash.exec(bash, "cat /f")
+      assert cat.stdout == "F\n"
+    end
+
+    test "cp -r copies a regular file like a plain cp" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /a.md /b.md")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /b.md")
+      assert cat.stdout == "A\n"
+    end
+
+    test "cp copies multiple sources into a directory" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/b.md" => "B\n", "/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp /a.md /b.md /d")
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, bash} = JustBash.exec(bash, "cat /d/a.md /d/b.md")
+      assert cat.stdout == "A\nB\n"
+
+      {cat2, _} = JustBash.exec(bash, "cat /d/k.md")
+      assert cat2.stdout == "K\n"
+    end
+
+    test "cp with several operands requires a directory target" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/b.md" => "B\n", "/c.md" => "C\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp /a.md /b.md /c.md")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: target '/c.md': Not a directory\n"
+
+      {cat, _} = JustBash.exec(bash, "cat /c.md")
+      assert cat.stdout == "C\n"
+    end
+
+    test "cp with several operands requires the target to exist" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/b.md" => "B\n"})
+
+      {result, _} = JustBash.exec(bash, "cp /a.md /b.md /nodir")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: target '/nodir': No such file or directory\n"
+    end
+
+    test "cp keeps copying after a failing source and exits 1" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp /nope.md /a.md /d")
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/nope.md': No such file or directory\n"
+
+      {cat, _} = JustBash.exec(bash, "cat /d/a.md")
+      assert cat.stdout == "A\n"
+    end
+
+    test "cp -r copies several directories into a directory" do
+      bash =
+        JustBash.new(files: %{"/s1/x.md" => "X\n", "/s2/y.md" => "Y\n", "/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -r /s1 /s2 /d")
+      assert result.exit_code == 0
+
+      {cat, bash} = JustBash.exec(bash, "cat /d/s1/x.md")
+      assert cat.stdout == "X\n"
+
+      {cat2, _} = JustBash.exec(bash, "cat /d/s2/y.md")
+      assert cat2.stdout == "Y\n"
+    end
+
+    test "cp treats operands after -- as paths" do
+      bash = JustBash.new(files: %{"/a.md" => "A\n", "/d/k.md" => "K\n"})
+
+      {result, bash} = JustBash.exec(bash, "cp -- /a.md /d")
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /d/a.md")
+      assert cat.stdout == "A\n"
+    end
   end
 
   describe "mv command" do
@@ -228,6 +597,17 @@ defmodule JustBash.Commands.FileOperationsTest do
       {result, _} = JustBash.exec(bash, "mv")
       assert result.exit_code == 1
       assert result.stderr =~ "missing file operand"
+    end
+
+    test "mv refuses to move a directory into a subdirectory of itself" do
+      bash = JustBash.new(files: %{"/a/b/c.md" => "C\n"})
+
+      {result, bash} = JustBash.exec(bash, "mv /a /a/b")
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot move '/a' to a subdirectory of itself, '/a/b/a'\n"
+
+      {cat, _} = JustBash.exec(bash, "cat /a/b/c.md")
+      assert cat.stdout == "C\n"
     end
 
     test "mv removes source file" do

--- a/test/fixtures/bash_cases/cp.json
+++ b/test/fixtures/bash_cases/cp.json
@@ -194,13 +194,17 @@
     {
       "name": "cp comparison: -n keeps an existing destination",
       "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; echo OLD > d/a.md; cp -n a.md d; echo rc=$?; cat d/a.md; rm -rf $D",
-      "opts": {"ignore_stderr": true},
+      "opts": {
+        "ignore_stderr": true
+      },
       "content_hash": "2ab44a3b656a69c0"
     },
     {
       "name": "cp comparison: -n copies a destination that does not exist",
       "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; cp -n a.md d; echo rc=$?; cat d/a.md; rm -rf $D",
-      "opts": {"ignore_stderr": true},
+      "opts": {
+        "ignore_stderr": true
+      },
       "content_hash": "dec4a50969f3c547"
     },
     {
@@ -217,6 +221,26 @@
       "name": "cp comparison: an empty target operand is rejected",
       "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; echo B > b.md; cp a.md b.md ''; echo rc=$?; rm -rf $D",
       "content_hash": "f0c084fd0dbbb24c"
+    },
+    {
+      "name": "cp comparison: -r into a symlink pointing at the source is refused",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir a; echo F > a/f.md; ln -s $D/a l; cp -r a l; echo rc=$?; cat a/f.md; rm -rf $D",
+      "content_hash": "e9450712650bb4a0"
+    },
+    {
+      "name": "cp comparison: a destination whose ancestor is a regular file cannot be stat'd",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; echo X > f; cp a.md f/sub.md; echo rc=$?; rm -rf $D",
+      "content_hash": "77d202dbbde3dd3b"
+    },
+    {
+      "name": "cp comparison: -r onto a destination whose ancestor is a regular file cannot be stat'd",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s; echo N > s/n.md; echo X > f; cp -r s f/sub; echo rc=$?; rm -rf $D",
+      "content_hash": "52a761acc5075034"
+    },
+    {
+      "name": "cp comparison: -r onto an existing regular file cannot overwrite a non-directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s; echo N > s/n.md; echo X > f; cp -r s f; echo rc=$?; rm -rf $D",
+      "content_hash": "3ee5b4e3ffbbc648"
     }
   ]
 }

--- a/test/fixtures/bash_cases/cp.json
+++ b/test/fixtures/bash_cases/cp.json
@@ -100,6 +100,123 @@
       "name": "cp comparison: a failing source does not stop the remaining copies",
       "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; cp nope.md a.md d; echo rc=$?; cat d/a.md; rm -rf $D",
       "content_hash": "3e83a61f0368f75d"
+    },
+    {
+      "name": "cp comparison: --recursive copies a directory into an existing directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s d; echo X > s/x.md; cp --recursive s d; echo rc=$?; cat d/s/x.md; rm -rf $D",
+      "content_hash": "8636fb7b9a2a2c90"
+    },
+    {
+      "name": "cp comparison: -a copies a directory into an existing directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s d; echo X > s/x.md; cp -a s d; echo rc=$?; cat d/s/x.md; rm -rf $D",
+      "content_hash": "eb20e4dc7aed830a"
+    },
+    {
+      "name": "cp comparison: operands after -- are paths",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; cp -- a.md d; echo rc=$?; cat d/a.md; rm -rf $D",
+      "content_hash": "87aca532d7b6d88f"
+    },
+    {
+      "name": "cp comparison: -r of a directory onto itself reports the same file",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir -p a/b; echo C > a/b/c.md; cp -r a/b a; echo rc=$?; rm -rf $D",
+      "content_hash": "a4488492292f4be0"
+    },
+    {
+      "name": "cp comparison: -r refuses to copy a directory onto itself",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir -p a/b; echo C > a/b/c.md; cp -r a a; echo rc=$?; rm -rf $D",
+      "content_hash": "e83bd2078dedfdd4"
+    },
+    {
+      "name": "cp comparison: a symlink to a directory needs -r",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir sd; echo X > sd/x.md; ln -s sd sdlink; cp sdlink outdir; echo rc=$?; ls; rm -rf $D",
+      "content_hash": "6b9fd2f91ff5af6e"
+    },
+    {
+      "name": "cp comparison: -r of a symlink to a directory copies the link",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir sd; echo X > sd/x.md; ln -s sd sdlink; cp -r sdlink outdir; echo rc=$?; readlink outdir; rm -rf $D",
+      "content_hash": "814d5ebddd8cf337"
+    },
+    {
+      "name": "cp comparison: -r of a symlink to a file copies the link",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo T > t.md; ln -s t.md alink; cp -r alink rcopy; echo rc=$?; readlink rcopy; rm -rf $D",
+      "content_hash": "a8e4a133aefc3761"
+    },
+    {
+      "name": "cp comparison: -a of a symlink copies the link",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo T > t.md; ln -s t.md alink; cp -a alink acopy; echo rc=$?; readlink acopy; rm -rf $D",
+      "content_hash": "cb44f9a84d5bd01d"
+    },
+    {
+      "name": "cp comparison: -P copies the link instead of dereferencing it",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo T > t.md; ln -s t.md alink; cp -P alink pcopy; echo rc=$?; readlink pcopy; rm -rf $D",
+      "content_hash": "20771d976df0636f"
+    },
+    {
+      "name": "cp comparison: -d copies the link instead of dereferencing it",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo T > t.md; ln -s t.md alink; cp -d alink dcopy; echo rc=$?; readlink dcopy; rm -rf $D",
+      "content_hash": "c5f5c96f4d3ffaa5"
+    },
+    {
+      "name": "cp comparison: a shallow copy dereferences a symlink",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo T > t.md; chmod 755 t.md; ln -s t.md alink; cp alink acopy; echo rc=$?; cat acopy; test -x acopy && echo exec; readlink acopy; rm -rf $D",
+      "content_hash": "593c9db343cebb63"
+    },
+    {
+      "name": "cp comparison: -L dereferences a symlink to a directory even with -r",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir sd; echo X > sd/x.md; ln -s sd sdlink; cp -rL sdlink ldir; echo rc=$?; cat ldir/x.md; readlink ldir; rm -rf $D",
+      "content_hash": "2db3651ccd4e6465"
+    },
+    {
+      "name": "cp comparison: -r of a dangling symlink copies the link",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; ln -s nope.md dangling; cp -r dangling dcopy; echo rc=$?; readlink dcopy; rm -rf $D",
+      "content_hash": "dcdf61c375db5941"
+    },
+    {
+      "name": "cp comparison: a dangling symlink cannot be dereferenced",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; ln -s nope.md dangling; cp dangling out.md; echo rc=$?; rm -rf $D",
+      "content_hash": "ce2c6d6af1a57bad"
+    },
+    {
+      "name": "cp comparison: -v reports the copy it made",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; cp -v a.md d; echo rc=$?; rm -rf $D",
+      "content_hash": "274e2b02b47009bc"
+    },
+    {
+      "name": "cp comparison: -v reports every copied entry, parents first",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir -p s/n d; echo N > s/n/n.md; echo Y > s/y.md; cp -rv s d; echo rc=$?; rm -rf $D",
+      "content_hash": "26c5955727277d52"
+    },
+    {
+      "name": "cp comparison: -v reports each source copied into a directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; echo B > b.md; cp -v a.md b.md d; echo rc=$?; rm -rf $D",
+      "content_hash": "5228b297a9a35c79"
+    },
+    {
+      "name": "cp comparison: -n keeps an existing destination",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; echo OLD > d/a.md; cp -n a.md d; echo rc=$?; cat d/a.md; rm -rf $D",
+      "opts": {"ignore_stderr": true},
+      "content_hash": "2ab44a3b656a69c0"
+    },
+    {
+      "name": "cp comparison: -n copies a destination that does not exist",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; cp -n a.md d; echo rc=$?; cat d/a.md; rm -rf $D",
+      "opts": {"ignore_stderr": true},
+      "content_hash": "dec4a50969f3c547"
+    },
+    {
+      "name": "cp comparison: an empty destination operand is rejected",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; cp a.md ''; echo rc=$?; ls; rm -rf $D",
+      "content_hash": "5a91d6dec88a59df"
+    },
+    {
+      "name": "cp comparison: an empty source operand is rejected",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; cp '' d; echo rc=$?; rm -rf $D",
+      "content_hash": "002e797cba953065"
+    },
+    {
+      "name": "cp comparison: an empty target operand is rejected",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; echo B > b.md; cp a.md b.md ''; echo rc=$?; rm -rf $D",
+      "content_hash": "f0c084fd0dbbb24c"
     }
   ]
 }

--- a/test/fixtures/bash_cases/cp.json
+++ b/test/fixtures/bash_cases/cp.json
@@ -1,0 +1,105 @@
+{
+  "suite": "cp",
+  "cases": [
+    {
+      "name": "cp comparison: copies a file into an existing directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; cp a.md d; echo rc=$?; cat d/a.md; rm -rf $D",
+      "content_hash": "c43f4c0f18de8b91"
+    },
+    {
+      "name": "cp comparison: copies a file into an existing directory with a trailing slash",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; cp a.md d/; echo rc=$?; cat d/a.md; rm -rf $D",
+      "content_hash": "d7521956cf2ccd49"
+    },
+    {
+      "name": "cp comparison: -r copies a directory into an existing directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s d; echo X > s/x.md; cp -r s d; echo rc=$?; cat d/s/x.md; rm -rf $D",
+      "content_hash": "fa707f67298ced09"
+    },
+    {
+      "name": "cp comparison: -R copies a directory into an existing directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s d; echo X > s/x.md; cp -R s d; echo rc=$?; cat d/s/x.md; rm -rf $D",
+      "content_hash": "6c83b15e06d40bd1"
+    },
+    {
+      "name": "cp comparison: -r copies a directory as the destination when it does not exist",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s; echo X > s/x.md; cp -r s newdir; echo rc=$?; cat newdir/x.md; ls newdir; rm -rf $D",
+      "content_hash": "f92d3843c2634dad"
+    },
+    {
+      "name": "cp comparison: -r with a trailing slash on the source",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s d; echo X > s/x.md; cp -r s/ d; echo rc=$?; cat d/s/x.md; rm -rf $D",
+      "content_hash": "53da879bc497619f"
+    },
+    {
+      "name": "cp comparison: -r with a trailing slash on the destination",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s d; echo X > s/x.md; cp -r s d/; echo rc=$?; cat d/s/x.md; rm -rf $D",
+      "content_hash": "4921949d6f04d391"
+    },
+    {
+      "name": "cp comparison: -r merges into an existing destination subtree",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir -p s d/s; echo X > s/x.md; echo K > d/s/k.md; cp -r s d; echo rc=$?; cat d/s/k.md d/s/x.md; rm -rf $D",
+      "content_hash": "3875e9273e551a48"
+    },
+    {
+      "name": "cp comparison: -r copies nested directories",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir -p s/n; echo X > s/n/x.md; echo Y > s/y.md; cp -r s d; echo rc=$?; cat d/n/x.md d/y.md; rm -rf $D",
+      "content_hash": "913bd9b8c1a697a9"
+    },
+    {
+      "name": "cp comparison: copies several files into a directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; echo B > b.md; cp a.md b.md d; echo rc=$?; cat d/a.md d/b.md; rm -rf $D",
+      "content_hash": "3d9728c3e2c3479b"
+    },
+    {
+      "name": "cp comparison: preserves the source file mode",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; chmod 755 a.md; cp a.md b.md; echo rc=$?; test -x b.md && echo exec; rm -rf $D",
+      "content_hash": "3856f344e6a3f5c8"
+    },
+    {
+      "name": "cp comparison: a directory source without -r is omitted",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s; echo X > s/x.md; cp s d; echo rc=$?; ls; rm -rf $D",
+      "content_hash": "1988380eca030677"
+    },
+    {
+      "name": "cp comparison: missing destination operand",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; cp a.md; echo rc=$?; rm -rf $D",
+      "content_hash": "e4cfb3414a0ecbd9"
+    },
+    {
+      "name": "cp comparison: missing file operand",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; cp; echo rc=$?; rm -rf $D",
+      "content_hash": "c3b6e0799b4dbd1f"
+    },
+    {
+      "name": "cp comparison: nonexistent source",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; cp nope.md d.md; echo rc=$?; rm -rf $D",
+      "content_hash": "4049b8b12fcaf6f7"
+    },
+    {
+      "name": "cp comparison: several operands need a directory target",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; echo B > b.md; echo C > c.md; cp a.md b.md c.md; echo rc=$?; rm -rf $D",
+      "content_hash": "73722303c03c8c04"
+    },
+    {
+      "name": "cp comparison: several operands need an existing target",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; echo B > b.md; cp a.md b.md nodir; echo rc=$?; rm -rf $D",
+      "content_hash": "a2548785d4a66b49"
+    },
+    {
+      "name": "cp comparison: -r refuses to copy a directory into itself",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir -p a/b; echo C > a/b/c.md; cp -r a a/b; echo rc=$?; rm -rf $D",
+      "content_hash": "f8b50f95ee8b854a"
+    },
+    {
+      "name": "cp comparison: -r cannot overwrite a non-directory with a directory",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s; echo X > s/x.md; echo F > f; cp -r s f; echo rc=$?; cat f; rm -rf $D",
+      "content_hash": "b5ba0d91ead4090c"
+    },
+    {
+      "name": "cp comparison: a failing source does not stop the remaining copies",
+      "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir d; echo A > a.md; cp nope.md a.md d; echo rc=$?; cat d/a.md; rm -rf $D",
+      "content_hash": "3e83a61f0368f75d"
+    }
+  ]
+}

--- a/test/fixtures/bash_cases/mv.json
+++ b/test/fixtures/bash_cases/mv.json
@@ -35,6 +35,16 @@
       "name": "mv comparison: refuses to move a directory into a subdirectory of itself",
       "script": "D=/tmp/jb_mv_$$; rm -rf $D; mkdir $D; cd $D; mkdir -p a/b; echo C > a/b/c.md; mv a a/b; echo rc=$?; cat a/b/c.md; rm -rf $D",
       "content_hash": "ded339f40627ef2d"
+    },
+    {
+      "name": "mv comparison: refuses to move into a symlink pointing at itself",
+      "script": "D=/tmp/jb_mv_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir a; echo F > a/f.md; ln -s $D/a l; mv a l; echo rc=$?; cat a/f.md; rm -rf $D",
+      "content_hash": "62b26859204b5de7"
+    },
+    {
+      "name": "mv comparison: refuses to move beneath a symlink pointing at itself",
+      "script": "D=/tmp/jb_mv_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir a; echo F > a/f.md; ln -s $D/a l; mv a l/x; echo rc=$?; cat a/f.md; rm -rf $D",
+      "content_hash": "849325d826f72e28"
     }
   ]
 }

--- a/test/fixtures/bash_cases/mv.json
+++ b/test/fixtures/bash_cases/mv.json
@@ -30,6 +30,11 @@
       "name": "mv comparison: moves a symlink without dereferencing it",
       "script": "D=/tmp/jb_mv_$$; rm -rf $D; mkdir $D; cd $D; echo hi > target; ln -s target link; mv link moved; readlink moved; cat moved; rm -rf $D",
       "content_hash": "265f43784862815d"
+    },
+    {
+      "name": "mv comparison: refuses to move a directory into a subdirectory of itself",
+      "script": "D=/tmp/jb_mv_$$; rm -rf $D; mkdir $D; cd $D; mkdir -p a/b; echo C > a/b/c.md; mv a a/b; echo rc=$?; cat a/b/c.md; rm -rf $D",
+      "content_hash": "ded339f40627ef2d"
     }
   ]
 }

--- a/test/fixtures/bash_expected/cp.json
+++ b/test/fixtures/bash_expected/cp.json
@@ -300,6 +300,34 @@
       "name": "cp comparison: an empty target operand is rejected",
       "stderr": "cp: target '': No such file or directory\n",
       "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e9450712650bb4a0",
+      "exit_code": 0,
+      "name": "cp comparison: -r into a symlink pointing at the source is refused",
+      "stderr": "cp: cannot copy a directory, 'a', into itself, 'l/a'\n",
+      "stdout": "rc=1\nF\n"
+    },
+    {
+      "content_hash": "77d202dbbde3dd3b",
+      "exit_code": 0,
+      "name": "cp comparison: a destination whose ancestor is a regular file cannot be stat'd",
+      "stderr": "cp: cannot stat 'f/sub.md': Not a directory\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "52a761acc5075034",
+      "exit_code": 0,
+      "name": "cp comparison: -r onto a destination whose ancestor is a regular file cannot be stat'd",
+      "stderr": "cp: cannot stat 'f/sub': Not a directory\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "3ee5b4e3ffbbc648",
+      "exit_code": 0,
+      "name": "cp comparison: -r onto an existing regular file cannot overwrite a non-directory",
+      "stderr": "cp: cannot overwrite non-directory 'f' with directory 's'\n",
+      "stdout": "rc=1\n"
     }
   ],
   "suite": "cp"

--- a/test/fixtures/bash_expected/cp.json
+++ b/test/fixtures/bash_expected/cp.json
@@ -139,6 +139,167 @@
       "name": "cp comparison: a failing source does not stop the remaining copies",
       "stderr": "cp: cannot stat 'nope.md': No such file or directory\n",
       "stdout": "rc=1\nA\n"
+    },
+    {
+      "content_hash": "8636fb7b9a2a2c90",
+      "exit_code": 0,
+      "name": "cp comparison: --recursive copies a directory into an existing directory",
+      "stderr": "",
+      "stdout": "rc=0\nX\n"
+    },
+    {
+      "content_hash": "eb20e4dc7aed830a",
+      "exit_code": 0,
+      "name": "cp comparison: -a copies a directory into an existing directory",
+      "stderr": "",
+      "stdout": "rc=0\nX\n"
+    },
+    {
+      "content_hash": "87aca532d7b6d88f",
+      "exit_code": 0,
+      "name": "cp comparison: operands after -- are paths",
+      "stderr": "",
+      "stdout": "rc=0\nA\n"
+    },
+    {
+      "content_hash": "a4488492292f4be0",
+      "exit_code": 0,
+      "name": "cp comparison: -r of a directory onto itself reports the same file",
+      "stderr": "cp: 'a/b' and 'a/b' are the same file\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e83bd2078dedfdd4",
+      "exit_code": 0,
+      "name": "cp comparison: -r refuses to copy a directory onto itself",
+      "stderr": "cp: cannot copy a directory, 'a', into itself, 'a/a'\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6b9fd2f91ff5af6e",
+      "exit_code": 0,
+      "name": "cp comparison: a symlink to a directory needs -r",
+      "stderr": "cp: -r not specified; omitting directory 'sdlink'\n",
+      "stdout": "rc=1\nsd\nsdlink\n"
+    },
+    {
+      "content_hash": "814d5ebddd8cf337",
+      "exit_code": 0,
+      "name": "cp comparison: -r of a symlink to a directory copies the link",
+      "stderr": "",
+      "stdout": "rc=0\nsd\n"
+    },
+    {
+      "content_hash": "a8e4a133aefc3761",
+      "exit_code": 0,
+      "name": "cp comparison: -r of a symlink to a file copies the link",
+      "stderr": "",
+      "stdout": "rc=0\nt.md\n"
+    },
+    {
+      "content_hash": "cb44f9a84d5bd01d",
+      "exit_code": 0,
+      "name": "cp comparison: -a of a symlink copies the link",
+      "stderr": "",
+      "stdout": "rc=0\nt.md\n"
+    },
+    {
+      "content_hash": "20771d976df0636f",
+      "exit_code": 0,
+      "name": "cp comparison: -P copies the link instead of dereferencing it",
+      "stderr": "",
+      "stdout": "rc=0\nt.md\n"
+    },
+    {
+      "content_hash": "c5f5c96f4d3ffaa5",
+      "exit_code": 0,
+      "name": "cp comparison: -d copies the link instead of dereferencing it",
+      "stderr": "",
+      "stdout": "rc=0\nt.md\n"
+    },
+    {
+      "content_hash": "593c9db343cebb63",
+      "exit_code": 0,
+      "name": "cp comparison: a shallow copy dereferences a symlink",
+      "stderr": "",
+      "stdout": "rc=0\nT\nexec\n"
+    },
+    {
+      "content_hash": "2db3651ccd4e6465",
+      "exit_code": 0,
+      "name": "cp comparison: -L dereferences a symlink to a directory even with -r",
+      "stderr": "",
+      "stdout": "rc=0\nX\n"
+    },
+    {
+      "content_hash": "dcdf61c375db5941",
+      "exit_code": 0,
+      "name": "cp comparison: -r of a dangling symlink copies the link",
+      "stderr": "",
+      "stdout": "rc=0\nnope.md\n"
+    },
+    {
+      "content_hash": "ce2c6d6af1a57bad",
+      "exit_code": 0,
+      "name": "cp comparison: a dangling symlink cannot be dereferenced",
+      "stderr": "cp: cannot stat 'dangling': No such file or directory\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "274e2b02b47009bc",
+      "exit_code": 0,
+      "name": "cp comparison: -v reports the copy it made",
+      "stderr": "",
+      "stdout": "'a.md' -> 'd/a.md'\nrc=0\n"
+    },
+    {
+      "content_hash": "26c5955727277d52",
+      "exit_code": 0,
+      "name": "cp comparison: -v reports every copied entry, parents first",
+      "stderr": "",
+      "stdout": "'s' -> 'd/s'\n's/n' -> 'd/s/n'\n's/n/n.md' -> 'd/s/n/n.md'\n's/y.md' -> 'd/s/y.md'\nrc=0\n"
+    },
+    {
+      "content_hash": "5228b297a9a35c79",
+      "exit_code": 0,
+      "name": "cp comparison: -v reports each source copied into a directory",
+      "stderr": "",
+      "stdout": "'a.md' -> 'd/a.md'\n'b.md' -> 'd/b.md'\nrc=0\n"
+    },
+    {
+      "content_hash": "2ab44a3b656a69c0",
+      "exit_code": 0,
+      "name": "cp comparison: -n keeps an existing destination",
+      "stderr": "cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead\n",
+      "stdout": "rc=0\nOLD\n"
+    },
+    {
+      "content_hash": "dec4a50969f3c547",
+      "exit_code": 0,
+      "name": "cp comparison: -n copies a destination that does not exist",
+      "stderr": "cp: warning: behavior of -n is non-portable and may change in future; use --update=none instead\n",
+      "stdout": "rc=0\nA\n"
+    },
+    {
+      "content_hash": "5a91d6dec88a59df",
+      "exit_code": 0,
+      "name": "cp comparison: an empty destination operand is rejected",
+      "stderr": "cp: cannot create regular file '': No such file or directory\n",
+      "stdout": "rc=1\na.md\n"
+    },
+    {
+      "content_hash": "002e797cba953065",
+      "exit_code": 0,
+      "name": "cp comparison: an empty source operand is rejected",
+      "stderr": "cp: cannot stat '': No such file or directory\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f0c084fd0dbbb24c",
+      "exit_code": 0,
+      "name": "cp comparison: an empty target operand is rejected",
+      "stderr": "cp: target '': No such file or directory\n",
+      "stdout": "rc=1\n"
     }
   ],
   "suite": "cp"

--- a/test/fixtures/bash_expected/cp.json
+++ b/test/fixtures/bash_expected/cp.json
@@ -1,0 +1,145 @@
+{
+  "results": [
+    {
+      "content_hash": "c43f4c0f18de8b91",
+      "exit_code": 0,
+      "name": "cp comparison: copies a file into an existing directory",
+      "stderr": "",
+      "stdout": "rc=0\nA\n"
+    },
+    {
+      "content_hash": "d7521956cf2ccd49",
+      "exit_code": 0,
+      "name": "cp comparison: copies a file into an existing directory with a trailing slash",
+      "stderr": "",
+      "stdout": "rc=0\nA\n"
+    },
+    {
+      "content_hash": "fa707f67298ced09",
+      "exit_code": 0,
+      "name": "cp comparison: -r copies a directory into an existing directory",
+      "stderr": "",
+      "stdout": "rc=0\nX\n"
+    },
+    {
+      "content_hash": "6c83b15e06d40bd1",
+      "exit_code": 0,
+      "name": "cp comparison: -R copies a directory into an existing directory",
+      "stderr": "",
+      "stdout": "rc=0\nX\n"
+    },
+    {
+      "content_hash": "f92d3843c2634dad",
+      "exit_code": 0,
+      "name": "cp comparison: -r copies a directory as the destination when it does not exist",
+      "stderr": "",
+      "stdout": "rc=0\nX\nx.md\n"
+    },
+    {
+      "content_hash": "53da879bc497619f",
+      "exit_code": 0,
+      "name": "cp comparison: -r with a trailing slash on the source",
+      "stderr": "",
+      "stdout": "rc=0\nX\n"
+    },
+    {
+      "content_hash": "4921949d6f04d391",
+      "exit_code": 0,
+      "name": "cp comparison: -r with a trailing slash on the destination",
+      "stderr": "",
+      "stdout": "rc=0\nX\n"
+    },
+    {
+      "content_hash": "3875e9273e551a48",
+      "exit_code": 0,
+      "name": "cp comparison: -r merges into an existing destination subtree",
+      "stderr": "",
+      "stdout": "rc=0\nK\nX\n"
+    },
+    {
+      "content_hash": "913bd9b8c1a697a9",
+      "exit_code": 0,
+      "name": "cp comparison: -r copies nested directories",
+      "stderr": "",
+      "stdout": "rc=0\nX\nY\n"
+    },
+    {
+      "content_hash": "3d9728c3e2c3479b",
+      "exit_code": 0,
+      "name": "cp comparison: copies several files into a directory",
+      "stderr": "",
+      "stdout": "rc=0\nA\nB\n"
+    },
+    {
+      "content_hash": "3856f344e6a3f5c8",
+      "exit_code": 0,
+      "name": "cp comparison: preserves the source file mode",
+      "stderr": "",
+      "stdout": "rc=0\nexec\n"
+    },
+    {
+      "content_hash": "1988380eca030677",
+      "exit_code": 0,
+      "name": "cp comparison: a directory source without -r is omitted",
+      "stderr": "cp: -r not specified; omitting directory 's'\n",
+      "stdout": "rc=1\ns\n"
+    },
+    {
+      "content_hash": "e4cfb3414a0ecbd9",
+      "exit_code": 0,
+      "name": "cp comparison: missing destination operand",
+      "stderr": "cp: missing destination file operand after 'a.md'\nTry 'cp --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c3b6e0799b4dbd1f",
+      "exit_code": 0,
+      "name": "cp comparison: missing file operand",
+      "stderr": "cp: missing file operand\nTry 'cp --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "4049b8b12fcaf6f7",
+      "exit_code": 0,
+      "name": "cp comparison: nonexistent source",
+      "stderr": "cp: cannot stat 'nope.md': No such file or directory\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "73722303c03c8c04",
+      "exit_code": 0,
+      "name": "cp comparison: several operands need a directory target",
+      "stderr": "cp: target 'c.md': Not a directory\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a2548785d4a66b49",
+      "exit_code": 0,
+      "name": "cp comparison: several operands need an existing target",
+      "stderr": "cp: target 'nodir': No such file or directory\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f8b50f95ee8b854a",
+      "exit_code": 0,
+      "name": "cp comparison: -r refuses to copy a directory into itself",
+      "stderr": "cp: cannot copy a directory, 'a', into itself, 'a/b/a'\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b5ba0d91ead4090c",
+      "exit_code": 0,
+      "name": "cp comparison: -r cannot overwrite a non-directory with a directory",
+      "stderr": "cp: cannot overwrite non-directory 'f' with directory 's'\n",
+      "stdout": "rc=1\nF\n"
+    },
+    {
+      "content_hash": "3e83a61f0368f75d",
+      "exit_code": 0,
+      "name": "cp comparison: a failing source does not stop the remaining copies",
+      "stderr": "cp: cannot stat 'nope.md': No such file or directory\n",
+      "stdout": "rc=1\nA\n"
+    }
+  ],
+  "suite": "cp"
+}

--- a/test/fixtures/bash_expected/mv.json
+++ b/test/fixtures/bash_expected/mv.json
@@ -48,6 +48,20 @@
       "name": "mv comparison: refuses to move a directory into a subdirectory of itself",
       "stderr": "mv: cannot move 'a' to a subdirectory of itself, 'a/b/a'\n",
       "stdout": "rc=1\nC\n"
+    },
+    {
+      "content_hash": "62b26859204b5de7",
+      "exit_code": 0,
+      "name": "mv comparison: refuses to move into a symlink pointing at itself",
+      "stderr": "mv: cannot move 'a' to a subdirectory of itself, 'l/a'\n",
+      "stdout": "rc=1\nF\n"
+    },
+    {
+      "content_hash": "849325d826f72e28",
+      "exit_code": 0,
+      "name": "mv comparison: refuses to move beneath a symlink pointing at itself",
+      "stderr": "mv: cannot move 'a' to a subdirectory of itself, 'l/x'\n",
+      "stdout": "rc=1\nF\n"
     }
   ],
   "suite": "mv"

--- a/test/fixtures/bash_expected/mv.json
+++ b/test/fixtures/bash_expected/mv.json
@@ -41,6 +41,13 @@
       "name": "mv comparison: moves a symlink without dereferencing it",
       "stderr": "",
       "stdout": "target\nhi\n"
+    },
+    {
+      "content_hash": "ded339f40627ef2d",
+      "exit_code": 0,
+      "name": "mv comparison: refuses to move a directory into a subdirectory of itself",
+      "stderr": "mv: cannot move 'a' to a subdirectory of itself, 'a/b/a'\n",
+      "stdout": "rc=1\nC\n"
     }
   ],
   "suite": "mv"

--- a/test/just_bash/fs_test.exs
+++ b/test/just_bash/fs_test.exs
@@ -401,6 +401,63 @@ defmodule JustBash.FSTest do
       {:ok, fs} = FS.cp(fs, "/ab", "/abc", recursive: true)
       assert {:ok, "x", _fs} = FS.read_file(fs, "/abc/x.txt")
     end
+
+    # The guard compares paths, so a symlink can make the spelling lie: with
+    # `/l -> /a`, "/l/x" shares no prefix with "/a" yet lands inside it. Before
+    # both operands were resolved these recursed until the VM died.
+    @tag timeout: 10_000
+    test "refuses a destination that reaches the source through a symlink" do
+      fs = FS.new(%{"/a/b/c.txt" => "c"})
+      {:ok, fs} = FS.symlink(fs, "/a", "/l")
+
+      assert {:error, %VFS.Error{kind: :einval}} = FS.cp(fs, "/a", "/l/x", recursive: true)
+      assert {:error, %VFS.Error{kind: :einval}} = FS.cp(fs, "/a", "/l", recursive: true)
+      assert {:error, %VFS.Error{kind: :einval}} = FS.cp(fs, "/a", "/l/b/deep", recursive: true)
+      assert {:ok, "c", _fs} = FS.read_file(fs, "/a/b/c.txt")
+    end
+
+    @tag timeout: 10_000
+    test "refuses a source spelled through a symlinked component" do
+      fs = FS.new(%{"/a/b/c.txt" => "c"})
+      {:ok, fs} = FS.symlink(fs, "/a", "/l")
+
+      # The link is a non-final component of the source: "/l/b" resolves to
+      # "/a/b", so "/a/b/x" is inside it. GNU 9.11 agrees —
+      # "cannot copy a directory, 'l/b', into itself, 'a/b/x'".
+      assert {:error, %VFS.Error{kind: :einval}} = FS.cp(fs, "/l/b", "/a/b/x", recursive: true)
+      assert {:ok, "c", _fs} = FS.read_file(fs, "/a/b/c.txt")
+    end
+
+    @tag timeout: 10_000
+    test "copies the link itself when the source is a symlink to the destination's parent" do
+      fs = FS.new(%{"/a/b/c.txt" => "c"})
+      {:ok, fs} = FS.symlink(fs, "/a", "/l")
+
+      # Not a self-copy: a symlink source copies the link, so there is nothing
+      # to recurse into. GNU 9.11 exits 0 here and writes a link too.
+      {:ok, fs} = FS.cp(fs, "/l", "/a/x", recursive: true)
+      assert {:ok, %VFS.Stat{type: :symlink}, fs} = FS.lstat(fs, "/a/x")
+      assert {:ok, "/a", _fs} = FS.readlink(fs, "/a/x")
+    end
+
+    @tag timeout: 10_000
+    test "still copies when a symlinked destination resolves outside the source" do
+      fs = FS.new(%{"/a/x.txt" => "x", "/other/keep.txt" => "keep"})
+      {:ok, fs} = FS.symlink(fs, "/other", "/out")
+
+      # Resolving the destination must not over-reject: /out is not inside /a.
+      {:ok, fs} = FS.cp(fs, "/a", "/out/copy", recursive: true)
+      assert {:ok, "x", fs} = FS.read_file(fs, "/other/copy/x.txt")
+      assert {:ok, "keep", _fs} = FS.read_file(fs, "/other/keep.txt")
+    end
+
+    @tag timeout: 10_000
+    test "reports rather than spins when a destination component is a symlink loop" do
+      fs = FS.new(%{"/a/x.txt" => "x"})
+      {:ok, fs} = FS.symlink(fs, "/loop", "/loop")
+
+      assert {:error, %VFS.Error{}} = FS.cp(fs, "/a", "/loop/x", recursive: true)
+    end
   end
 
   describe "mv/3" do
@@ -442,6 +499,21 @@ defmodule JustBash.FSTest do
 
       assert {:error, %VFS.Error{kind: :einval}} = FS.mv(fs, "/a", "/a/b/a")
       assert {:ok, "c", _fs} = FS.read_file(fs, "/a/b/c.txt")
+    end
+
+    # `mv` composes on `cp/4`, so it inherits the resolved guard. This is the
+    # case that used to destroy the source: the copy silently did nothing and
+    # the recursive remove then deleted the original.
+    @tag timeout: 10_000
+    test "refuses to move into its own subtree reached through a symlink" do
+      fs = FS.new(%{"/a/f.txt" => "hi"})
+      {:ok, fs} = FS.symlink(fs, "/a", "/l")
+
+      assert {:error, %VFS.Error{kind: :einval}} = FS.mv(fs, "/a", "/l/x")
+      assert {:ok, "hi", fs} = FS.read_file(fs, "/a/f.txt")
+
+      assert {:error, %VFS.Error{kind: :einval}} = FS.mv(fs, "/a", "/l/deep/x")
+      assert {:ok, "hi", _fs} = FS.read_file(fs, "/a/f.txt")
     end
   end
 

--- a/test/just_bash/fs_test.exs
+++ b/test/just_bash/fs_test.exs
@@ -373,6 +373,34 @@ defmodule JustBash.FSTest do
       assert {:ok, "a", fs} = FS.read_file(fs, "/destdir/file.txt")
       assert {:ok, "b", _fs} = FS.read_file(fs, "/destdir/subdir/nested.txt")
     end
+
+    test "merges into an existing destination directory" do
+      fs = FS.new(%{"/srcdir/new.txt" => "new", "/destdir/kept.txt" => "kept"})
+
+      {:ok, fs} = FS.cp(fs, "/srcdir", "/destdir", recursive: true)
+      assert {:ok, "new", fs} = FS.read_file(fs, "/destdir/new.txt")
+      assert {:ok, "kept", _fs} = FS.read_file(fs, "/destdir/kept.txt")
+    end
+
+    test "refuses to copy a directory into itself instead of recursing forever" do
+      fs = FS.new(%{"/a/b/c.txt" => "c"})
+
+      assert {:error, %VFS.Error{kind: :einval}} = FS.cp(fs, "/a", "/a/b/a", recursive: true)
+      assert {:error, %VFS.Error{kind: :einval}} = FS.cp(fs, "/a", "/a", recursive: true)
+    end
+
+    test "refuses to copy the root directory into a subdirectory of itself" do
+      fs = FS.new(%{"/a/b/c.txt" => "c"})
+
+      assert {:error, %VFS.Error{kind: :einval}} = FS.cp(fs, "/", "/copy", recursive: true)
+    end
+
+    test "copies a sibling directory whose path shares a prefix with the source" do
+      fs = FS.new(%{"/ab/x.txt" => "x"})
+
+      {:ok, fs} = FS.cp(fs, "/ab", "/abc", recursive: true)
+      assert {:ok, "x", _fs} = FS.read_file(fs, "/abc/x.txt")
+    end
   end
 
   describe "mv/3" do
@@ -407,6 +435,13 @@ defmodule JustBash.FSTest do
       fs = FS.new(%{"/file.txt" => "content"})
       {:ok, fs} = FS.mv(fs, "/file.txt", "/file.txt")
       assert {:ok, "content", _fs} = FS.read_file(fs, "/file.txt")
+    end
+
+    test "refuses to move a directory into a subdirectory of itself" do
+      fs = FS.new(%{"/a/b/c.txt" => "c"})
+
+      assert {:error, %VFS.Error{kind: :einval}} = FS.mv(fs, "/a", "/a/b/a")
+      assert {:ok, "c", _fs} = FS.read_file(fs, "/a/b/c.txt")
     end
   end
 

--- a/test/just_bash/not_a_directory_test.exs
+++ b/test/just_bash/not_a_directory_test.exs
@@ -293,6 +293,30 @@ defmodule JustBash.NotADirectoryTest do
       assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, "/m/j/a.md")
     end
 
+    test "cp -r reports Not a directory when an ancestor of the destination is a file" do
+      bash = bash_with_file_parent(%{"/s/n.md" => "n\n"})
+      {result, bash} = JustBash.exec(bash, "cp -r /s /m/j/sub")
+
+      assert result.exit_code == 1
+
+      # Same rule as the regular-file copy above: an ancestor that is a file is
+      # a failed stat of the destination, not a failed overwrite. Verified
+      # against GNU coreutils 9.11.
+      assert result.stderr == "cp: cannot stat '/m/j/sub': Not a directory\n"
+
+      assert {:error, %VFS.Error{}} = FS.read_file(bash.fs, "/m/j/sub/n.md")
+    end
+
+    test "cp -r keeps 'cannot overwrite non-directory' when the destination is the file" do
+      bash = bash_with_file_parent(%{"/s/n.md" => "n\n"})
+      {result, _bash} = JustBash.exec(bash, "cp -r /s /m/j")
+
+      # The destination itself exists as a regular file — a different failure
+      # from an ancestor being one, and GNU words it differently.
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot overwrite non-directory '/m/j' with directory '/s'\n"
+    end
+
     test "cp keeps 'cannot create regular file' for a non-ENOTDIR failure" do
       bash = JustBash.new(files: %{"/src.txt" => "x\n"})
       {result, _bash} = JustBash.exec(bash, "mkdir -p /d && cp /src.txt /d")


### PR DESCRIPTION
Closes #52

Two independent `cp` bugs, plus one hang they exposed.

## Bug 1: `cp SRC DIR` raised an uncaught MatchError

**Root cause.** `Cp.execute/3` never looked at the destination: it read the source and wrote the content straight to the destination path with a hard match, `{:ok, fs} = FS.write_file(fs, dest_resolved, content)`. When the destination was an existing directory, `write_file` returned `{:error, %VFS.Error{kind: :eisdir}}`, the match failed, and the `MatchError` escaped `JustBash.exec/2` and crashed the host. `mv` already did the right thing (stat the destination, append the source basename when it is a directory); `cp` did not.

**Fix.** `cp` stats the destination and, when it is a directory, copies into it under the source's basename — for `cp SRC DIR` and `cp SRC DIR/` alike. No filesystem result is hard-matched any more; each error kind becomes a bash-shaped message on stderr with exit 1 (same precedent as dffd5dd for `mkdir`/`rm`).

## Bug 2: `cp -r SRC DIR` copied nothing and reported "missing file operand"

**Root cause.** `cp` parsed no flags at all. `-r` was therefore just another operand, `["-r", "/m/s", "/m/d"]` did not match the `[src, dest]` clause, and the catch-all arity error fired. Recursive copy was unreachable through the shell even though `FS.cp/4` has supported `recursive: true` all along.

**Fix.** `cp` parses flags through the shared `JustBash.FlagParser`: `-r`, `-R`, `--recursive`, and `-a`/`--archive` (implies recursive) enable directory copies; `-f`/`--force` and `-p`/`--preserve` are accepted no-ops (a copy always overwrites, and always carries the source's mode and mtime across). Combined forms (`-rf`) and `--` work through the parser. Directory copies go through `FS.cp(recursive: true)`, so a source directory copies *into* an existing destination directory (`d/s/...`) and *as* the destination when it does not exist — matching bash.

## Also fixed: infinite recursion on a copy into its own subtree

Enabling `-r` made a latent `FS.cp/4` hang reachable: copying a directory into a path inside itself recursed forever, because each pass created new children under the tree still being walked. It was already reachable today through `mv /a /a/b`, which hung the exec. `FS.cp/4` now rejects that up front with `:einval` before mutating anything, and the callers translate it to bash's wording:

- `cp: cannot copy a directory, '/a', into itself, '/a/b/a'`
- `mv: cannot move '/a' to a subdirectory of itself, '/a/b/a'`

`Mv` also gained a catch-all `%VFS.Error{}` clause, so a new error kind can no longer raise a `CaseClauseError` out of `mv`.

## Behaviors changed

- `cp SRC DIR` / `cp SRC DIR/` copy into the directory, exit 0 (was: MatchError crash).
- `cp -r`/`-R`/`--recursive`/`-a` copy directory trees, including merging into an existing destination subtree and the `cp -r src/. dest` contents idiom.
- Any number of sources may be copied into a trailing directory operand (`cp *.md dir/`). The trailing operand must be an existing directory, else `cp: target 'x': Not a directory` / `No such file or directory`, as in bash. A failing source no longer stops the rest: bash copies what it can, reports each failure, exits 1.
- Errors now match GNU coreutils wording: `missing file operand` / `missing destination file operand after 'x'` (both with the `Try 'cp --help'` line), `cannot stat`, `-r not specified; omitting directory`, `cannot overwrite non-directory 'd' with directory 's'`, `'a' and 'a' are the same file`, `target 'c': Not a directory`.
- A symlink source is dereferenced (bash's default without `-d`/`-P`); a regular-file copy now carries the source's mode across (it previously landed as 0644).
- Unchanged divergence, shared with `mv`: this filesystem creates missing destination parent directories instead of failing with ENOENT. Covered by a test with a comment so it is deliberate rather than accidental.

## Tests

Written first, all failing before the fix (34 failures, including the `mv` recursion timeout).

- `test/commands/file_operations_test.exs`: 30 new `cp` cases (directory destinations, every recursive form, trailing slashes, `dir/.`, merges, nested trees, multi-source, mode, symlinks, `--`, and each error message) plus the `mv` subdirectory-of-itself case.
- `test/just_bash/fs_test.exs`: `FS.cp/4` merge and self-copy guards, `FS.mv/3` subdirectory guard, and a sibling-prefix case (`/ab` -> `/abc`) so the guard cannot over-match on a shared path prefix.
- `test/fixtures/bash_cases/cp.json` + `bash_expected/cp.json`: 20 new bash comparison cases recorded from GNU coreutils via `mix bash_fixtures cp` (there were none for `cp`), asserting stdout, stderr, and exit code against real bash.

All five gates pass: `mix compile --warnings-as-errors`, `mix dialyzer` (17 errors / 17 skipped, unchanged from main), `mix credo --strict` (only the pre-existing intentional test-fixture finding), `mix format --check-formatted`, `mix test` (3798 tests, 0 failures; also green with `--include bash_comparison`).
