### PR TITLE
fix: a command whose redirect fails should not run at all

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -72,12 +72,16 @@ Every difference a script can observe, verified against the 0.3 sources:
    through the directory it lands in; this does not admit unreachable
    state, so it stayed out of scope.
 
-   A **failed redirect no longer leaks the command's output.** The bytes
-   were bound for the file, so `echo hi > /m/j/a.md` now yields empty
-   stdout with the error on stderr; previously `result.stdout` still held
-   `"hi\n"`. Same for `2>`, `>>`, and `&>`, and for a redirect onto a
-   directory (`:eisdir`). bash produces no output at all here because it
-   opens the target before running the command.
+   A **command whose redirect cannot be opened no longer runs at all.**
+   bash opens every redirect target before it forks the command, so
+   `mkdir /made > /m/j/x` reports `bash: /m/j/x: Not a directory`, exits
+   1, and leaves no `/made` behind — the side effects never happen, not
+   just the output. 0.3 ran the command and applied the redirection to
+   its result, so `result.stdout` still held `"hi\n"` for
+   `echo hi > /m/j/a.md` and `/made` was created. This covers `>`, `>>`,
+   `2>`, `&>`, `&>>`, a target that is a directory (`:eisdir`), and every
+   construct a redirect can attach to: simple commands, functions,
+   `for`/`while`/`until`, subshells, and groups.
 
    Because resolution now follows symlinks in every component, `stat/2`
    reports a symlinked directory *as* a directory — so **recursive commands
@@ -98,7 +102,19 @@ Every difference a script can observe, verified against the 0.3 sources:
    `%{"/m/j" => "x", "/m/j/a.md" => "y"}` (0.3 accepted it and which entry
    survived depended on map iteration order) or one that collides with a
    directory the backend already holds, such as `%{"/" => "x"}`.
-8. **With additional mounts only** (a 0.4 capability): the parents of a
+8. **A redirect target is created and truncated before the command runs**,
+   as `open(2)` with `O_CREAT | O_TRUNC` does, so a command can no longer
+   read the file it is redirecting into: `cat f > f` leaves `f` empty
+   (0.3 rewrote `f` with its own contents), and so does any
+   read-then-overwrite of the same path. `>>` opens with `O_APPEND`
+   instead — an existing target keeps its contents *and* its mtime, so
+   `true >> f` no longer touches `f` at all. A redirect target is also
+   expanded exactly once now: `> $(gen-name)` runs `gen-name` once,
+   before the command, rather than after it. When several redirections
+   are listed and one cannot be opened, the ones to its left are still
+   created or truncated and the ones to its right are never expanded —
+   `echo hi > /bad > $(gen-name)` does not run `gen-name`.
+9. **With additional mounts only** (a 0.4 capability): the parents of a
    mountpoint appear as synthetic directories, and foreign backends keep
    their own semantics — e.g. a plain `VFS.Memory` mount treats
    directories implicitly and refuses `rm` of an empty directory with

--- a/lib/just_bash/interpreter/executor.ex
+++ b/lib/just_bash/interpreter/executor.ex
@@ -286,8 +286,10 @@ defmodule JustBash.Interpreter.Executor do
         _stdin
       ) do
     {_redir_stdin, non_stdin_redirs} = Redirection.extract_heredoc_stdin(bash, redirs)
