### PR TITLE
fix: date rejects unknown arguments instead of returning today at exit 0

### DIFF
--- a/lib/just_bash/commands/date.ex
+++ b/lib/just_bash/commands/date.ex
@@ -15,11 +15,18 @@ defmodule JustBash.Commands.Date do
   so a caller can tell the difference between "not supported" and a real value.
 
   Flags: `-d` / `--date=`, `-I[FMT]` / `--iso-8601[=FMT]`, `-u`, `-r SECONDS`,
-  the BSD `-v` adjustments, and the BSD `-j` / `-f` pair.
+  the BSD `-v` adjustments, and the BSD `-j` / `-f` pair. Values may be attached
+  or separate (`-d2024-06-15`), no-argument flags may cluster (`-ju`), and `--`
+  ends option parsing — the getopt conventions real date inherits.
 
   Everything else is an error. An unimplemented flag must not be dropped:
   ignoring it would print the current date at exit 0, which a caller cannot
   tell apart from a real answer.
+
+  Errors follow whichever real implementation spells the flag: GNU's wording for
+  a long option (`unrecognized option '--foo'`), BSD's for a short one
+  (`illegal option -- X`), since BSD names a long option by its second `-` and
+  so identifies nothing.
 
   Two BSD features are deliberately partial, and say so rather than guessing:
   `-v` implements only the relative form (`[+-]val[ymwdHMS]`), not the
@@ -38,6 +45,25 @@ defmodule JustBash.Commands.Date do
   # Real date's operand is a time to set the system clock to. There is no clock
   # to set here, and an unprivileged real date fails on it too.
   @settable_time ~r/^(\d{2}){2,6}(\.\d{2})?$/
+
+  # Short flags that take no value, and so may cluster: `-ju` is `-j -u`.
+  @no_argument_flags [?j, ?u]
+
+  # The ISO calendar spans fewer than 3.7M days, so no adjustment larger than
+  # that lands inside it from any base.
+  @max_seconds 3_652_425 * 86_400
+
+  # Seconds per unit, each rounded down to the shortest that unit can be, so the
+  # bound above never rejects an adjustment that would have been in range.
+  @unit_seconds %{
+    "y" => 365 * 86_400,
+    "m" => 28 * 86_400,
+    "w" => 7 * 86_400,
+    "d" => 86_400,
+    "H" => 3_600,
+    "M" => 60,
+    "S" => 1
+  }
 
   @impl true
   def names, do: ["date"]
@@ -64,16 +90,10 @@ defmodule JustBash.Commands.Date do
     })
   end
 
-  defp parse_args([], opts), do: {:ok, opts}
+  defp parse_args([], opts), do: finish(opts)
 
-  # Real date rejects competing output formats rather than picking one.
-  defp parse_args(["+" <> _format | _rest], %{iso_format: iso}) when iso != nil do
-    {:error, "date: multiple output formats specified\n"}
-  end
-
-  defp parse_args(["+" <> format | rest], opts) do
-    parse_args(rest, %{opts | format: format})
-  end
+  defp parse_args(["+" <> format | rest], opts),
+    do: put_format(format, rest, opts, &parse_args/2)
 
   defp parse_args(["-I" <> spec | rest], opts), do: put_iso_format(spec, rest, opts)
   defp parse_args(["--iso-8601" | rest], opts), do: put_iso_format("", rest, opts)
@@ -112,33 +132,86 @@ defmodule JustBash.Commands.Date do
     parse_args(rest, opts)
   end
 
+  # Inside a cluster the next character is an option character, and `-` is not
+  # one. This clause has to precede the rewrite below, which would otherwise read
+  # `-u-` as `-u --` and print the date at exit 0.
+  defp parse_args([<<?-, flag, ?-, _::binary>> | _rest], _opts)
+       when flag in @no_argument_flags do
+    {:error, "date: illegal option -- -\n" <> usage()}
+  end
+
+  # getopt lets no-argument flags cluster, and lets whichever flag ends a cluster
+  # carry its value attached: `-ur0` is `-u -r 0`.
+  defp parse_args([<<?-, flag, rest::binary>> | args], opts)
+       when flag in @no_argument_flags and rest != "" do
+    parse_args([<<?-, flag>>, "-" <> rest | args], opts)
+  end
+
   # When we have an input_format set (BSD -f flag) and encounter a non-option arg
   defp parse_args([<<c, _::binary>> = date_str | rest], %{input_format: input_format} = opts)
        when input_format != nil and c != ?+ and c != ?- do
-    case parse_formatted_date(date_str, input_format) do
-      {:ok, datetime} ->
-        parse_args(rest, %{opts | datetime: datetime, input_format: nil})
-
-      {:error, _} ->
-        {:error, "date: invalid date '#{date_str}'\n"}
-    end
+    put_formatted_date(date_str, rest, opts, &parse_args/2)
   end
+
+  # `--` ends option parsing, as getopt does.
+  defp parse_args(["--" | rest], opts), do: parse_operands(rest, opts)
 
   # An option we do not implement fails loudly. Dropping it would print the
   # current date at exit 0 — a wrong answer nothing downstream can detect.
-  defp parse_args(["-" <> flag = arg | _rest], _opts) when flag != "" do
-    {:error, "date: illegal option -- #{arg}\n" <> usage()}
+  defp parse_args(["--" <> flag | _rest], _opts) when flag != "" do
+    {:error, "date: unrecognized option '--#{flag}'\n" <> usage()}
   end
+
+  # A short option is named by the character getopt rejected, so `-Xu` is a bad
+  # `X` rather than a bad `Xu`. A lone `-` has no such character and falls
+  # through to the operand clause below, which is where getopt leaves it too.
+  defp parse_args([<<?-, char, _::binary>> | _rest], _opts) do
+    {:error, "date: illegal option -- #{<<char>>}\n" <> usage()}
+  end
+
+  defp parse_args([operand | _rest], opts), do: operand_error(operand, opts)
+
+  # After `--` nothing is an option, so an argument is `+format`, the operand a
+  # pending -f describes, or a time we are being asked to set the clock to.
+  defp parse_operands([], opts), do: finish(opts)
+
+  defp parse_operands(["+" <> format | rest], opts),
+    do: put_format(format, rest, opts, &parse_operands/2)
+
+  defp parse_operands([date_str | rest], %{input_format: input_format} = opts)
+       when input_format != nil do
+    put_formatted_date(date_str, rest, opts, &parse_operands/2)
+  end
+
+  defp parse_operands([operand | _rest], opts), do: operand_error(operand, opts)
+
+  # -f names the format of an operand. With no operand there is nothing to parse,
+  # and real date prints usage rather than falling back to the current time.
+  defp finish(%{input_format: input_format}) when input_format != nil, do: {:error, usage()}
+  defp finish(opts), do: {:ok, opts}
 
   # With -j there is no clock to set, so an operand is a time to display — and
   # the canonical `[[[[mm]dd]HH]MM[[cc]yy][.SS]` form is one we cannot parse.
