### PR TITLE
fix: date implements %F and -I instead of emitting them literally

### DIFF
--- a/lib/just_bash/commands/date.ex
+++ b/lib/just_bash/commands/date.ex
@@ -220,7 +220,7 @@ defmodule JustBash.Commands.Date do
   defp directive(?e, dt), do: dt.day |> Integer.to_string() |> String.pad_leading(2, " ")
   defp directive(?I, dt), do: dt.hour |> twelve_hour() |> pad2()
   defp directive(?p, dt), do: if(dt.hour < 12, do: "AM", else: "PM")
-  defp directive(?P, dt), do: dt |> directive(?p) |> String.downcase()
+  defp directive(?P, dt), do: ?p |> directive(dt) |> String.downcase()
   defp directive(?Z, dt), do: dt.zone_abbr
 
   defp directive(?N, dt) do

--- a/lib/just_bash/commands/date.ex
+++ b/lib/just_bash/commands/date.ex
@@ -1,5 +1,22 @@
 defmodule JustBash.Commands.Date do
-  @moduledoc "The `date` command - display the current date and time."
+  @moduledoc """
+  The `date` command — display the current date and time.
+
+  Output is always UTC. Supported directives:
+
+    * compound — `%F` (`%Y-%m-%d`), `%T` (`%H:%M:%S`), `%R` (`%H:%M`),
+      `%D` (`%m/%d/%y`)
+    * date — `%Y`, `%y`, `%C`, `%m`, `%d`, `%e` (space-padded), `%j`,
+      `%a`, `%A`, `%b`, `%h`, `%B`, `%u`, `%w`
+    * time — `%H`, `%M`, `%S`, `%I`, `%p`, `%P`, `%Z`, `%s`
+    * literal — `%%`, `%n`, `%t`
+
+  An unrecognized directive is emitted verbatim (`%J` → `%J`), as GNU date does,
+  so a caller can tell the difference between "not supported" and a real value.
+
+  Flags: `-d` / `--date=`, `-I[FMT]` / `--iso-8601[=FMT]`, `-u`, and the BSD
+  `-j` / `-f` pair.
+  """
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
@@ -14,7 +31,7 @@ defmodule JustBash.Commands.Date do
     case parse_args(args) do
       {:ok, opts} ->
         datetime = opts.datetime || DateTime.utc_now()
-        format = opts.format || @default_format
+        format = opts.format || opts.iso_format || @default_format
         output = format_datetime(datetime, format) <> "\n"
         {Command.ok(output), bash}
 
@@ -24,14 +41,35 @@ defmodule JustBash.Commands.Date do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{format: nil, datetime: nil, input_format: nil, no_set: false})
+    parse_args(args, %{
+      format: nil,
+      iso_format: nil,
+      datetime: nil,
+      input_format: nil,
+      no_set: false
+    })
   end
 
   defp parse_args([], opts), do: {:ok, opts}
 
+  # `-I` and an explicit `+format` are two answers to the same question, and real
+  # date refuses to guess which one was meant rather than silently dropping one.
+  defp parse_args(["+" <> _format | _rest], %{iso_format: iso}) when iso != nil do
+    {:error, "date: multiple output formats specified\n"}
+  end
+
   defp parse_args(["+" <> format | rest], opts) do
     parse_args(rest, %{opts | format: format})
   end
+
+  # `-I[FMT]` / `--iso-8601[=FMT]`: ISO 8601 output at the requested precision.
+  # These used to fall through the catch-all clause at the bottom and be silently
+  # ignored, so `date -I` printed the full default format — a flag that changes
+  # the output shape appearing to do nothing at all.
+  defp parse_args(["-I" <> spec | rest], opts), do: put_iso_format(spec, rest, opts)
+  defp parse_args(["--iso-8601" | rest], opts), do: put_iso_format("", rest, opts)
+
+  defp parse_args(["--iso-8601=" <> spec | rest], opts), do: put_iso_format(spec, rest, opts)
 
   defp parse_args(["-d", date_str | rest], opts) do
     case parse_date_string(date_str) do