-    {result, new_bash} = Loop.execute_for(bash, variable, words, body, &execute_body/2)
-    Redirection.apply_redirections(result, new_bash, non_stdin_redirs)
+
+    with_redirections(bash, non_stdin_redirs, fn bash ->
+      Loop.execute_for(bash, variable, words, body, &execute_body/2)
+    end)
   end
 
   def execute_command(
@@ -298,10 +300,9 @@ defmodule JustBash.Interpreter.Executor do
     {redir_stdin, non_stdin_redirs} = Redirection.extract_heredoc_stdin(bash, redirs)
     effective_stdin = redir_stdin || stdin
 
-    {result, new_bash} =
+    with_redirections(bash, non_stdin_redirs, fn bash ->
       Loop.execute_while(bash, condition, body, effective_stdin, &execute_body/2)
-
-    Redirection.apply_redirections(result, new_bash, non_stdin_redirs)
+    end)
   end
 
   def execute_command(
@@ -312,10 +313,9 @@ defmodule JustBash.Interpreter.Executor do
     {redir_stdin, non_stdin_redirs} = Redirection.extract_heredoc_stdin(bash, redirs)
     effective_stdin = redir_stdin || stdin
 
-    {result, new_bash} =
+    with_redirections(bash, non_stdin_redirs, fn bash ->
       Loop.execute_until(bash, condition, body, effective_stdin, &execute_body/2)
-
-    Redirection.apply_redirections(result, new_bash, non_stdin_redirs)
+    end)
   end
 
   def execute_command(bash, %AST.Case{word: word, items: items}, _stdin) do
@@ -324,16 +324,19 @@ defmodule JustBash.Interpreter.Executor do
   end
 
   def execute_command(bash, %AST.Subshell{body: body, redirections: redirs}, _stdin) do
-    {result, _subshell_bash} = execute_body(bash, body)
-    # Apply any redirections attached to the subshell
-    {result, bash} = Redirection.apply_redirections(result, bash, redirs)
-    {result, bash}
+    # The subshell's own state is discarded, so the redirections are applied to
+    # the outer shell — but to the outer shell as the preflight left it, since
+    # opening the target creates or truncates it.
+    with_redirections(bash, redirs, fn bash ->
+      {result, _subshell_bash} = execute_body(bash, body)
+      {result, bash}
+    end)
   end
 
   def execute_command(bash, %AST.Group{body: body, redirections: redirs}, stdin) do
-    {result, new_bash} = execute_body_with_stdin(bash, body, stdin)
-    # Apply any redirections attached to the group
-    Redirection.apply_redirections(result, new_bash, redirs)
+    with_redirections(bash, redirs, fn bash ->
+      execute_body_with_stdin(bash, body, stdin)
+    end)
   end
 
   def execute_command(bash, %AST.FunctionDef{name: name, body: body}, _stdin) do
@@ -389,54 +392,70 @@ defmodule JustBash.Interpreter.Executor do
     {heredoc_stdin, non_heredoc_redirs} = Redirection.extract_heredoc_stdin(temp_bash, redirs)
     effective_stdin = heredoc_stdin || stdin
 
-    {result, exec_bash} =
-      case Map.get(temp_bash.functions, cmd_name) do
-        nil ->
-          JustBash.Telemetry.command_span(cmd_name, expanded_args, fn ->
-            {result, new_bash} =
-              case Map.get(temp_bash.commands, cmd_name) do
-                nil ->
-                  execute_builtin(temp_bash, cmd_name, expanded_args, effective_stdin)
-
-                module ->
-                  execute_custom_command(
-                    temp_bash,
-                    cmd_name,
-                    module,
-                    expanded_args,
-                    effective_stdin
-                  )
-              end
-
-            # A JustBash.CLI router stashes the resolved subcommand path here; surface it
-            # in telemetry and strip it before the result reaches the shell.
-            {subcommand, result} = Map.pop(result, :__subcommand__)
-
-            stop_metadata = %{
-              exit_code: result.exit_code,
-              bytes_in: byte_size(effective_stdin),
-              bytes_out: byte_size(result.stdout) + byte_size(result.stderr)
-            }
-
-            stop_metadata =
-              if subcommand,
-                do: Map.put(stop_metadata, :subcommand, subcommand),
-                else: stop_metadata
-
-            {{result, new_bash}, stop_metadata}
-          end)
-
-        func_body ->
-          execute_function(temp_bash, func_body, expanded_args)
-      end
-
-    Redirection.apply_redirections(result, exec_bash, non_heredoc_redirs)
+    with_redirections(temp_bash, non_heredoc_redirs, fn temp_bash ->
+      invoke_command(temp_bash, cmd_name, expanded_args, effective_stdin)
+    end)
   rescue
     e in Expansion.UnsetVariableError ->
       {%{stdout: "", stderr: "bash: #{Exception.message(e)}\n", exit_code: 1}, bash}
 
     e in ArithmeticError ->
       {%{stdout: "", stderr: "bash: #{Exception.message(e)}\n", exit_code: 1}, bash}
+  end
+
+  defp invoke_command(bash, cmd_name, args, stdin) do
+    case Map.get(bash.functions, cmd_name) do
+      nil ->
+        JustBash.Telemetry.command_span(cmd_name, args, fn ->
+          {result, new_bash} =
+            case Map.get(bash.commands, cmd_name) do
+              nil -> execute_builtin(bash, cmd_name, args, stdin)
+              module -> execute_custom_command(bash, cmd_name, module, args, stdin)
+            end
+
+          # A JustBash.CLI router stashes the resolved subcommand path here; surface it
+          # in telemetry and strip it before the result reaches the shell.
+          {subcommand, result} = Map.pop(result, :__subcommand__)
+
+          stop_metadata = %{
+            exit_code: result.exit_code,
+            bytes_in: byte_size(stdin),
+            bytes_out: byte_size(result.stdout) + byte_size(result.stderr)
+          }
+
+          stop_metadata =
+            if subcommand,
+              do: Map.put(stop_metadata, :subcommand, subcommand),
+              else: stop_metadata
+
+          {{result, new_bash}, stop_metadata}
+        end)
+
+      func_body ->
+        execute_function(bash, func_body, args)
+    end
+  end
+
+  # --- Redirections ---
+
+  # bash opens every redirect target before it forks the command, so a target
+  # it cannot open means the body never runs and its side effects never
+  # happen. Opening also creates or truncates the target, which is why `fun`
+  # receives the preflighted shell rather than the one passed in.
+  @spec with_redirections(
+          JustBash.t(),
+          [AST.Redirection.t()],
+          (JustBash.t() -> {result(), JustBash.t()})
+        ) :: {result(), JustBash.t()}
+  defp with_redirections(bash, redirections, fun) do
+    case Redirection.preflight(bash, redirections) do
+      {:ok, prepared, bash} ->
+        {result, bash} = fun.(bash)
+        Redirection.apply_redirections(result, bash, prepared)
+
+      {:error, result, bash} ->
+        {result, bash}
+    end
   end
 
   # --- If/Case Execution ---

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -18,6 +18,18 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   alias JustBash.Limit
 
   @type result :: %{stdout: String.t(), stderr: String.t(), exit_code: non_neg_integer()}
+
+  @typedoc """
+  A redirection whose target has already been expanded, resolved, and opened
+  by `preflight/2`.
+
+  The path is `nil` for redirections that touch no file (`/dev/null`, stream
+  duplication, `<`). Carrying the resolved path forward is what keeps a
+  target containing a command substitution from being expanded a second
+  time when the output is finally written.
+  """
+  @type prepared :: {redir_type(), String.t() | nil}
+
   @type redir_type ::
           :stdout_dev_null
           | :stderr_dev_null
@@ -35,16 +47,40 @@ defmodule JustBash.Interpreter.Executor.Redirection do
           | :noop
 
   @doc """
-  Apply a list of redirections to the result.
+  Expand, resolve, and open every redirection target, left to right, *before*
+  the command body runs.
+
+  bash opens redirect targets before forking the command, so a target it
+  cannot open means the command never runs — none of its side effects happen.
+  On `{:error, result, bash}` the caller must return `result` without
+  executing the body; on `{:ok, prepared, bash}` it runs the body and hands
+  `prepared` to `apply_redirections/3`.
+
+  Opening follows the `open/2` flags bash uses: `>`, `2>` and `&>` create or
+  truncate (`O_CREAT | O_TRUNC`), `>>` and `&>>` create only if missing
+  (`O_CREAT | O_APPEND`). Redirections that touch no file — `/dev/null`,
+  `>&`, `<` — are classified and passed through untouched.
+
+  Targets to the left of a failing one are still created or truncated, and
+  targets to its right are never expanded, so a command substitution in one
+  of them does not run. Both match bash.
   """
-  @spec apply_redirections(result(), JustBash.t(), [AST.Redirection.t()]) ::
+  @spec preflight(JustBash.t(), [AST.Redirection.t()]) ::
+          {:ok, [prepared()], JustBash.t()} | {:error, result(), JustBash.t()}
+  def preflight(bash, redirections), do: do_preflight(bash, redirections, [])
+
+  @doc """
+  Apply preflighted redirections to the result, writing each stream to the
+  target `preflight/2` already opened.
+  """
+  @spec apply_redirections(result(), JustBash.t(), [prepared()]) ::
           {result(), JustBash.t()}
   def apply_redirections(result, bash, []) do
     {result, bash}
   end
 
-  def apply_redirections(result, bash, [redir | rest]) do
-    {result, bash} = apply_redirection(result, bash, redir)
+  def apply_redirections(result, bash, [{redir_type, resolved} | rest]) do
+    {result, bash} = apply_classified_redirection(redir_type, result, bash, resolved)
     apply_redirections(result, bash, rest)
   end
 
@@ -70,15 +106,72 @@ defmodule JustBash.Interpreter.Executor.Redirection do
 
   # --- Private Functions ---
 
-  defp apply_redirection(result, bash, %AST.Redirection{
-         fd: fd,
-         operator: operator,
-         target: target
-       }) do
+  defp do_preflight(bash, [], prepared), do: {:ok, Enum.reverse(prepared), bash}
+
+  defp do_preflight(bash, [redirection | rest], prepared) do
+    %AST.Redirection{fd: fd, operator: operator, target: target} = redirection
+
     target_path = Expansion.expand_redirect_target(bash, target)
-    resolved = FS.resolve_path(bash.cwd, target_path)
     redir_type = classify_redirection(fd, operator, target_path)
-    apply_classified_redirection(redir_type, result, bash, resolved)
+    resolved = FS.resolve_path(bash.cwd, target_path)
+
+    case open_target(bash, redir_type, resolved) do
+      {:ok, bash} ->
+        do_preflight(bash, rest, [{redir_type, resolved} | prepared])
+
+      {:error, error, bash} ->
+        {:error, open_failed(resolved, error), bash}
+    end
+  end
+
+  # The shell reports the failure itself and the command produces nothing:
+  # its stdout and stderr were bound for a file that was never opened.
+  defp open_failed(path, error) do
+    %{stdout: "", stderr: "bash: #{path}: #{FS.strerror(error)}\n", exit_code: 1}
+  end
+
+  defp open_target(bash, redir_type, path) do
+    case open_mode(redir_type) do
+      :truncate -> create_or_truncate(bash, path)
+      :append -> open_for_append(bash, path)
+      :none -> {:ok, bash}
+    end
+  end
+
+  @spec open_mode(redir_type()) :: :truncate | :append | :none
+  defp open_mode(:stdout_write), do: :truncate
+  defp open_mode(:stderr_write), do: :truncate
+  defp open_mode(:combined_write), do: :truncate
+  defp open_mode(:stdout_append), do: :append
+  defp open_mode(:stderr_append), do: :append
+  defp open_mode(:combined_append), do: :append
+  defp open_mode(_redir_type), do: :none
+
+  defp create_or_truncate(bash, path) do
+    case FS.write_file(bash.fs, path, "") do
+      {:ok, fs} -> {:ok, %{bash | fs: fs}}
+      {:error, %VFS.Error{} = error} -> {:error, error, bash}
+    end
+  end
+
+  # `O_APPEND` keeps what is already there, so an existing target is left
+  # alone — writing it back would bump its mtime for nothing. Everything a
+  # later append would reject still has to be rejected here: a directory, or
+  # a path running through a regular file.
+  defp open_for_append(bash, path) do
+    case FS.stat(bash.fs, path) do
+      {:ok, %VFS.Stat{type: :directory}, fs} ->
+        {:error, VFS.Error.new(:eisdir, path: path), %{bash | fs: fs}}
+
+      {:ok, %VFS.Stat{}, fs} ->
+        {:ok, %{bash | fs: fs}}
+
+      {:error, %VFS.Error{kind: :enoent}} ->
+        create_or_truncate(bash, path)
+
+      {:error, %VFS.Error{} = error} ->
+        {:error, error, bash}
+    end
   end
 
   @spec classify_redirection(non_neg_integer(), atom(), String.t()) :: redir_type()
@@ -162,6 +255,13 @@ defmodule JustBash.Interpreter.Executor.Redirection do
     {result, bash}
   end
 
+  # A command that produced nothing leaves the target exactly as `preflight/2`
+  # opened it — truncated for `>`, untouched for `>>` — so the four clauses
+  # below have nothing to write. Skipping the write is not just an
+  # optimization: appending zero bytes is not a write at all, and bash leaves
+  # the target's mtime alone after `true >> file`.
+  defp write_to_file(bash, _path, "", result, stream), do: {clear_stream(result, stream), bash}
+
   defp write_to_file(bash, path, content, result, stream) do
     Limit.check_file_size!(bash, content)
 
@@ -174,6 +274,8 @@ defmodule JustBash.Interpreter.Executor.Redirection do
         {redirect_failed(result, stream, path, error), bash}
     end
   end
+
+  defp append_to_file(bash, _path, "", result, stream), do: {clear_stream(result, stream), bash}
 
   defp append_to_file(bash, path, content, result, stream) do
     bash = check_append_size!(bash, path, content)
@@ -188,6 +290,10 @@ defmodule JustBash.Interpreter.Executor.Redirection do
     end
   end
 
+  defp write_combined_to_file(bash, _path, "", result) do
+    {%{result | stdout: "", stderr: ""}, bash}
+  end
+
   defp write_combined_to_file(bash, path, content, result) do
     Limit.check_file_size!(bash, content)
 
@@ -198,6 +304,10 @@ defmodule JustBash.Interpreter.Executor.Redirection do
       {:error, error} ->
         {result |> clear_stream(:stdout) |> redirect_failed(:stderr, path, error), bash}
     end
+  end
+
+  defp append_combined_to_file(bash, _path, "", result) do
+    {%{result | stdout: "", stderr: ""}, bash}
   end
 
   defp append_combined_to_file(bash, path, content, result) do
@@ -228,12 +338,11 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   defp clear_stream(result, :stdout), do: %{result | stdout: ""}
   defp clear_stream(result, :stderr), do: %{result | stderr: ""}
 
-  # bash opens the redirect target before running the command, so a target it
-  # cannot open means the command produces nothing at all. Clearing the
-  # redirected stream is how far that goes here: the command has already run,
-  # but its output was bound for the file and must not surface as the
-  # caller's stdout. Not running the command at all needs the target expanded
-  # and opened before the body — see issue #59.
+  # Failures the open in `preflight/2` cannot predict, because they depend on
+  # what the command produced — a write past `Limit`'s file-size cap, or a
+  # target that stopped being writable while the body ran. The command has
+  # already run, so all that is left is to suppress the stream that was bound
+  # for the file and report the failure the way bash does.
   defp redirect_failed(result, stream, path, error) do
     cleared = clear_stream(result, stream)
     error_msg = "bash: #{path}: #{FS.strerror(error)}\n"

--- a/test/just_bash/redirect_preflight_test.exs
+++ b/test/just_bash/redirect_preflight_test.exs
@@ -1,0 +1,316 @@
+defmodule JustBash.RedirectPreflightTest do
+  @moduledoc """
+  Regression tests for issue #59: a command whose redirect cannot be opened
+  must not run at all.
+
+  bash opens every redirect target before it forks the command, so the
+  command's side effects — the directory `mkdir` would have made, the file
+  `touch` would have created — never happen when the open fails. Suppressing
+  the command's *output* is not enough; issue #53 covered that half, and
+  `not_a_directory_test.exs` holds those expectations.
+
+  Opening the target early is also what truncates it, and what fixes when a
+  command substitution in the target runs. Every expectation below was
+  checked against GNU bash 3.2.57.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.FS
+
+  # /m/j is a regular file, so /m/j/x can never be opened: POSIX resolution
+  # requires every non-final component to be a directory.
+  @unopenable "/m/j/x"
+
+  defp bash(files \\ %{}) do
+    JustBash.new(files: Map.merge(%{"/m/j" => "parent\n"}, files))
+  end
+
+  defp exists?(bash, path), do: bash.fs |> FS.exists?(path) |> elem(0)
+
+  defp read(bash, path) do
+    case FS.read_file(bash.fs, path) do
+      {:ok, content, _fs} -> content
+      {:error, %VFS.Error{kind: kind}} -> {:error, kind}
+    end
+  end
+
+  describe "a failed open stops the command body from running" do
+    test "mkdir does not create its directory" do
+      {result, b} = JustBash.exec(bash(), "mkdir /made > #{@unopenable}")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "bash: #{@unopenable}: Not a directory\n"
+      refute exists?(b, "/made")
+    end
+
+    test "touch does not create its file" do
+      {result, b} = JustBash.exec(bash(), "touch /t.txt > #{@unopenable}")
+
+      assert result.exit_code == 1
+      refute exists?(b, "/t.txt")
+    end
+
+    test "the repro from the issue reports absent, not MADE" do
+      {result, b} =
+        JustBash.exec(
+          bash(%{"/m/j" => "f\n"}),
+          "mkdir /made > /m/j/x; [ -d /made ] && echo MADE || echo absent"
+        )
+
+      assert result.stdout == "absent\n"
+      refute exists?(b, "/made")
+    end
+
+    test "a failed >> open also stops the body" do
+      {result, b} = JustBash.exec(bash(), "mkdir /made >> #{@unopenable}")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: #{@unopenable}: Not a directory\n"
+      refute exists?(b, "/made")
+    end
+
+    test "a failed 2> open stops the body, even though only stderr was redirected" do
+      {result, b} = JustBash.exec(bash(), "mkdir /made 2> #{@unopenable}")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "bash: #{@unopenable}: Not a directory\n"
+      refute exists?(b, "/made")
+    end
+
+    test "a failed &> open stops the body" do
+      {result, b} = JustBash.exec(bash(), "mkdir /made &> #{@unopenable}")
+
+      assert result.exit_code == 1
+      refute exists?(b, "/made")
+    end
+
+    test "a directory target stops the body too" do
+      {result, b} = JustBash.exec(bash(), "mkdir -p /d && mkdir /made > /d")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /d: Is a directory\n"
+      refute exists?(b, "/made")
+    end
+
+    test "a shell function body does not run either" do
+      script = """
+      f() { mkdir /made; }
+      f > #{@unopenable}
+      """
+
+      {result, b} = JustBash.exec(bash(), script)
+
+      assert result.exit_code == 1
+      refute exists?(b, "/made")
+    end
+
+    test "a builtin that mutates shell state does not run" do
+      {result, b} = JustBash.exec(bash(), "mkdir -p /elsewhere; cd /elsewhere > #{@unopenable}")
+
+      assert result.exit_code == 1
+      assert b.cwd != "/elsewhere"
+    end
+  end
+
+  describe "a failed open stops each compound command's body" do
+    test "for" do
+      {result, b} = JustBash.exec(bash(), "for i in 1 2 3; do mkdir /L$i; done > #{@unopenable}")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: #{@unopenable}: Not a directory\n"
+      refute exists?(b, "/L1")
+      refute exists?(b, "/L2")
+      refute exists?(b, "/L3")
+    end
+
+    test "while" do
+      script = "i=0; while [ $i -lt 2 ]; do mkdir /W$i; i=$((i+1)); done > #{@unopenable}"
+      {result, b} = JustBash.exec(bash(), script)
+
+      assert result.exit_code == 1
+      refute exists?(b, "/W0")
+      refute exists?(b, "/W1")
+    end
+
+    test "until" do
+      script = "i=0; until [ $i -ge 2 ]; do mkdir /U$i; i=$((i+1)); done > #{@unopenable}"
+      {result, b} = JustBash.exec(bash(), script)
+
+      assert result.exit_code == 1
+      refute exists?(b, "/U0")
+      refute exists?(b, "/U1")
+    end
+
+    test "subshell" do
+      {result, b} = JustBash.exec(bash(), "( mkdir /S1; echo in ) > #{@unopenable}")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      refute exists?(b, "/S1")
+    end
+
+    test "group" do
+      {result, b} = JustBash.exec(bash(), "{ mkdir /G1; echo in ; } > #{@unopenable}")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      refute exists?(b, "/G1")
+    end
+  end
+
+  describe "opening the target creates or truncates it" do
+    test "> truncates before the body runs, so a command cannot read its own target" do
+      {result, b} = JustBash.exec(bash(), "printf 'a\\nb\\n' > /data; cat /data > /data")
+
+      assert result.exit_code == 0
+      assert read(b, "/data") == ""
+    end
+
+    test ">> does not truncate, so the body appends to what was there" do
+      {_result, b} = JustBash.exec(bash(), "echo one > /app.txt; echo two >> /app.txt")
+
+      assert read(b, "/app.txt") == "one\ntwo\n"
+    end
+
+    test ">> leaves an existing target's mtime alone" do
+      b = JustBash.new(files: %{"/keep.txt" => "one\n"})
+      {:ok, %VFS.Stat{mtime: before}, _fs} = FS.stat(b.fs, "/keep.txt")
+
+      {_result, b} = JustBash.exec(b, "true >> /keep.txt")
+
+      assert {:ok, %VFS.Stat{mtime: ^before}, _fs} = FS.stat(b.fs, "/keep.txt")
+      assert read(b, "/keep.txt") == "one\n"
+    end
+
+    test "a loop's target is opened once for the whole loop, not per iteration" do
+      script = "printf 'X\\n' > /lo; for i in 1 2 3; do echo $i; done > /lo"
+      {_result, b} = JustBash.exec(bash(), script)
+
+      assert read(b, "/lo") == "1\n2\n3\n"
+    end
+
+    test "a target left of a failing one is still truncated" do
+      script = "echo pre > /ok.txt; echo hi > /ok.txt > #{@unopenable}"
+      {result, b} = JustBash.exec(bash(), script)
+
+      assert result.exit_code == 1
+      assert read(b, "/ok.txt") == ""
+    end
+
+    test "a target right of a failing one is never opened" do
+      {result, b} = JustBash.exec(bash(), "echo hi > #{@unopenable} > /right.txt")
+
+      assert result.exit_code == 1
+      refute exists?(b, "/right.txt")
+    end
+  end
+
+  describe "the target is expanded exactly once" do
+    defmodule NextName do
+      @moduledoc """
+      Returns a different path on each call, so the target a redirection
+      actually writes to reveals how many times it was expanded.
+      """
+      @behaviour JustBash.Commands.Command
+
+      @impl true
+      def names, do: ["next-name"]
+
+      @impl true
+      def execute(bash, _args, _stdin) do
+        n = Agent.get_and_update(__MODULE__, &{&1, &1 + 1})
+        {%{stdout: "/call#{n}.txt\n", stderr: "", exit_code: 0}, bash}
+      end
+    end
+
+    setup do
+      start_supervised!(%{
+        id: NextName,
+        start: {Agent, :start_link, [fn -> 0 end, [name: NextName]]}
+      })
+
+      :ok
+    end
+
+    test "a command substitution in the target runs once, before the body" do
+      b = JustBash.new(commands: %{"next-name" => NextName})
+      {result, b} = JustBash.exec(b, "echo hi > $(next-name)")
+
+      assert result.exit_code == 0
+      assert read(b, "/call0.txt") == "hi\n"
+      refute exists?(b, "/call1.txt")
+    end
+
+    test "a command substitution right of a failing target does not run at all" do
+      b = JustBash.new(files: %{"/m/j" => "parent\n"}, commands: %{"next-name" => NextName})
+      {result, b} = JustBash.exec(b, "echo hi > #{@unopenable} > $(next-name)")
+
+      assert result.exit_code == 1
+      refute exists?(b, "/call0.txt")
+      assert Agent.get(NextName, & &1) == 0
+    end
+
+    test "a compound command's target is expanded once, not once per iteration" do
+      b = JustBash.new(commands: %{"next-name" => NextName})
+      {result, b} = JustBash.exec(b, "for i in 1 2 3; do echo $i; done > $(next-name)")
+
+      assert result.exit_code == 0
+      assert read(b, "/call0.txt") == "1\n2\n3\n"
+      refute exists?(b, "/call1.txt")
+    end
+  end
+
+  describe "successful redirections still behave as they did" do
+    test "the redirected stdout lands in the file and not in the result" do
+      {result, b} = JustBash.exec(bash(), "echo hi > /out.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == ""
+      assert read(b, "/out.txt") == "hi\n"
+    end
+
+    test "a failing command still truncates its target" do
+      {result, b} = JustBash.exec(bash(), "echo old > /f.txt; false > /f.txt")
+
+      assert result.exit_code == 1
+      assert read(b, "/f.txt") == ""
+    end
+
+    test "&& short-circuits on a failed open" do
+      {result, _b} =
+        JustBash.exec(bash(), "echo hi > #{@unopenable} && echo AND || echo OR")
+
+      assert result.stdout == "OR\n"
+    end
+
+    test "> /dev/null still discards without touching the filesystem" do
+      {result, b} = JustBash.exec(bash(), "echo hi > /dev/null")
+
+      assert result.exit_code == 0
+      assert result.stdout == ""
+      refute exists?(b, "/dev/null")
+    end
+
+    test "2>&1 still folds stderr into stdout" do
+      {result, _b} = JustBash.exec(bash(), "ls /nope 2>&1")
+
+      assert result.stderr == ""
+      assert result.stdout =~ "/nope"
+    end
+
+    test "a heredoc still reaches the body as stdin" do
+      {result, _b} = JustBash.exec(bash(), "cat <<EOF\nline\nEOF\n")
+
+      assert result.stdout == "line\n"
+    end
+
+    test "< reads the file without the target being opened for writing" do
+      {result, b} = JustBash.exec(bash(%{"/in.txt" => "data\n"}), "cat < /in.txt")
+
+      assert result.stdout == "data\n"
+      assert read(b, "/in.txt") == "data\n"
+    end
+  end
+end


### PR DESCRIPTION
Closes #59. Rebased onto `main` now that #56 has merged — this is a single commit against `main`.

## Root cause

bash opens every redirect target before it forks the command, so a target it cannot open means the command never runs. JustBash ran the command and applied redirections to the result afterwards, so the command's side effects survived a failed redirect:

```elixir
b = JustBash.new(files: %{"/m/j" => "f\n"})   # /m/j is a regular file

{r, _} = JustBash.exec(b, "mkdir /made > /m/j/x; [ -d /made ] && echo MADE || echo absent")
r.stdout  #=> "MADE\n"
```

Real bash:

```
$ mkdir made > j/x; [ -d made ] && echo MADE || echo absent
bash: j/x: Not a directory
absent
```

#56 fixed the observable-output half — `$?`, `&&`/`||`, stdout suppression, and truncate-on-open already matched. This is the body half: the only remaining divergence was that the command executed.

## The shape

`Redirection.preflight/2` expands, resolves, and *opens* every redirection target, left to right, before the body. It returns either the opened redirections for `apply_redirections/3` to consume, or the shell's own error result for the first target that would not open — in which case the caller returns it without executing the body.

Opening follows the `open(2)` flags bash uses: `>`, `2>`, `&>` create or truncate; `>>`, `&>>` create only if missing. Redirections that touch no file (`/dev/null`, `>&`, `<`) are classified and passed through.

`Executor.with_redirections/3` wraps all six call sites that can carry a redirection — `do_execute_simple_command/6`, `AST.For`, `AST.While`, `AST.Until`, `AST.Subshell`, `AST.Group` — so each skips its body on a failed open. The compound cases open **once for the whole body** rather than per iteration, which is what bash does and what already matched the existing behavior of applying the redirection once to the accumulated output:

```
$ printf 'X\n' > loopout; for i in 1 2 3; do echo $i; done > loopout; cat loopout
1
2
3
```

Because targets are now resolved up front and threaded through to the write, `apply_redirections/3` takes preflighted `{type, resolved_path}` pairs instead of AST nodes, so a target containing a command substitution is expanded exactly once.

`redirect_failed/4` stays for failures the open cannot predict, because they depend on what the command produced — a write past `Limit`'s file-size cap.

The subshell case keeps discarding the subshell's own state, but now runs the body against the *preflighted* outer shell, since opening the target creates or truncates it.

## Behaviors that changed

All verified against GNU bash 3.2.57. With `/m/j` a regular file, every one of these was exit 1 *with the side effect applied* and is now exit 1 with no side effect:

| script | now |
|---|---|
| `mkdir /made > /m/j/x` | exit 1, no `/made` |
| `touch /t > /m/j/x` | exit 1, no `/t` |
| `mkdir /made 2> /m/j/x`, `>> …`, `&> …` | exit 1, no `/made` |
| `mkdir -p /d && mkdir /made > /d` (`:eisdir`) | exit 1, no `/made` |
| `f() { mkdir /made; }; f > /m/j/x` | exit 1, no `/made` |
| `cd /elsewhere > /m/j/x` | exit 1, cwd unchanged |
| `for i in 1 2 3; do mkdir /L$i; done > /m/j/x` | exit 1, no `/L*` |
| `while`/`until` equivalents | exit 1, nothing made |
| `( mkdir /S ) > /m/j/x`, `{ mkdir /G ; } > /m/j/x` | exit 1, nothing made |

Opening the target is also what truncates it, which moves two more cases toward bash:

- **`cat f > f` leaves `f` empty.** `O_TRUNC` happens before the body reads the file; previously `f` was rewritten with its own contents.
- **`true >> f` leaves an existing `f`'s mtime alone.** `O_APPEND` with nothing to append is not a write, so the four `apply` write paths now no-op on empty content instead of rewriting the file.

And ordering across several redirections now matches bash: the ones left of a failure are still created or truncated, and the ones to its right are never expanded — `echo hi > /bad > $(gen)` does not run `gen`.

UPGRADING.md item 7 gains the body half; a new item 8 states the truncate-at-open, expand-once, and ordering changes.

## Tests

New `test/just_bash/redirect_preflight_test.exs`, 30 tests:

- side effects suppressed for each of the six call sites, plus shell functions and a state-mutating builtin (`cd`);
- open-time truncate/append semantics, including the loop-opens-once case and the `>>` mtime case;
- targets either side of a failing one;
- a command substitution proven to run **exactly once**, via a custom command that returns a different path on each call — so the file that actually receives the bytes reveals the expansion count;
- regression guards for the redirections that already worked (`/dev/null`, `2>&1`, heredocs, `<`, truncate-on-failure).

**18 of the 30 fail on the parent commit** (confirmed by stashing the `lib/` changes); the other 12 are the deliberate no-regression guards, which pass on both sides.

Full suite: 3855 tests / 56 properties, 0 failures — also green with `--include bash_comparison`. `mix compile --warnings-as-errors`, `mix credo --strict` (only the known intentional test-fixture finding), `mix format --check-formatted`, and `mix dialyzer` all clean. The one "Unnecessary Skip" dialyzer reports pre-exists on the parent commit.

## Out of scope

- **A failed `<` also blocks the command in bash** (`cat < nosuchfile` → exit 1, `cat` never runs); JustBash still substitutes empty stdin. #59 scoped preflight to non-stdin redirections, so `extract_heredoc_stdin/2` is untouched.
- **`$(...)` discards filesystem writes** in JustBash, so a command substitution cannot be counted via a file it writes — which is why the expand-once test uses an Agent-backed custom command. Unrelated to this issue; happy to file it separately.
- **`echo hi > a > b`** writes `a` and empties `b`; bash empties `a` and writes `b` (last wins for the same fd). Pre-existing, not made worse by preflight.