-  defp parse_args([_operand | _rest], %{no_set: true}), do: {:error, illegal_time_format()}
+  defp operand_error(_operand, %{no_set: true}), do: {:error, illegal_time_format()}
 
-  defp parse_args([operand | _rest], _opts) do
+  defp operand_error(operand, _opts) do
     if Regex.match?(@settable_time, operand) do
       {:error, "date: clock_settime: Operation not permitted\n"}
     else
       {:error, illegal_time_format()}
+    end
+  end
+
+  # Real date rejects competing output formats rather than picking one.
+  defp put_format(_format, _rest, %{iso_format: iso}, _cont) when iso != nil,
+    do: {:error, "date: multiple output formats specified\n"}
+
+  defp put_format(format, rest, opts, cont), do: cont.(rest, %{opts | format: format})
+
+  defp put_formatted_date(date_str, rest, %{input_format: input_format} = opts, cont) do
+    case parse_formatted_date(date_str, input_format) do
+      {:ok, datetime} -> cont.(rest, %{opts | datetime: datetime, input_format: nil})
+      {:error, _} -> {:error, "date: invalid date '#{date_str}'\n"}
     end
   end
 
@@ -160,13 +233,27 @@ defmodule JustBash.Commands.Date do
   end
 
   defp put_adjustment(spec, rest, opts) do
-    case Regex.run(@adjustment, spec) do
-      [_spec, sign, value, unit] ->
-        amount = String.to_integer(sign <> value)
-        parse_args(rest, %{opts | adjustments: [{amount, unit, spec} | opts.adjustments]})
+    case parse_adjustment(spec) do
+      {:ok, adjustment} ->
+        parse_args(rest, %{opts | adjustments: [adjustment | opts.adjustments]})
 
-      nil ->
+      :error ->
         {:error, cannot_adjust(spec)}
+    end
+  end
+
+  # An adjustment too large for the ISO calendar is rejected here, before it is
+  # applied, and not by the range check in adjust/2 afterwards. That is not just
+  # an early exit: a fixed-length unit is applied with DateTime.add/3, whose cost
+  # grows with how far the result lands from the epoch, so a spec like
+  # `+99999999999999999999d` does not come back at all.
+  defp parse_adjustment(spec) do
+    with [_spec, sign, value, unit] <- Regex.run(@adjustment, spec),
+         amount = String.to_integer(sign <> value),
+         true <- abs(amount) * Map.fetch!(@unit_seconds, unit) <= @max_seconds do
+      {:ok, {amount, unit, spec}}
+    else
+      _unparseable_or_too_large -> :error
     end
   end
 

--- a/lib/just_bash/commands/date.ex
+++ b/lib/just_bash/commands/date.ex
@@ -14,8 +14,16 @@ defmodule JustBash.Commands.Date do
   An unrecognized directive is emitted verbatim (`%J` → `%J`), as GNU date does,
   so a caller can tell the difference between "not supported" and a real value.
 