@@ -76,6 +114,28 @@ defmodule JustBash.Commands.Date do
   defp parse_args([_arg | rest], opts) do
     parse_args(rest, opts)
   end
+
+  defp put_iso_format(_spec, _rest, %{format: format}) when format != nil do
+    {:error, "date: multiple output formats specified\n"}
+  end
+
+  defp put_iso_format(spec, rest, opts) do
+    case iso_format(spec) do
+      {:ok, format} -> parse_args(rest, %{opts | iso_format: format})
+      :error -> {:error, "date: invalid argument '#{spec}' for '--iso-8601'\n"}
+    end
+  end
+
+  defp iso_format(spec) when spec in ["", "date"], do: {:ok, "%Y-%m-%d"}
+  defp iso_format("hours"), do: {:ok, "%Y-%m-%dT%H+00:00"}
+  defp iso_format("minutes"), do: {:ok, "%Y-%m-%dT%H:%M+00:00"}
+  defp iso_format("seconds"), do: {:ok, "%Y-%m-%dT%H:%M:%S+00:00"}
+
+  defp iso_format(spec) when spec in ["ns", "date,ns"] do
+    {:ok, "%Y-%m-%dT%H:%M:%S,000000000+00:00"}
+  end
+
+  defp iso_format(_spec), do: :error
 
   defp parse_formatted_date(date_str, format) do
     cond do
@@ -128,26 +188,79 @@ defmodule JustBash.Commands.Date do
 
   defp parse_relative_date(_), do: {:error, :invalid_format}
 