-  Flags: `-d` / `--date=`, `-I[FMT]` / `--iso-8601[=FMT]`, `-u`, and the BSD
-  `-j` / `-f` pair.
+  Flags: `-d` / `--date=`, `-I[FMT]` / `--iso-8601[=FMT]`, `-u`, `-r SECONDS`,
+  the BSD `-v` adjustments, and the BSD `-j` / `-f` pair.
+
+  Everything else is an error. An unimplemented flag must not be dropped:
+  ignoring it would print the current date at exit 0, which a caller cannot
+  tell apart from a real answer.
+
+  Two BSD features are deliberately partial, and say so rather than guessing:
+  `-v` implements only the relative form (`[+-]val[ymwdHMS]`), not the
+  set-a-field form (`-v1d`, `-vfri`); `-r` takes epoch seconds, not a filename.
   """
   @behaviour JustBash.Commands.Command
 
@@ -23,20 +31,25 @@ defmodule JustBash.Commands.Date do
 
   @default_format "%a %b %d %H:%M:%S UTC %Y"
 
+  # `-v[+-]val[unit]`. The sign is what distinguishes an adjustment from BSD's
+  # set-this-field form, which we do not implement.
+  @adjustment ~r/^([+-])(\d+)([ymwdHMS])$/
+
+  # Real date's operand is a time to set the system clock to. There is no clock
+  # to set here, and an unprivileged real date fails on it too.
+  @settable_time ~r/^(\d{2}){2,6}(\.\d{2})?$/
+
   @impl true
   def names, do: ["date"]
 
   @impl true
   def execute(bash, args, _stdin) do
-    case parse_args(args) do
-      {:ok, opts} ->
-        datetime = opts.datetime || DateTime.utc_now()
-        format = opts.format || opts.iso_format || @default_format
-        output = format_datetime(datetime, format) <> "\n"
-        {Command.ok(output), bash}
-
-      {:error, msg} ->
-        {Command.error(msg), bash}
+    with {:ok, opts} <- parse_args(args),
+         {:ok, datetime} <- adjust(opts.datetime || DateTime.utc_now(), opts.adjustments) do
+      format = opts.format || opts.iso_format || @default_format
+      {Command.ok(format_datetime(datetime, format) <> "\n"), bash}
+    else
+      {:error, msg} -> {Command.error(msg), bash}
     end
   end
 
@@ -46,6 +59,7 @@ defmodule JustBash.Commands.Date do
       iso_format: nil,
       datetime: nil,
       input_format: nil,
+      adjustments: [],
       no_set: false
     })
   end
@@ -66,19 +80,21 @@ defmodule JustBash.Commands.Date do
 
   defp parse_args(["--iso-8601=" <> spec | rest], opts), do: put_iso_format(spec, rest, opts)
 
-  defp parse_args(["-d", date_str | rest], opts) do
-    case parse_date_string(date_str) do
-      {:ok, datetime} -> parse_args(rest, %{opts | datetime: datetime})
-      {:error, _} -> {:error, "date: invalid date '#{date_str}'\n"}
-    end
-  end
+  # A flag's value may be attached (-d2024-01-01) or separate, as getopt allows.
+  defp parse_args(["-d"], _opts), do: {:error, missing_argument("-d")}
+  defp parse_args(["-d", date_str | rest], opts), do: put_datetime(date_str, rest, opts)
+  defp parse_args(["-d" <> date_str | rest], opts), do: put_datetime(date_str, rest, opts)
+  defp parse_args(["--date=" <> date_str | rest], opts), do: put_datetime(date_str, rest, opts)
 
-  defp parse_args(["--date=" <> date_str | rest], opts) do
-    case parse_date_string(date_str) do
-      {:ok, datetime} -> parse_args(rest, %{opts | datetime: datetime})
-      {:error, _} -> {:error, "date: invalid date '#{date_str}'\n"}
-    end
-  end
+  # BSD date: -r takes the time from an epoch timestamp.
+  defp parse_args(["-r"], _opts), do: {:error, missing_argument("-r")}
+  defp parse_args(["-r", secs | rest], opts), do: put_epoch(secs, rest, opts)
+  defp parse_args(["-r" <> secs | rest], opts), do: put_epoch(secs, rest, opts)
+
+  # BSD date: -v adjusts a field of the date, as many times as given.
+  defp parse_args(["-v"], _opts), do: {:error, missing_argument("-v")}
+  defp parse_args(["-v", spec | rest], opts), do: put_adjustment(spec, rest, opts)
+  defp parse_args(["-v" <> spec | rest], opts), do: put_adjustment(spec, rest, opts)
 
   # BSD date: -j flag means "don't set the date" (just display)
   defp parse_args(["-j" | rest], opts) do
@@ -86,6 +102,8 @@ defmodule JustBash.Commands.Date do
   end
 
   # BSD date: -f input_format to parse a date string
+  defp parse_args(["-f"], _opts), do: {:error, missing_argument("-f")}
+
   defp parse_args(["-f", input_format | rest], opts) do
     parse_args(rest, %{opts | input_format: input_format})
   end
@@ -106,8 +124,111 @@ defmodule JustBash.Commands.Date do
     end
   end
 
-  defp parse_args([_arg | rest], opts) do
-    parse_args(rest, opts)
+  # An option we do not implement fails loudly. Dropping it would print the
+  # current date at exit 0 — a wrong answer nothing downstream can detect.
+  defp parse_args(["-" <> flag = arg | _rest], _opts) when flag != "" do
+    {:error, "date: illegal option -- #{arg}\n" <> usage()}
+  end
+
+  # With -j there is no clock to set, so an operand is a time to display — and
+  # the canonical `[[[[mm]dd]HH]MM[[cc]yy][.SS]` form is one we cannot parse.
+  defp parse_args([_operand | _rest], %{no_set: true}), do: {:error, illegal_time_format()}
+
+  defp parse_args([operand | _rest], _opts) do
+    if Regex.match?(@settable_time, operand) do
+      {:error, "date: clock_settime: Operation not permitted\n"}
+    else
+      {:error, illegal_time_format()}
+    end
+  end
+
+  defp put_datetime(date_str, rest, opts) do
+    case parse_date_string(date_str) do
+      {:ok, datetime} -> parse_args(rest, %{opts | datetime: datetime})
+      {:error, _} -> {:error, "date: invalid date '#{date_str}'\n"}
+    end
+  end
+
+  defp put_epoch(secs, rest, opts) do
+    with {seconds, ""} <- Integer.parse(secs),
+         {:ok, datetime} <- DateTime.from_unix(seconds) do
+      parse_args(rest, %{opts | datetime: datetime})
+    else
+      {:error, :invalid_unix_time} -> {:error, "date: invalid time\n"}
+      _not_a_number -> {:error, "date: illegal time value -- #{secs}\n" <> usage()}
+    end
+  end
+
+  defp put_adjustment(spec, rest, opts) do
+    case Regex.run(@adjustment, spec) do
+      [_spec, sign, value, unit] ->
+        amount = String.to_integer(sign <> value)
+        parse_args(rest, %{opts | adjustments: [{amount, unit, spec} | opts.adjustments]})
+
+      nil ->
+        {:error, cannot_adjust(spec)}
+    end
+  end
+
+  defp cannot_adjust(spec), do: "date: #{spec}: Cannot apply date adjustment\n" <> usage()
+
+  defp missing_argument(flag), do: "date: option requires an argument -- #{flag}\n" <> usage()
+
+  defp illegal_time_format, do: "date: illegal time format\n" <> usage()
+
+  defp usage do
+    """
+    usage: date [-u] [-d datestr | -r seconds] [-j] [-f input_fmt]
+                [-I[date|hours|minutes|seconds|ns]] [-v[+|-]val[y|m|w|d|H|M|S]]
+                [+output_fmt]
+    """
+  end
+
+  # Adjustments are applied in the order given, each to the result of the last,
+  # which is how BSD composes `-v+1m -v-1d`. An adjustment that lands outside the
+  # ISO calendar is rejected rather than printed: `%Y` is four digits and `-d`
+  # only parses ISO dates, so a year like -97973 is not an answer.
+  defp adjust(datetime, adjustments) do
+    adjustments
+    |> Enum.reverse()
+    |> Enum.reduce_while({:ok, datetime}, fn {_n, _unit, spec} = adjustment, {:ok, dt} ->
+      case apply_adjustment(dt, adjustment) do
+        %DateTime{year: year} = adjusted when year in 0..9999 -> {:cont, {:ok, adjusted}}
+        %DateTime{} -> {:halt, {:error, cannot_adjust(spec)}}
+      end
+    end)
+  end
+
+  defp apply_adjustment(dt, {n, "y", _spec}), do: shift_years(dt, n)
+  defp apply_adjustment(dt, {n, "m", _spec}), do: shift_months(dt, n)
+  defp apply_adjustment(dt, {n, "w", _spec}), do: DateTime.add(dt, n * 7, :day)
+  defp apply_adjustment(dt, {n, "d", _spec}), do: DateTime.add(dt, n, :day)
+  defp apply_adjustment(dt, {n, "H", _spec}), do: DateTime.add(dt, n, :hour)
+  defp apply_adjustment(dt, {n, "M", _spec}), do: DateTime.add(dt, n, :minute)
+  defp apply_adjustment(dt, {n, "S", _spec}), do: DateTime.add(dt, n, :second)
+
+  # A year adjustment moves the year field and lets an impossible result
+  # normalize forward: Feb 29 plus a year is Mar 1. BSD really does differ here
+  # from the month adjustment below, which clamps instead — `-v+1y` off Feb 29
+  # gives Mar 1 where `-v+12m` gives Feb 28.
+  defp shift_years(dt, n) do
+    year = dt.year + n
+    days = Calendar.ISO.days_in_month(year, dt.month)
+
+    case dt.day - days do
+      overflow when overflow > 0 -> shift_months(%{dt | year: year, day: overflow}, 1)
+      _fits -> %{dt | year: year}
+    end
+  end
+
+  # Months are a variable-length unit, so BSD preserves the day of the month and
+  # clamps to the target month's last day when it doesn't exist there: May 31
+  # plus a month is June 30.
+  defp shift_months(dt, n) do
+    total = dt.year * 12 + (dt.month - 1) + n
+    year = Integer.floor_div(total, 12)
+    month = Integer.mod(total, 12) + 1
+    %{dt | year: year, month: month, day: min(dt.day, Calendar.ISO.days_in_month(year, month))}
   end
 
   defp put_iso_format(_spec, _rest, %{format: format}) when format != nil do

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -485,20 +485,36 @@ defmodule JustBash.Commands.UtilitiesTest do
   # An unimplemented flag must not be dropped: silently ignoring it returns the
   # current date at exit 0, which the caller cannot tell from a real answer.
   describe "unrecognized arguments" do
+    # A long option is named in full, as GNU date words it. BSD reports the
+    # offending character, which for a long option is the second `-` — a message
+    # that identifies nothing.
     test "an unknown long option is an error, not a silently ignored flag" do
       bash = JustBash.new()
       {result, _} = JustBash.exec(bash, "date --definitely-not-a-flag '+%Y-%m-%d'")
       assert result.exit_code == 1
       assert result.stdout == ""
-      assert result.stderr =~ "illegal option -- --definitely-not-a-flag"
+      assert result.stderr =~ "date: unrecognized option '--definitely-not-a-flag'\n"
     end
 
-    test "an unknown short option is an error" do
+    # A short option is named by its character, as BSD date does, because that
+    # is the unit getopt rejected — `-Xu` is a bad `X`, not a bad `Xu`.
+    test "an unknown short option is named by its character" do
       bash = JustBash.new()
-      {result, _} = JustBash.exec(bash, "date -X '+%Y'")
+      {r1, _} = JustBash.exec(bash, "date -X '+%Y'")
+      {r2, _} = JustBash.exec(bash, "date -Xu '+%Y'")
+      assert r1.exit_code == 1
+      assert r1.stdout == ""
+      assert r1.stderr =~ "date: illegal option -- X\n"
+      assert r2.exit_code == 1
+      assert r2.stderr =~ "date: illegal option -- X\n"
+    end
+
+    # A lone `-` is not option-shaped to getopt, so it is an operand.
+    test "a lone dash is an operand, not an option" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -")
       assert result.exit_code == 1
-      assert result.stdout == ""
-      assert result.stderr =~ "illegal option -- -X"
+      assert result.stderr =~ "illegal time format"
     end
 
     test "the error names the supported flags" do
@@ -550,6 +566,87 @@ defmodule JustBash.Commands.UtilitiesTest do
         assert result.stderr =~ "option requires an argument -- #{flag}"
       end
     end
+
+    # -f names the format of an operand. With no operand there is nothing for it
+    # to parse, so real date prints usage rather than falling back to now — the
+    # same defect class as an ignored flag, on the one path that still had it.
+    test "-f without an operand is an error, not the current date" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -f '%Y-%m-%d' '+%F'")
+      {r2, _} = JustBash.exec(bash, "date -j -f '%Y-%m-%d' '+%F'")
+      assert r1.exit_code == 1
+      assert r1.stdout == ""
+      assert r1.stderr =~ "usage: date"
+      assert r2.exit_code == 1
+      assert r2.stdout == ""
+      assert r2.stderr =~ "usage: date"
+    end
+  end
+
+  # getopt's conventions, which real date inherits: `--` ends option parsing and
+  # no-argument flags may be clustered. Rejecting unknown options meant these
+  # two spellings started erroring, so they need to be understood rather than
+  # merely tolerated.
+  describe "getopt conventions" do
+    test "-- ends option parsing" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15' -- '+%F'")
+      assert result.exit_code == 0
+      assert result.stdout == "2024-06-15\n"
+    end
+
+    test "-- alone still prints the date" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date --")
+      assert result.exit_code == 0
+      assert result.stdout =~ ~r/^\w{3} \w{3} \d{2} \d{2}:\d{2}:\d{2} UTC \d{4}\n$/
+    end
+
+    # After `--` an option-shaped argument is an operand, so it fails as a time
+    # rather than as an option.
+    test "an option after -- is an operand" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -- -X")
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "illegal time format"
+      refute result.stderr =~ "illegal option"
+    end
+
+    test "no-argument short flags may be clustered" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -ju -d '2024-06-15' '+%F'")
+      {r2, _} = JustBash.exec(bash, "date -uj -d '2024-06-15' '+%F'")
+      assert r1.exit_code == 0, r1.stderr
+      assert r1.stdout == "2024-06-15\n"
+      assert r2.stdout == "2024-06-15\n"
+    end
+
+    # Inside a cluster the next character is an option character, and `-` is not
+    # one. Reading the remainder as a fresh argument instead would turn `-u-`
+    # into `-u --` and print the date at exit 0.
+    test "a dash inside a cluster is an illegal option, not end-of-options" do
+      bash = JustBash.new()
+
+      for arg <- ["-u-", "-u-x", "-ju-"] do
+        {result, _} = JustBash.exec(bash, "date #{arg} '+%F'")
+        assert result.exit_code == 1, "expected date #{arg} to fail"
+        assert result.stdout == ""
+        assert result.stderr =~ "date: illegal option -- -\n"
+      end
+    end
+
+    # A cluster ends at the first flag that takes a value; the remainder is that
+    # value, so `-ur0` is `-u -r 0`.
+    test "a clustered flag may carry the value of the flag that ends the cluster" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -ur0 '+%F'")
+      {r2, _} = JustBash.exec(bash, "date -d '2024-06-15' -ujv+1d '+%F'")
+      {r3, _} = JustBash.exec(bash, "date -d '2024-06-15' -uIseconds")
+      assert r1.stdout == "1970-01-01\n"
+      assert r2.stdout == "2024-06-16\n"
+      assert r3.stdout == "2024-06-15T00:00:00+00:00\n"
+    end
   end
 
   describe "-v adjustments" do
@@ -566,11 +663,18 @@ defmodule JustBash.Commands.UtilitiesTest do
       assert result.stdout == "2025-08-04\n"
     end
 
+    # Bracketing the call rather than reading the clock once keeps the assertion
+    # honest across UTC midnight.
     test "the adjustment applies to the current date when there is no -d" do
       bash = JustBash.new()
+      before = Date.utc_today()
       {result, _} = JustBash.exec(bash, "date -v+1d '+%Y-%m-%d'")
-      expected = Date.utc_today() |> Date.add(1) |> Date.to_iso8601()
-      assert result.stdout == expected <> "\n"
+      after_call = Date.utc_today()
+
+      allowed =
+        for day <- [before, after_call], do: "#{Date.to_iso8601(Date.add(day, 1))}\n"
+
+      assert result.stdout in allowed
     end
 
     test "the value may be a separate argument, as getopt allows" do
@@ -630,13 +734,17 @@ defmodule JustBash.Commands.UtilitiesTest do
       assert s.stdout == "2026-08-04 12:31:05\n"
     end
 
-    # BSD: "Flags are processed in the order given."
+    # BSD: "Flags are processed in the order given." March 31 is a base where the
+    # two orders genuinely disagree: +1m clamps to April 30 before -1d takes a
+    # day off, where -1d lands on March 30 first and +1m then keeps the 30th. A
+    # base like August 4 gives the same answer either way and so cannot tell an
+    # ordered fold from a reversed one.
     test "several adjustments compose left to right" do
       bash = JustBash.new()
-      {r1, _} = JustBash.exec(bash, "date -d '2026-08-04' -v+1m -v-1d '+%Y-%m-%d'")
-      {r2, _} = JustBash.exec(bash, "date -d '2026-08-04' -v-1d -v+1m '+%Y-%m-%d'")
-      assert r1.stdout == "2026-09-03\n"
-      assert r2.stdout == "2026-09-03\n"
+      {r1, _} = JustBash.exec(bash, "date -d '2026-03-31' -v+1m -v-1d '+%Y-%m-%d'")
+      {r2, _} = JustBash.exec(bash, "date -d '2026-03-31' -v-1d -v+1m '+%Y-%m-%d'")
+      assert r1.stdout == "2026-04-29\n"
+      assert r2.stdout == "2026-04-30\n"
     end
 
     test "an unsigned adjustment sets rather than adjusts, and is not supported" do
@@ -684,6 +792,41 @@ defmodule JustBash.Commands.UtilitiesTest do
         assert result.exit_code == 1, "expected -v#{spec} to fail"
         assert result.stderr =~ "#{spec}: Cannot apply date adjustment"
       end
+    end
+
+    # An out-of-range adjustment has to be rejected before it is applied, not
+    # after: the fixed-length units go through DateTime.add/3, whose cost grows
+    # with how far the result lands from the epoch, so 10^20 days does not come
+    # back at all. This asserts termination first — a rejection that arrives in a
+    # week is not a rejection.
+    test "an enormous adjustment is rejected rather than computed" do
+      for unit <- ~w(y m w d H M S), sign <- ~w(+ -) do
+        spec = "#{sign}#{String.duplicate("9", 20)}#{unit}"
+
+        task =
+          Task.async(fn -> JustBash.exec(JustBash.new(), "date -v#{spec} '+%Y-%m-%d'") end)
+
+        case Task.yield(task, 2_000) || Task.shutdown(task, :brutal_kill) do
+          {:ok, {result, _}} ->
+            assert result.exit_code == 1, "expected -v#{spec} to fail"
+            assert result.stdout == ""
+            assert result.stderr =~ "#{spec}: Cannot apply date adjustment"
+
+          nil ->
+            flunk("date -v#{spec} did not terminate within 2s")
+        end
+      end
+    end
+
+    # The bound on a fixed-length unit has to be the whole ISO calendar, not a
+    # convenient round number: these two adjustments span it exactly, from the
+    # first representable day to the last.
+    test "an adjustment spanning the whole calendar is still applied" do
+      bash = JustBash.new()
+      {days, _} = JustBash.exec(bash, "date -d '0000-01-01' -v+3652424d '+%Y-%m-%d'")
+      {secs, _} = JustBash.exec(bash, "date -d '0000-01-01' -v+315569433600S '+%Y-%m-%d'")
+      assert days.stdout == "9999-12-31\n", days.stderr
+      assert secs.stdout == "9999-12-31\n", secs.stderr
     end
   end
 

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -482,6 +482,274 @@ defmodule JustBash.Commands.UtilitiesTest do
     end
   end
 
+  # An unimplemented flag must not be dropped: silently ignoring it returns the
+  # current date at exit 0, which the caller cannot tell from a real answer.
+  describe "unrecognized arguments" do
+    test "an unknown long option is an error, not a silently ignored flag" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date --definitely-not-a-flag '+%Y-%m-%d'")
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "illegal option -- --definitely-not-a-flag"
+    end
+
+    test "an unknown short option is an error" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -X '+%Y'")
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "illegal option -- -X"
+    end
+
+    test "the error names the supported flags" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -X")
+      assert result.stderr =~ "usage: date"
+      assert result.stderr =~ "-v[+|-]val[y|m|w|d|H|M|S]"
+    end
+
+    test "a bare operand cannot set the clock" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date 1432")
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "Operation not permitted"
+    end
+
+    test "an operand that is not even a settable time is a format error" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date notadate")
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "illegal time format"
+    end
+
+    # -j means "display, don't set", so the operand is a time we cannot parse
+    # rather than a clock we failed to set.
+    test "an operand under -j is a format error" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -j 0900")
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "illegal time format"
+    end
+
+    test "-u is still accepted, since output is always UTC" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -u -d '2024-06-15 10:30:00' '+%F %T'")
+      assert result.exit_code == 0
+      assert result.stdout == "2024-06-15 10:30:00\n"
+    end
+
+    test "a flag whose argument is missing is an error" do
+      bash = JustBash.new()
+
+      for flag <- ["-d", "-f", "-r", "-v"] do
+        {result, _} = JustBash.exec(bash, "date #{flag}")
+        assert result.exit_code == 1, "expected #{flag} with no argument to fail"
+        assert result.stderr =~ "option requires an argument -- #{flag}"
+      end
+    end
+  end
+
+  describe "-v adjustments" do
+    test "+6m moves six months forward" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2026-08-04' -v+6m '+%Y-%m-%d'")
+      assert result.exit_code == 0
+      assert result.stdout == "2027-02-04\n"
+    end
+
+    test "-1y moves a year back" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2026-08-04' -v-1y '+%Y-%m-%d'")
+      assert result.stdout == "2025-08-04\n"
+    end
+
+    test "the adjustment applies to the current date when there is no -d" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -v+1d '+%Y-%m-%d'")
+      expected = Date.utc_today() |> Date.add(1) |> Date.to_iso8601()
+      assert result.stdout == expected <> "\n"
+    end
+
+    test "the value may be a separate argument, as getopt allows" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2026-08-04' -v +6m '+%Y-%m-%d'")
+      assert result.stdout == "2027-02-04\n"
+    end
+
+    # BSD: "date tries to preserve the day of the month. If it is impossible
+    # because the target month is shorter [...] the last day of the target
+    # month will be the result."
+    test "a month adjustment clamps to the last day of a shorter target month" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -d '2026-01-31' -v+1m '+%Y-%m-%d'")
+      {r2, _} = JustBash.exec(bash, "date -d '2026-03-31' -v-1m '+%Y-%m-%d'")
+      {r3, _} = JustBash.exec(bash, "date -d '2024-01-31' -v+1m '+%Y-%m-%d'")
+      assert r1.stdout == "2026-02-28\n"
+      assert r2.stdout == "2026-02-28\n"
+      assert r3.stdout == "2024-02-29\n"
+    end
+
+    # A year adjustment moves the year field and lets an impossible result
+    # normalize forward, where a month adjustment clamps. BSD really does treat
+    # the two differently: +1y off Feb 29 is Mar 1, +12m off Feb 29 is Feb 28.
+    test "a year adjustment rolls February 29 forward onto a non-leap year" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -d '2024-02-29' -v+1y '+%Y-%m-%d'")
+      {r2, _} = JustBash.exec(bash, "date -d '2024-02-29' -v-1y '+%Y-%m-%d'")
+      {r3, _} = JustBash.exec(bash, "date -d '2024-02-29' -v+12m '+%Y-%m-%d'")
+      {r4, _} = JustBash.exec(bash, "date -d '2024-02-29' -v+4y '+%Y-%m-%d'")
+      assert r1.stdout == "2025-03-01\n"
+      assert r2.stdout == "2023-03-01\n"
+      assert r3.stdout == "2025-02-28\n"
+      assert r4.stdout == "2028-02-29\n"
+    end
+
+    test "months roll across the year boundary in both directions" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -d '2026-11-15' -v+3m '+%Y-%m-%d'")
+      {r2, _} = JustBash.exec(bash, "date -d '2026-02-15' -v-3m '+%Y-%m-%d'")
+      assert r1.stdout == "2027-02-15\n"
+      assert r2.stdout == "2025-11-15\n"
+    end
+
+    test "weeks, days, hours, minutes and seconds each adjust their own field" do
+      bash = JustBash.new()
+      base = "date -d '2026-08-04 12:30:45'"
+      {w, _} = JustBash.exec(bash, "#{base} -v+2w '+%F %T'")
+      {d, _} = JustBash.exec(bash, "#{base} -v-3d '+%F %T'")
+      {h, _} = JustBash.exec(bash, "#{base} -v+12H '+%F %T'")
+      {m, _} = JustBash.exec(bash, "#{base} -v-45M '+%F %T'")
+      {s, _} = JustBash.exec(bash, "#{base} -v+20S '+%F %T'")
+      assert w.stdout == "2026-08-18 12:30:45\n"
+      assert d.stdout == "2026-08-01 12:30:45\n"
+      assert h.stdout == "2026-08-05 00:30:45\n"
+      assert m.stdout == "2026-08-04 11:45:45\n"
+      assert s.stdout == "2026-08-04 12:31:05\n"
+    end
+
+    # BSD: "Flags are processed in the order given."
+    test "several adjustments compose left to right" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -d '2026-08-04' -v+1m -v-1d '+%Y-%m-%d'")
+      {r2, _} = JustBash.exec(bash, "date -d '2026-08-04' -v-1d -v+1m '+%Y-%m-%d'")
+      assert r1.stdout == "2026-09-03\n"
+      assert r2.stdout == "2026-09-03\n"
+    end
+
+    test "an unsigned adjustment sets rather than adjusts, and is not supported" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -v1d '+%Y-%m-%d'")
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "1d: Cannot apply date adjustment"
+    end
+
+    # `%Y` is four digits and -d only parses ISO dates, so the representable
+    # range is the ISO calendar's. Leaving it must be an error, not a year like
+    # -97973 printed at exit 0.
+    test "an adjustment that leaves the representable range is an error" do
+      bash = JustBash.new()
+
+      for spec <- ["-99999y", "+99999y", "+9999999999m", "+9999999999999d", "-3000y"] do
+        {result, _} = JustBash.exec(bash, "date -v#{spec} '+%Y-%m-%d'")
+        assert result.exit_code == 1, "expected -v#{spec} to fail"
+        assert result.stdout == ""
+        assert result.stderr =~ "#{spec}: Cannot apply date adjustment"
+      end
+    end
+
+    test "an intermediate adjustment out of range fails even if the total is in range" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15' -v+9000y -v-9000y '+%Y-%m-%d'")
+      assert result.exit_code == 1
+      assert result.stderr =~ "+9000y: Cannot apply date adjustment"
+    end
+
+    test "an adjustment at the edge of the range still works" do
+      bash = JustBash.new()
+      {r1, _} = JustBash.exec(bash, "date -d '2024-06-15' -v+7975y '+%Y-%m-%d'")
+      {r2, _} = JustBash.exec(bash, "date -d '2024-06-15' -v-2024y '+%Y-%m-%d'")
+      assert r1.stdout == "9999-06-15\n"
+      assert r2.stdout == "0000-06-15\n"
+    end
+
+    test "an unparseable adjustment is an error" do
+      bash = JustBash.new()
+
+      for spec <- ["bogus", "+fri", "+1x", "+m", "+1.5d"] do
+        {result, _} = JustBash.exec(bash, "date -v#{spec} '+%Y-%m-%d'")
+        assert result.exit_code == 1, "expected -v#{spec} to fail"
+        assert result.stderr =~ "#{spec}: Cannot apply date adjustment"
+      end
+    end
+  end
+
+  describe "-r seconds" do
+    test "-r 0 is the epoch" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -r 0 '+%Y-%m-%d %H:%M:%S'")
+      assert result.exit_code == 0
+      assert result.stdout == "1970-01-01 00:00:00\n"
+    end
+
+    test "-r takes the value attached too" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -r1718409600 '+%Y-%m-%d'")
+      assert result.stdout == "2024-06-15\n"
+    end
+
+    test "-r accepts a negative timestamp" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -r -1 '+%Y-%m-%d %H:%M:%S'")
+      assert result.stdout == "1969-12-31 23:59:59\n"
+    end
+
+    test "-r composes with -v" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -r 0 -v+1y '+%Y-%m-%d'")
+      assert result.stdout == "1971-01-01\n"
+    end
+
+    test "a timestamp outside the representable range is an error, not a crash" do
+      bash = JustBash.new()
+
+      for secs <- ["99999999999999999999", "-99999999999999999999"] do
+        {result, _} = JustBash.exec(bash, "date -r #{secs} '+%Y-%m-%d'")
+        assert result.exit_code == 1, "expected -r #{secs} to fail"
+        assert result.stdout == ""
+        assert result.stderr =~ "invalid time"
+      end
+    end
+
+    # Real date also accepts a filename here; we do not, and say so rather than
+    # falling back to the current time.
+    test "a non-numeric -r argument is an error" do
+      bash = JustBash.new(files: %{"/tmp/f.txt" => "hi"})
+      {result, _} = JustBash.exec(bash, "date -r /tmp/f.txt '+%Y-%m-%d'")
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "illegal time value -- /tmp/f.txt"
+    end
+  end
+
+  describe "-d attached value" do
+    test "-d takes the date attached, as GNU date allows" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -d2024-06-15 '+%Y-%m-%d'")
+      assert result.stdout == "2024-06-15\n"
+    end
+
+    test "an attached -d value is still validated" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -dnonsense")
+      assert result.exit_code == 1
+      assert result.stderr =~ "invalid date 'nonsense'"
+    end
+  end
+
   describe "seq command" do
     test "seq generates sequence" do
       bash = JustBash.new()

--- a/test/property_test.exs
+++ b/test/property_test.exs
@@ -415,12 +415,14 @@ defmodule JustBash.PropertyTest do
     # The failure mode this guards is worse than a missing flag: an option that
     # gets dropped prints the current date at exit 0, so the caller reads a
     # wrong answer as a real one. Exit 0 is only ever allowed for an option we
-    # actually implement.
+    # actually implement — or for `--`, which is getopt's end-of-options marker
+    # rather than an option, and which real date accepts.
     @implemented ~w(-u -j -I -d -f -r -v)
 
     property "an option date does not implement never exits 0" do
       check all(
               flag <- string([?a..?z, ?A..?Z, ?0..?9, ?-, ?=, ?+], min_length: 1, max_length: 6),
+              flag != "-",
               not Enum.any?(@implemented, &String.starts_with?("-" <> flag, &1))
             ) do
         bash = JustBash.new()
@@ -432,15 +434,66 @@ defmodule JustBash.PropertyTest do
       end
     end
 
+    # Clustering must not launder an unknown option: a run of flags date does
+    # implement, followed by one it does not, is still an error. `-` is in the
+    # unknown set because inside a cluster it is an option character, not the
+    # start of the end-of-options marker.
+    @option_chars Enum.to_list(?a..?z) ++ Enum.to_list(?A..?Z) ++ [?-]
+    @known_option_chars [?j, ?u, ?d, ?f, ?r, ?v, ?I]
+
+    property "an unknown option is rejected inside a cluster too" do
+      check all(
+              cluster <- string([?j, ?u], min_length: 1, max_length: 3),
+              unknown <- member_of(@option_chars -- @known_option_chars)
+            ) do
+        bash = JustBash.new()
+        arg = "-#{cluster}#{<<unknown>>}"
+        {result, _} = JustBash.exec(bash, "date #{arg} '+%Y-%m-%d'")
+
+        assert result.exit_code == 1, "date #{arg} exited 0 with #{inspect(result.stdout)}"
+        assert result.stdout == ""
+        assert result.stderr =~ "date:"
+      end
+    end
+
+    # A -v adjustment is applied by moving a DateTime, and the cost of that grows
+    # with how far the result lands from the epoch — far enough and it never
+    # comes back. Every spec must therefore reach a verdict, whatever its
+    # magnitude, so an out-of-range value has to be rejected before it is
+    # applied rather than after.
+    property "a -v adjustment always reaches a verdict, however large" do
+      check all(
+              sign <- member_of(~w(+ -)),
+              digits <- integer(1..40),
+              unit <- member_of(~w(y m w d H M S))
+            ) do
+        spec = "#{sign}#{String.duplicate("9", digits)}#{unit}"
+        task = Task.async(fn -> JustBash.exec(JustBash.new(), "date -v#{spec} '+%F'") end)
+
+        case Task.yield(task, 2_000) || Task.shutdown(task, :brutal_kill) do
+          {:ok, {result, _}} ->
+            assert result.exit_code in [0, 1]
+
+          nil ->
+            flunk("date -v#{spec} did not terminate within 2s")
+        end
+      end
+    end
+
     # An adjustment we cannot apply must be rejected, never silently skipped.
-    @base "2024-06-15 12:00:00"
+    # Named for its describe block rather than plainly, because a module
+    # attribute is module-wide however deeply it is indented.
+    @adjustment_base "2024-06-15 12:00:00"
 
     property "a -v adjustment is either applied or rejected, never ignored" do
       check all(
               spec <- string([?a..?z, ?A..?Z, ?0..?9, ?+, ?-, ?.], min_length: 1, max_length: 5)
             ) do
         bash = JustBash.new()
-        {result, _} = JustBash.exec(bash, "date -d '#{@base}' -v#{spec} '+%F %T'")
+        {result, _} = JustBash.exec(bash, "date -d '#{@adjustment_base}' -v#{spec} '+%F %T'")
+        # Deliberately a second copy of the implementation's grammar, not a
+        # shared constant: an oracle that imports the rule it is checking cannot
+        # catch the rule being wrong.
         parsed = Regex.run(~r/^([+-])(\d+)([ymwdHMS])$/, spec)
 
         case {result.exit_code, parsed} do
@@ -452,7 +505,7 @@ defmodule JustBash.PropertyTest do
           # Applied: every unit strictly moves the clock, so only a zero
           # adjustment may leave the base date untouched.
           {0, [_, sign, value, _unit]} ->
-            moved = result.stdout != "#{@base}\n"
+            moved = result.stdout != "#{@adjustment_base}\n"
             assert moved == (String.to_integer(sign <> value) != 0)
 
           {0, nil} ->

--- a/test/property_test.exs
+++ b/test/property_test.exs
@@ -411,6 +411,55 @@ defmodule JustBash.PropertyTest do
         assert result.stdout == expected <> "\n"
       end
     end
+
+    # The failure mode this guards is worse than a missing flag: an option that
+    # gets dropped prints the current date at exit 0, so the caller reads a
+    # wrong answer as a real one. Exit 0 is only ever allowed for an option we
+    # actually implement.
+    @implemented ~w(-u -j -I -d -f -r -v)
+
+    property "an option date does not implement never exits 0" do
+      check all(
+              flag <- string([?a..?z, ?A..?Z, ?0..?9, ?-, ?=, ?+], min_length: 1, max_length: 6),
+              not Enum.any?(@implemented, &String.starts_with?("-" <> flag, &1))
+            ) do
+        bash = JustBash.new()
+        {result, _} = JustBash.exec(bash, "date -#{flag} '+%Y-%m-%d'")
+
+        assert result.exit_code == 1, "date -#{flag} exited 0 with #{inspect(result.stdout)}"
+        assert result.stdout == ""
+        assert result.stderr =~ "date:"
+      end
+    end
+
+    # An adjustment we cannot apply must be rejected, never silently skipped.
+    @base "2024-06-15 12:00:00"
+
+    property "a -v adjustment is either applied or rejected, never ignored" do
+      check all(
+              spec <- string([?a..?z, ?A..?Z, ?0..?9, ?+, ?-, ?.], min_length: 1, max_length: 5)
+            ) do
+        bash = JustBash.new()
+        {result, _} = JustBash.exec(bash, "date -d '#{@base}' -v#{spec} '+%F %T'")
+        parsed = Regex.run(~r/^([+-])(\d+)([ymwdHMS])$/, spec)
+
+        case {result.exit_code, parsed} do
+          # Rejected: unparseable, or a result outside the ISO calendar.
+          {1, _} ->
+            assert result.stdout == ""
+            assert result.stderr =~ "date:"
+
+          # Applied: every unit strictly moves the clock, so only a zero
+          # adjustment may leave the base date untouched.
+          {0, [_, sign, value, _unit]} ->
+            moved = result.stdout != "#{@base}\n"
+            assert moved == (String.to_integer(sign <> value) != 0)
+
+          {0, nil} ->
+            flunk("date -v#{spec} was ignored: exit 0 with #{inspect(result.stdout)}")
+        end
+      end
+    end
   end
 
   describe "file operations properties" do


### PR DESCRIPTION
## Summary

`date` dropped every argument it did not recognise and exited 0, so an unimplemented flag returned *the current date* as if it were the answer. This closes the general case: nothing option-shaped is silently ignored any more, and `-v` / `-r` are implemented rather than dropped.

Against `274e86b`:

| command | before | after (= real `date`) |
| --- | --- | --- |
| `date -v+6m +%Y-%m-%d` | `2026-08-04` exit 0 | `2027-02-04` exit 0 |
| `date -v-1y +%Y-%m-%d` | `2026-08-04` exit 0 | `2025-08-04` exit 0 |
| `date -r 0 +%Y-%m-%d` | `2026-08-04` exit 0 | `1970-01-01` exit 0 |
| `date --definitely-not-a-flag` | `2026-08-04` exit 0 | exit 1, `illegal option` |

(`-r 0` is `1970-01-01` rather than BSD's `1969-12-31` because output is always UTC.)

## Changes

**Failing loudly.** The catch-all becomes three clauses: an option-shaped argument is `illegal option` plus a usage block naming every supported flag — a caller who can only run the command learns the surface by running it; a bare operand is real date's set-the-clock form, so `date 1432` fails the way an unprivileged real date does and anything else is `illegal time format`; a flag whose value is missing (`date -d`, `-f`, `-r`, `-v`) was the same silent exit 0 and is now `option requires an argument`.

**`-v[+-]val[ymwdHMS]`**, applied in the order given, which is how BSD composes `-v+1m -v-1d`. Month adjustments preserve the day of the month and clamp to the target month's last day; year adjustments move the year field and let an impossible result normalize forward. BSD really does differ here — `-v+1y` off Feb 29 is Mar 1 where `-v+12m` is Feb 28 — which only turned up under differential testing.

**`-r SECONDS`**, negative included. BSD's set-a-field form (`-v1d`, `-vfri`) and `-r`'s filename form are rejected with a message rather than approximated, since guessing is the behaviour this PR exists to remove.

**Attached flag values** (`-d2024-06-15`), as getopt allows, so the GNU spelling isn't mistaken for an illegal option.

**Range**: a result outside the ISO calendar (`-v+99999y`) is an error, not a year printed as `-97973`; `-r` past the representable range was raising `ArgumentError` out of `exec/2`.

## Related Issues

Fixes #64.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

Note for review: an argument that used to be ignored now exits 1. `date -R`, `date --help` and a bare `date 0613162785` are the realistic cases — all previously returned a wrong answer at exit 0.

## Testing

- [x] Added new tests
- [x] All existing tests pass
- [x] Tested manually

47 unit tests, plus two properties that guard the defect class rather than these flags: *an option date does not implement never exits 0*, and *a `-v` adjustment is either applied or rejected, never ignored*.

`-v` was differential-tested against real BSD `date` over 686 base × spec combinations and 1200 randomized cases with up to three composed adjustments — **0 mismatches**. No bash fixtures added: those are recorded against GNU `date` in Docker, which has no `-v` and words its errors differently.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly (the `date` moduledoc, including what is deliberately partial)
- [ ] I have updated the CHANGELOG.md — release-please generates it