-  defp format_datetime(datetime, format) do
-    format
-    |> String.replace("%Y", Integer.to_string(datetime.year) |> String.pad_leading(4, "0"))
-    |> String.replace("%m", Integer.to_string(datetime.month) |> String.pad_leading(2, "0"))
-    |> String.replace("%d", Integer.to_string(datetime.day) |> String.pad_leading(2, "0"))
-    |> String.replace("%H", Integer.to_string(datetime.hour) |> String.pad_leading(2, "0"))
-    |> String.replace("%M", Integer.to_string(datetime.minute) |> String.pad_leading(2, "0"))
-    |> String.replace("%S", Integer.to_string(datetime.second) |> String.pad_leading(2, "0"))
-    |> String.replace("%s", Integer.to_string(DateTime.to_unix(datetime)))
-    |> String.replace("%a", short_day_name(datetime))
-    |> String.replace("%A", full_day_name(datetime))
-    |> String.replace("%b", short_month_name(datetime))
-    |> String.replace("%B", full_month_name(datetime))
-    |> String.replace("%j", day_of_year(datetime))
-    |> String.replace("%u", Integer.to_string(Date.day_of_week(datetime)))
-    |> String.replace("%w", Integer.to_string(rem(Date.day_of_week(datetime), 7)))
-    |> String.replace("%n", "\n")
-    |> String.replace("%t", "\t")
-    |> String.replace("%%", "%")
+  # A single left-to-right scan over the format string, NOT a chain of
+  # `String.replace/3`.
+  #
+  # Chained replacement cannot express escaping: it rewrote `%Y` everywhere
+  # before it ever considered `%%`, so `%%Y` — a literal percent followed by Y —
+  # came out as `%2024`. No ordering fixes that, because by the time a later pass
+  # runs it can no longer tell which percents an earlier pass already consumed.
+  # Scanning consumes each directive exactly once, so `%%` is just another
+  # two-character directive and the ambiguity disappears.
+  #
+  # An unrecognized directive is emitted verbatim (`%J` -> `%J`), matching GNU
+  # date. That matters more than it looks: the reason this function was rewritten
+  # is that an unimplemented `%F` printed the literal text "%F" while exiting 0,
+  # so an agent asking the sandbox for today's date got "%F" back and believed
+  # it. Passing unknown directives through keeps that visible rather than
+  # inventing a value — and every directive a caller is likely to reach for is
+  # now implemented.
+  defp format_datetime(datetime, format), do: scan(format, datetime, [])
+
+  defp scan(<<>>, _datetime, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
+
+  # A trailing bare `%` is literal, as in real date.
+  defp scan(<<?%>>, datetime, acc), do: scan(<<>>, datetime, ["%" | acc])
+
+  defp scan(<<?%, directive::utf8, rest::binary>>, datetime, acc) do
+    scan(rest, datetime, [directive(directive, datetime) | acc])
   end
+
+  defp scan(<<char::utf8, rest::binary>>, datetime, acc) do
+    scan(rest, datetime, [<<char::utf8>> | acc])
+  end
+
+  # Compound directives, composed from their single-field parts so the two can't
+  # drift. `%F` is the one that started all this.
+  defp directive(?F, dt), do: "#{directive(?Y, dt)}-#{directive(?m, dt)}-#{directive(?d, dt)}"
+  defp directive(?T, dt), do: "#{directive(?H, dt)}:#{directive(?M, dt)}:#{directive(?S, dt)}"
+  defp directive(?R, dt), do: "#{directive(?H, dt)}:#{directive(?M, dt)}"
+  defp directive(?D, dt), do: "#{directive(?m, dt)}/#{directive(?d, dt)}/#{directive(?y, dt)}"
+
+  defp directive(?Y, dt), do: dt.year |> Integer.to_string() |> String.pad_leading(4, "0")
+  defp directive(?m, dt), do: pad2(dt.month)
+  defp directive(?d, dt), do: pad2(dt.day)
+  defp directive(?H, dt), do: pad2(dt.hour)
+  defp directive(?M, dt), do: pad2(dt.minute)
+  defp directive(?S, dt), do: pad2(dt.second)
+  defp directive(?y, dt), do: dt.year |> rem(100) |> pad2()
+  defp directive(?C, dt), do: dt.year |> div(100) |> pad2()
+  # `%e` is space-padded rather than zero-padded — the one directive where the
+  # difference is visible in column-aligned output.
+  defp directive(?e, dt), do: dt.day |> Integer.to_string() |> String.pad_leading(2, " ")
+  defp directive(?I, dt), do: dt.hour |> twelve_hour() |> pad2()
+  defp directive(?p, dt), do: if(dt.hour < 12, do: "AM", else: "PM")
+  defp directive(?P, dt), do: dt |> directive(?p) |> String.downcase()
+  defp directive(?Z, dt), do: dt.zone_abbr || "UTC"
+  defp directive(?s, dt), do: Integer.to_string(DateTime.to_unix(dt))
+  defp directive(?a, dt), do: short_day_name(dt)
+  defp directive(?A, dt), do: full_day_name(dt)
+  defp directive(?b, dt), do: short_month_name(dt)
+  defp directive(?h, dt), do: short_month_name(dt)
+  defp directive(?B, dt), do: full_month_name(dt)
+  defp directive(?j, dt), do: day_of_year(dt)
+  defp directive(?u, dt), do: Integer.to_string(Date.day_of_week(dt))
+  defp directive(?w, dt), do: Integer.to_string(rem(Date.day_of_week(dt), 7))
+  defp directive(?n, _dt), do: "\n"
+  defp directive(?t, _dt), do: "\t"
+  defp directive(?%, _dt), do: "%"
+  defp directive(other, _dt), do: <<?%, other::utf8>>
+
+  defp pad2(n), do: n |> Integer.to_string() |> String.pad_leading(2, "0")
+
+  defp twelve_hour(0), do: 12
+  defp twelve_hour(hour) when hour > 12, do: hour - 12
+  defp twelve_hour(hour), do: hour
 
   defp short_day_name(dt) do
     case Date.day_of_week(dt) do

--- a/lib/just_bash/commands/date.ex
+++ b/lib/just_bash/commands/date.ex
@@ -8,7 +8,7 @@ defmodule JustBash.Commands.Date do
       `%D` (`%m/%d/%y`)
     * date — `%Y`, `%y`, `%C`, `%m`, `%d`, `%e` (space-padded), `%j`,
       `%a`, `%A`, `%b`, `%h`, `%B`, `%u`, `%w`
-    * time — `%H`, `%M`, `%S`, `%I`, `%p`, `%P`, `%Z`, `%s`
+    * time — `%H`, `%M`, `%S`, `%N`, `%I`, `%p`, `%P`, `%Z`, `%s`
     * literal — `%%`, `%n`, `%t`
 
   An unrecognized directive is emitted verbatim (`%J` → `%J`), as GNU date does,
@@ -52,8 +52,7 @@ defmodule JustBash.Commands.Date do
 
   defp parse_args([], opts), do: {:ok, opts}
 
-  # `-I` and an explicit `+format` are two answers to the same question, and real
-  # date refuses to guess which one was meant rather than silently dropping one.
+  # Real date rejects competing output formats rather than picking one.
   defp parse_args(["+" <> _format | _rest], %{iso_format: iso}) when iso != nil do
     {:error, "date: multiple output formats specified\n"}
   end
@@ -62,10 +61,6 @@ defmodule JustBash.Commands.Date do
     parse_args(rest, %{opts | format: format})
   end
 
-  # `-I[FMT]` / `--iso-8601[=FMT]`: ISO 8601 output at the requested precision.
-  # These used to fall through the catch-all clause at the bottom and be silently
-  # ignored, so `date -I` printed the full default format — a flag that changes
-  # the output shape appearing to do nothing at all.
   defp parse_args(["-I" <> spec | rest], opts), do: put_iso_format(spec, rest, opts)
   defp parse_args(["--iso-8601" | rest], opts), do: put_iso_format("", rest, opts)
 
@@ -130,11 +125,7 @@ defmodule JustBash.Commands.Date do
   defp iso_format("hours"), do: {:ok, "%Y-%m-%dT%H+00:00"}
   defp iso_format("minutes"), do: {:ok, "%Y-%m-%dT%H:%M+00:00"}
   defp iso_format("seconds"), do: {:ok, "%Y-%m-%dT%H:%M:%S+00:00"}
-
-  defp iso_format(spec) when spec in ["ns", "date,ns"] do
-    {:ok, "%Y-%m-%dT%H:%M:%S,000000000+00:00"}
-  end
-
+  defp iso_format("ns"), do: {:ok, "%Y-%m-%dT%H:%M:%S,%N+00:00"}
   defp iso_format(_spec), do: :error
 
   defp parse_formatted_date(date_str, format) do
@@ -188,23 +179,12 @@ defmodule JustBash.Commands.Date do
 
   defp parse_relative_date(_), do: {:error, :invalid_format}
 
-  # A single left-to-right scan over the format string, NOT a chain of
-  # `String.replace/3`.
-  #
-  # Chained replacement cannot express escaping: it rewrote `%Y` everywhere
-  # before it ever considered `%%`, so `%%Y` — a literal percent followed by Y —
-  # came out as `%2024`. No ordering fixes that, because by the time a later pass
-  # runs it can no longer tell which percents an earlier pass already consumed.
-  # Scanning consumes each directive exactly once, so `%%` is just another
-  # two-character directive and the ambiguity disappears.
-  #
-  # An unrecognized directive is emitted verbatim (`%J` -> `%J`), matching GNU
-  # date. That matters more than it looks: the reason this function was rewritten
-  # is that an unimplemented `%F` printed the literal text "%F" while exiting 0,
-  # so an agent asking the sandbox for today's date got "%F" back and believed
-  # it. Passing unknown directives through keeps that visible rather than
-  # inventing a value — and every directive a caller is likely to reach for is
-  # now implemented.
+  # A single left-to-right scan consumes each directive exactly once, so `%%`
+  # escaping works — chained String.replace/3 cannot express it (`%%Y` became
+  # `%2024`). Unknown directives pass through verbatim (`%J` -> `%J`), matching
+  # GNU date. The scan is byte-wise, not codepoint-wise: format strings are raw
+  # binaries and need not be valid UTF-8; every known directive is ASCII, and
+  # passthrough reconstructs other bytes verbatim either way.
   defp format_datetime(datetime, format), do: scan(format, datetime, [])
 
   defp scan(<<>>, _datetime, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
@@ -212,16 +192,16 @@ defmodule JustBash.Commands.Date do
   # A trailing bare `%` is literal, as in real date.
   defp scan(<<?%>>, datetime, acc), do: scan(<<>>, datetime, ["%" | acc])
 
-  defp scan(<<?%, directive::utf8, rest::binary>>, datetime, acc) do
+  defp scan(<<?%, directive, rest::binary>>, datetime, acc) do
     scan(rest, datetime, [directive(directive, datetime) | acc])
   end
 
-  defp scan(<<char::utf8, rest::binary>>, datetime, acc) do
-    scan(rest, datetime, [<<char::utf8>> | acc])
+  defp scan(<<char, rest::binary>>, datetime, acc) do
+    scan(rest, datetime, [<<char>> | acc])
   end
 
-  # Compound directives, composed from their single-field parts so the two can't
-  # drift. `%F` is the one that started all this.
+  # Compound directives are composed from their single-field parts so the two
+  # can't drift.
   defp directive(?F, dt), do: "#{directive(?Y, dt)}-#{directive(?m, dt)}-#{directive(?d, dt)}"
   defp directive(?T, dt), do: "#{directive(?H, dt)}:#{directive(?M, dt)}:#{directive(?S, dt)}"
   defp directive(?R, dt), do: "#{directive(?H, dt)}:#{directive(?M, dt)}"
@@ -241,7 +221,13 @@ defmodule JustBash.Commands.Date do
   defp directive(?I, dt), do: dt.hour |> twelve_hour() |> pad2()
   defp directive(?p, dt), do: if(dt.hour < 12, do: "AM", else: "PM")
   defp directive(?P, dt), do: dt |> directive(?p) |> String.downcase()
-  defp directive(?Z, dt), do: dt.zone_abbr || "UTC"
+  defp directive(?Z, dt), do: dt.zone_abbr
+
+  defp directive(?N, dt) do
+    {microsecond, _precision} = dt.microsecond
+    (microsecond * 1_000) |> Integer.to_string() |> String.pad_leading(9, "0")
+  end
+
   defp directive(?s, dt), do: Integer.to_string(DateTime.to_unix(dt))
   defp directive(?a, dt), do: short_day_name(dt)
   defp directive(?A, dt), do: full_day_name(dt)
@@ -254,7 +240,7 @@ defmodule JustBash.Commands.Date do
   defp directive(?n, _dt), do: "\n"
   defp directive(?t, _dt), do: "\t"
   defp directive(?%, _dt), do: "%"
-  defp directive(other, _dt), do: <<?%, other::utf8>>
+  defp directive(other, _dt), do: <<?%, other>>
 
   defp pad2(n), do: n |> Integer.to_string() |> String.pad_leading(2, "0")
 

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -286,10 +286,6 @@ defmodule JustBash.Commands.UtilitiesTest do
     end
   end
 
-  # `date +%F` is the single most common way to ask for today's date, and it
-  # used to emit the literal string "%F" — a silently wrong answer rather than
-  # an error, which is the worst failure mode a sandbox can have. An agent
-  # asking the sandbox what day it is got "%F" back and carried on.
   describe "compound format specifiers" do
     test "%F is the ISO date" do
       bash = JustBash.new()
@@ -353,11 +349,14 @@ defmodule JustBash.Commands.UtilitiesTest do
       {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+%Z'")
       assert result.stdout == "UTC\n"
     end
+
+    test "%N is nanoseconds" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15T10:30:00.123456Z' '+%N'")
+      assert result.stdout == "123456000\n"
+    end
   end
 
-  # A single left-to-right scan, not a chain of String.replace/3 — otherwise an
-  # escaped percent gets eaten by whichever specifier its following character
-  # happens to name. `%%F` means a literal "%F" and must never become a date.
   describe "percent escaping" do
     test "%%F is a literal percent followed by F" do
       bash = JustBash.new()
@@ -382,11 +381,16 @@ defmodule JustBash.Commands.UtilitiesTest do
       {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+%J'")
       assert result.stdout == "%J\n"
     end
+
+    # Format strings are raw binaries, not necessarily valid UTF-8.
+    test "a raw non-UTF-8 byte in the format passes through" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, ~S|date -d '2024-06-15 00:00:00' +$'\xff%Y'|)
+      assert result.exit_code == 0
+      assert result.stdout == <<0xFF>> <> "2024\n"
+    end
   end
 
-  # `-I` / `--iso-8601` was accepted and silently ignored, so it printed the
-  # full default format. Silently ignoring a flag that changes the output shape
-  # is the same class of bug as `%F`.
   describe "-I / --iso-8601" do
     test "-I prints just the date" do
       bash = JustBash.new()
@@ -421,13 +425,48 @@ defmodule JustBash.Commands.UtilitiesTest do
       assert result.stdout == "2024-06-15\n"
     end
 
-    # Measured against real `date`, which rejects this rather than picking one:
-    # "date: multiple output formats specified".
+    test "--iso-8601=seconds is the long form with a value" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' --iso-8601=seconds")
+      assert result.stdout == "2024-06-15T10:30:00+00:00\n"
+    end
+
+    test "-Ins includes the actual nanoseconds" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -d '2024-06-15T10:30:00.123456Z' -Ins")
+      {r2, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' -Ins")
+      assert r1.stdout == "2024-06-15T10:30:00,123456000+00:00\n"
+      assert r2.stdout == "2024-06-15T10:30:00,000000000+00:00\n"
+    end
+
+    # Real date rejects competing output formats rather than picking one,
+    # in either argument order.
     test "-I together with an explicit +format is an error" do
       bash = JustBash.new()
       {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' -I '+%Y'")
       assert result.exit_code == 1
       assert result.stderr =~ "multiple output formats specified"
+    end
+
+    test "+format followed by -I is also an error" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' '+%Y' -I")
+      assert result.exit_code == 1
+      assert result.stderr =~ "multiple output formats specified"
+    end
+
+    test "an invalid -I argument is an error" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -Ibogus")
+      assert result.exit_code == 1
+      assert result.stderr =~ "invalid argument 'bogus' for '--iso-8601'"
+    end
+
+    test "date,ns is rejected as real date rejects it" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date --iso-8601=date,ns")
+      assert result.exit_code == 1
+      assert result.stderr =~ "invalid argument 'date,ns' for '--iso-8601'"
     end
   end
 

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -344,6 +344,18 @@ defmodule JustBash.Commands.UtilitiesTest do
       assert result.stdout == "12 AM\n"
     end
 
+    test "%P is the lowercase %p" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 13:30:00' '+%P'")
+      assert result.stdout == "pm\n"
+    end
+
+    test "%P renders midnight as am" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:30:00' '+%P'")
+      assert result.stdout == "am\n"
+    end
+
     test "%Z is the timezone name" do
       bash = JustBash.new()
       {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+%Z'")

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -286,6 +286,151 @@ defmodule JustBash.Commands.UtilitiesTest do
     end
   end
 
+  # `date +%F` is the single most common way to ask for today's date, and it
+  # used to emit the literal string "%F" — a silently wrong answer rather than
+  # an error, which is the worst failure mode a sandbox can have. An agent
+  # asking the sandbox what day it is got "%F" back and carried on.
+  describe "compound format specifiers" do
+    test "%F is the ISO date" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' '+%F'")
+      assert result.exit_code == 0
+      assert result.stdout == "2024-06-15\n"
+    end
+
+    test "%T is the 24-hour time" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:05' '+%T'")
+      assert result.stdout == "10:30:05\n"
+    end
+
+    test "%D is the US short date" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' '+%D'")
+      assert result.stdout == "06/15/24\n"
+    end
+
+    test "%R is hours and minutes" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:05' '+%R'")
+      assert result.stdout == "10:30\n"
+    end
+
+    test "%F and %T compose" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:05' '+%F %T'")
+      assert result.stdout == "2024-06-15 10:30:05\n"
+    end
+  end
+
+  describe "single-field format specifiers" do
+    test "%y is the two-digit year and %C the century" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+%y %C'")
+      assert result.stdout == "24 20\n"
+    end
+
+    test "%e is the space-padded day of month" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-05 00:00:00' '+[%e]'")
+      assert result.stdout == "[ 5]\n"
+    end
+
+    test "%I and %p are the 12-hour clock" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 13:30:00' '+%I %p'")
+      assert result.stdout == "01 PM\n"
+    end
+
+    test "%I renders midnight as 12 AM" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:30:00' '+%I %p'")
+      assert result.stdout == "12 AM\n"
+    end
+
+    test "%Z is the timezone name" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+%Z'")
+      assert result.stdout == "UTC\n"
+    end
+  end
+
+  # A single left-to-right scan, not a chain of String.replace/3 — otherwise an
+  # escaped percent gets eaten by whichever specifier its following character
+  # happens to name. `%%F` means a literal "%F" and must never become a date.
+  describe "percent escaping" do
+    test "%%F is a literal percent followed by F" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+%%F'")
+      assert result.stdout == "%F\n"
+    end
+
+    test "%%Y is a literal percent followed by Y" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+%%Y'")
+      assert result.stdout == "%Y\n"
+    end
+
+    test "a trailing bare percent survives" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+abc%'")
+      assert result.stdout == "abc%\n"
+    end
+
+    test "an unknown specifier is passed through rather than silently dropped" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 00:00:00' '+%J'")
+      assert result.stdout == "%J\n"
+    end
+  end
+
+  # `-I` / `--iso-8601` was accepted and silently ignored, so it printed the
+  # full default format. Silently ignoring a flag that changes the output shape
+  # is the same class of bug as `%F`.
+  describe "-I / --iso-8601" do
+    test "-I prints just the date" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' -I")
+      assert result.exit_code == 0
+      assert result.stdout == "2024-06-15\n"
+    end
+
+    test "--iso-8601 is the long form" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' --iso-8601")
+      assert result.stdout == "2024-06-15\n"
+    end
+
+    test "-Iseconds includes the time and offset" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' -Iseconds")
+      assert result.stdout == "2024-06-15T10:30:00+00:00\n"
+    end
+
+    test "-Ihours and -Iminutes truncate the time" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:05' -Ihours")
+      {r2, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:05' -Iminutes")
+      assert r1.stdout == "2024-06-15T10+00:00\n"
+      assert r2.stdout == "2024-06-15T10:30+00:00\n"
+    end
+
+    test "-Idate is the same as bare -I" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' -Idate")
+      assert result.stdout == "2024-06-15\n"
+    end
+
+    # Measured against real `date`, which rejects this rather than picking one:
+    # "date: multiple output formats specified".
+    test "-I together with an explicit +format is an error" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15 10:30:00' -I '+%Y'")
+      assert result.exit_code == 1
+      assert result.stderr =~ "multiple output formats specified"
+    end
+  end
+
   describe "seq command" do
     test "seq generates sequence" do
       bash = JustBash.new()

--- a/test/property_test.exs
+++ b/test/property_test.exs
@@ -375,6 +375,44 @@ defmodule JustBash.PropertyTest do
     end
   end
 
+  describe "date format properties" do
+    # Every printable ASCII byte is a candidate directive: known ones render a
+    # field, the rest pass through verbatim. Neither outcome may raise out of
+    # exec/2, so a caller cannot be crashed by a format string. `'` is excluded
+    # because it would terminate the single-quoted format on the command line.
+    @directive_bytes Enum.to_list(33..126) -- [?']
+
+    property "every single-byte directive formats without raising" do
+      check all(byte <- member_of(@directive_bytes)) do
+        bash = JustBash.new()
+        {result, _} = JustBash.exec(bash, "date -d '2024-06-15 13:30:00' '+%#{<<byte>>}'")
+
+        assert result.exit_code == 0
+        assert result.stdout != "\n"
+      end
+    end
+
+    # The scan consumes each directive exactly once, so a sequence of them is
+    # the concatenation of its parts — no directive may consume, drop, or
+    # rewrite a neighbour's bytes.
+    property "a sequence of directives is the concatenation of each alone" do
+      check all(bytes <- list_of(member_of(@directive_bytes), min_length: 1, max_length: 8)) do
+        bash = JustBash.new()
+        format = Enum.map_join(bytes, fn byte -> "%#{<<byte>>}" end)
+        {result, _} = JustBash.exec(bash, "date -d '2024-06-15 13:30:00' '+#{format}'")
+
+        expected =
+          Enum.map_join(bytes, fn byte ->
+            {one, _} = JustBash.exec(bash, "date -d '2024-06-15 13:30:00' '+%#{<<byte>>}'")
+            # Only the newline `date` itself appends — `%n` renders one too.
+            String.replace_suffix(one.stdout, "\n", "")
+          end)
+
+        assert result.stdout == expected <> "\n"
+      end
+    end
+  end
+
   describe "file operations properties" do
     property "touch creates file that exists" do
       check all(name <- string(:alphanumeric, min_length: 1, max_length: 20)) do


### PR DESCRIPTION
Fixes #62.

`date +%F` printed the literal string `%F` and exited 0. That is the shape of bug worth prioritising: a consumer cannot tell it apart from a real answer. I found it because an LLM agent driving a JustBash sandbox asked what today's date was, got `%F` back, and used it.

## What changed

**`format_datetime/2` is now a single left-to-right scan** instead of a chain of `String.replace/3`.

The chain could not express escaping. It rewrote `%Y` everywhere before it ever considered `%%`, so `%%Y` — a literal percent followed by Y — came out as `%2024`. Reordering does not fix this: any fixed order has the same flaw for some input, because a later pass cannot tell which percent signs an earlier pass already consumed. Scanning consumes each directive exactly once, so `%%` is just another two-character directive and the ambiguity disappears.

**Added the directives that were missing**: `%F %T %R %D` (composed from their single-field parts so the two can't drift), plus `%y %C %e %I %p %P %Z %h`.

**Unknown directives now pass through verbatim** (`%J` → `%J`), matching GNU date. This is the point of the whole change: "unsupported" stays distinguishable from a value, rather than looking like output.

**Implemented `-I[FMT]` / `--iso-8601[=FMT]`**, which previously fell through the catch-all arg clause and was silently discarded. Supports `date`, `hours`, `minutes`, `seconds`, `ns`, and errors with GNU's `multiple output formats specified` when it competes with an explicit `+format` rather than quietly picking one.

## Testing

Tests in `test/commands/utilities_test.exs` cover the compound directives, the single-field ones, percent escaping (`%%F`, `%%Y`, trailing bare `%`, unknown directive), and every `-I` form. Expected values were measured against real `date` rather than derived from the spec — which caught one of my own assumptions: I had assumed an explicit `+format` would win over `-I`, and real `date` errors instead. `%e`'s space padding was checked the same way.

Two properties in `test/property_test.exs` cover the directive alphabet rather than the directives I happened to think of:

- every single-byte directive formats without raising out of `exec/2`
- a sequence of directives equals the concatenation of each formatted alone

Both fail on byte 80 (`%P`) against the first version of this branch — see below.

All five gates pass on Elixir 1.19 / OTP 28: `mix test` (4,010 tests, 58 properties, 0 failures), `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix dialyzer` (13 skips, all pre-existing), and `mix credo --strict` (clean apart from the intentional `test/support/banned_fixture_apply.ex` fixture finding).

An earlier revision of this body reported 3,989 tests, 14 pre-existing compile warnings, and a repo-wide credo crash. None of that reproduces on the supported toolchain — it came from a different local setup and understated how clean the repo is. Corrected above.

## Fixed in review

`date +%P` raised `ArgumentError` out of `JustBash.exec/2` and crashed the caller: `directive(?P, dt)` piped `dt` in as the first argument, so it called `directive(dt, ?p)` and fell to the catch-all clause, which tried to build `<<?%, other>>` from a DateTime. Thanks @ivarvong for catching it. Fixed, with the two properties above written first — they reproduce it without naming `%P`, so the whole class stays covered.

## Not addressed

`date` still reports UTC regardless of `TZ`. Out of scope here, but worth knowing if you're weighing how far to take this: a sandbox consumer that needs a user's *local* day still can't get it from `date`. Happy to follow up separately if you want it.

`date -I seconds` (spec as a separate operand) prints the ISO date and ignores `seconds`, where GNU errors `invalid date 'seconds'`. Pre-existing catch-all-operand behavior, left alone.
