### PR TITLE
test: enumerate the fixture corpus instead of growing it by example

### DIFF
--- a/lib/just_bash/commands/date.ex
+++ b/lib/just_bash/commands/date.ex
@@ -25,11 +25,18 @@ defmodule JustBash.Commands.Date do
   that from a legitimate literal. `test/fixtures/bash_cases/date_matrix.json`
   enumerates the whole conversion alphabet against real GNU date to keep it so.
 
-  Flags: `-d` / `--date=`, `-I[FMT]` / `--iso-8601[=FMT]`, `-R` / `--rfc-email`,
-  `-u` / `--utc` / `--universal`, `-r SECONDS`, the BSD `-v` adjustments, and the
-  BSD `-j` / `-f` pair. Values may be attached or separate (`-d2024-06-15`),
-  no-argument flags may cluster (`-ju`), and `--` ends option parsing — the
-  getopt conventions real date inherits.
+  Flags: `-d` / `--date=`, `-r SECONDS|FILE` / `--reference=FILE`, `-I[FMT]` /
+  `--iso-8601[=FMT]`, `-R` / `--rfc-email`, `-u` / `--utc` / `--universal`, the
+  BSD `-v` adjustments, and the BSD `-j` / `-f` pair. Values may be attached or
+  separate (`-d2024-06-15`), no-argument flags may cluster (`-ju`), and `--` ends
+  option parsing — the getopt conventions real date inherits.
+
+  `-r` reads both spellings the flag has in the wild, as FreeBSD's date does: a
+  numeric value is epoch seconds, and anything else names a file whose
+  modification time to report. GNU's `--reference=FILE` is always a file. The VFS
+  records mtimes, so the file's time comes from the sandbox rather than the host
+  clock, and a failure to read it reports the real error kind — descending
+  through a regular file is ENOTDIR, not "no such file".
 
   Everything else is an error. An unimplemented flag must not be dropped:
   ignoring it would print the current date at exit 0, which a caller cannot
@@ -40,13 +47,14 @@ defmodule JustBash.Commands.Date do
   (`illegal option -- X`), since BSD names a long option by its second `-` and
   so identifies nothing.
 
-  Two BSD features are deliberately partial, and say so rather than guessing:
+  One BSD feature is deliberately partial, and says so rather than guessing:
   `-v` implements only the relative form (`[+-]val[ymwdHMS]`), not the
-  set-a-field form (`-v1d`, `-vfri`); `-r` takes epoch seconds, not a filename.
+  set-a-field form (`-v1d`, `-vfri`).
   """
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.FS
 
   @default_format "%a %b %d %H:%M:%S UTC %Y"
   @rfc_format "%a, %d %b %Y %H:%M:%S %z"
@@ -87,12 +95,33 @@ defmodule JustBash.Commands.Date do
 
   @impl true
   def execute(bash, args, _stdin) do
-    with {:ok, opts} <- parse_args(args),
-         {:ok, datetime} <- adjust(opts.datetime || DateTime.utc_now(), opts.adjustments) do
-      format = opts.format || opts.iso_format || opts.rfc_format || @default_format
-      {Command.ok(format_datetime(datetime, format) <> "\n"), bash}
-    else
+    case parse_args(args) do
+      {:ok, opts} -> emit(bash, opts)
       {:error, msg} -> {Command.error(msg), bash}
+    end
+  end
+
+  defp emit(bash, %{reference: nil} = opts) do
+    render_at(bash, opts, opts.datetime || DateTime.utc_now())
+  end
+
+  # A reference file's modification time. The VFS records mtimes, so this reads
+  # from the sandbox rather than the host clock.
+  defp emit(bash, %{reference: path} = opts) do
+    case FS.stat(bash.fs, FS.resolve_path(bash.cwd, path)) do
+      {:ok, %{mtime: mtime}, fs} -> render_at(%{bash | fs: fs}, opts, mtime)
+      {:error, error} -> {Command.error("date: #{path}: #{FS.strerror(error)}\n"), bash}
+    end
+  end
+
+  defp render_at(bash, opts, datetime) do
+    case adjust(datetime, opts.adjustments) do
+      {:ok, adjusted} ->
+        format = opts.format || opts.iso_format || opts.rfc_format || @default_format
+        {Command.ok(format_datetime(adjusted, format) <> "\n"), bash}
+
+      {:error, msg} ->
+        {Command.error(msg), bash}
     end
   end
 
@@ -102,6 +131,7 @@ defmodule JustBash.Commands.Date do
       iso_format: nil,
       rfc_format: nil,
       datetime: nil,
+      reference: nil,
       input_format: nil,
       adjustments: [],
       no_set: false
@@ -124,10 +154,14 @@ defmodule JustBash.Commands.Date do
   defp parse_args(["-d" <> date_str | rest], opts), do: put_datetime(date_str, rest, opts)
   defp parse_args(["--date=" <> date_str | rest], opts), do: put_datetime(date_str, rest, opts)
 
-  # BSD date: -r takes the time from an epoch timestamp.
+  # -r takes an epoch timestamp or a file to read a modification time from.
   defp parse_args(["-r"], _opts), do: {:error, missing_argument("-r")}
-  defp parse_args(["-r", secs | rest], opts), do: put_epoch(secs, rest, opts)
-  defp parse_args(["-r" <> secs | rest], opts), do: put_epoch(secs, rest, opts)
+  defp parse_args(["-r", value | rest], opts), do: put_epoch_or_reference(value, rest, opts)
+  defp parse_args(["-r" <> value | rest], opts), do: put_epoch_or_reference(value, rest, opts)
+
+  # GNU's spelling of the same flag names a file and only a file, so a numeric
+  # value here is a file called "0" rather than the epoch.
+  defp parse_args(["--reference=" <> path | rest], opts), do: put_reference(path, rest, opts)
 
   # BSD date: -v adjusts a field of the date, as many times as given.
   defp parse_args(["-v"], _opts), do: {:error, missing_argument("-v")}
@@ -249,15 +283,25 @@ defmodule JustBash.Commands.Date do
     end
   end
 
-  defp put_epoch(secs, rest, opts) do
-    with {seconds, ""} <- Integer.parse(secs),
-         {:ok, datetime} <- DateTime.from_unix(seconds) do
-      parse_args(rest, %{opts | datetime: datetime})
-    else
-      {:error, :invalid_unix_time} -> {:error, "date: invalid time\n"}
-      _not_a_number -> {:error, "date: illegal time value -- #{secs}\n" <> usage()}
+  # `-r` reads both spellings the flag has in the wild, the way FreeBSD's date
+  # does: a number is epoch seconds, and anything else names a file. Falling back
+  # to the file is what makes an unparseable value an error about that file
+  # rather than a "not a number" the caller cannot act on.
+  defp put_epoch_or_reference(value, rest, opts) do
+    case Integer.parse(value) do
+      {seconds, ""} -> put_epoch(seconds, rest, opts)
+      _not_a_number -> put_reference(value, rest, opts)
     end
   end
+
+  defp put_epoch(seconds, rest, opts) do
+    case DateTime.from_unix(seconds) do
+      {:ok, datetime} -> parse_args(rest, %{opts | datetime: datetime})
+      {:error, :invalid_unix_time} -> {:error, "date: invalid time\n"}
+    end
+  end
+
+  defp put_reference(path, rest, opts), do: parse_args(rest, %{opts | reference: path})
 
   defp put_adjustment(spec, rest, opts) do
     case parse_adjustment(spec) do
@@ -292,7 +336,7 @@ defmodule JustBash.Commands.Date do
 
   defp usage do
     """
-    usage: date [-u] [-d datestr | -r seconds] [-j] [-f input_fmt]
+    usage: date [-u] [-d datestr | -r seconds|file] [-j] [-f input_fmt]
                 [-I[date|hours|minutes|seconds|ns]] [-v[+|-]val[y|m|w|d|H|M|S]]
                 [+output_fmt]
     """

--- a/lib/just_bash/commands/date.ex
+++ b/lib/just_bash/commands/date.ex
@@ -12,31 +12,46 @@ defmodule JustBash.Commands.Date do
     * zone offset — `%z` (`+0000`), `%:z`, `%::z`, `%:::z`
     * literal — `%%`, `%n`, `%t`
 
-  Directives accept GNU's field flags between the `%` and the conversion:
-  `-` (no padding), `_` (space padding), `0` (zero padding), `^` (upper case) and
-  `#` (also upper case, for conversions whose default is mixed case). A numeric
-  field width may follow the flags, as in `%03d`.
+  A directive is `%`, then field flags, then an optional width, then an optional
+  locale modifier, then the conversion — `%_5Od` is all four at once. The flags
+  are `-` (no padding), `_` (space padding), `0` (zero padding), `^` (upper case)
+  and `#` (swap the conversion's default case). The modifiers are `E` and `O`,
+  which select nothing in the C locale but are accepted only for the conversions
+  GNU accepts them for; the rest pass through verbatim.
+
+  None of that composes the way it reads. A flag reaches a numeric field and not
+  a compound one, so `%-T` is "09:05:03" and only `%-D` loses its year padding;
+  the last padding flag wins outright, so `%-0d` is "05"; a width *replaces* a
+  conversion's own width rather than raising it, so `%1d` is "5"; and a modifier
+  drops the padding flag entirely, so `%-Od` is "05". Every one of those rules is
+  recorded in `test/fixtures/bash_cases/date_matrix.json` against real GNU date
+  rather than reasoned about here — this paragraph describes the recording, it
+  does not define it.
 
   An unrecognized directive is emitted verbatim (`%J` → `%J`), as GNU date does,
   so a caller can tell the difference between "not supported" and a real value.
   That passthrough is only safe because the supported set is complete enough that
   reaching it means the directive really does not exist: a directive that *is*
   real but unimplemented would print itself at exit 0, and a caller cannot tell
-  that from a legitimate literal. `test/fixtures/bash_cases/date_matrix.json`
-  enumerates the whole conversion alphabet against real GNU date to keep it so.
+  that from a legitimate literal. The matrix enumerates the whole conversion
+  alphabet — crossed with every flag, width and modifier — to keep it so.
 
-  Flags: `-d` / `--date=`, `-r SECONDS|FILE` / `--reference=FILE`, `-I[FMT]` /
+  Flags: `-d` / `--date`, `-r SECONDS|FILE` / `--reference FILE`, `-I[FMT]` /
   `--iso-8601[=FMT]`, `-R` / `--rfc-email`, `-u` / `--utc` / `--universal`, the
-  BSD `-v` adjustments, and the BSD `-j` / `-f` pair. Values may be attached or
-  separate (`-d2024-06-15`), no-argument flags may cluster (`-ju`), and `--` ends
-  option parsing — the getopt conventions real date inherits.
+  BSD `-v` adjustments, and the BSD `-j` / `-f` pair. A value may be attached or
+  separate (`-d2024-06-15`, `--date=2024-06-15`), no-argument flags may cluster
+  (`-ju`), and `--` ends option parsing — the getopt conventions real date
+  inherits.
 
   `-r` reads both spellings the flag has in the wild, as FreeBSD's date does: a
   numeric value is epoch seconds, and anything else names a file whose
-  modification time to report. GNU's `--reference=FILE` is always a file. The VFS
+  modification time to report. GNU's `--reference` is always a file. The VFS
   records mtimes, so the file's time comes from the sandbox rather than the host
   clock, and a failure to read it reports the real error kind — descending
   through a regular file is ENOTDIR, not "no such file".
+
+  `-d` and `-r` each name the instant to print, so giving both is an error rather
+  than a silent choice between two answers.
 
   Everything else is an error. An unimplemented flag must not be dropped:
   ignoring it would print the current date at exit 0, which a caller cannot
@@ -62,6 +77,10 @@ defmodule JustBash.Commands.Date do
   # The flags that each name an output format. They compete rather than compose,
   # so setting one when another is already set is an error however it arrived.
   @format_keys [:format, :iso_format, :rfc_format]
+
+  # `-d` and `-r` each name the instant to print. Accepting both would answer one
+  # question with two answers and report success doing it.
+  @exclusive "date: the options to specify dates for printing are mutually exclusive\n"
 
   # `-v[+-]val[unit]`. The sign is what distinguishes an adjustment from BSD's
   # set-this-field form, which we do not implement.
@@ -96,18 +115,18 @@ defmodule JustBash.Commands.Date do
   @impl true
   def execute(bash, args, _stdin) do
     case parse_args(args) do
-      {:ok, opts} -> emit(bash, opts)
+      {:ok, opts} -> report(bash, opts)
       {:error, msg} -> {Command.error(msg), bash}
     end
   end
 
-  defp emit(bash, %{reference: nil} = opts) do
+  defp report(bash, %{reference: nil} = opts) do
     render_at(bash, opts, opts.datetime || DateTime.utc_now())
   end
 
-  # A reference file's modification time. The VFS records mtimes, so this reads
-  # from the sandbox rather than the host clock.
-  defp emit(bash, %{reference: path} = opts) do
+  # `-r FILE` reports the file's modification time. The VFS records mtimes, so
+  # this reads from the sandbox rather than the host clock.
+  defp report(bash, %{reference: path} = opts) do
     case FS.stat(bash.fs, FS.resolve_path(bash.cwd, path)) do
       {:ok, %{mtime: mtime}, fs} -> render_at(%{bash | fs: fs}, opts, mtime)
       {:error, error} -> {Command.error("date: #{path}: #{FS.strerror(error)}\n"), bash}
@@ -153,6 +172,7 @@ defmodule JustBash.Commands.Date do
   defp parse_args(["-d", date_str | rest], opts), do: put_datetime(date_str, rest, opts)
   defp parse_args(["-d" <> date_str | rest], opts), do: put_datetime(date_str, rest, opts)
   defp parse_args(["--date=" <> date_str | rest], opts), do: put_datetime(date_str, rest, opts)
+  defp parse_args(["--date", date_str | rest], opts), do: put_datetime(date_str, rest, opts)
 
   # -r takes an epoch timestamp or a file to read a modification time from.
   defp parse_args(["-r"], _opts), do: {:error, missing_argument("-r")}
@@ -162,6 +182,7 @@ defmodule JustBash.Commands.Date do
   # GNU's spelling of the same flag names a file and only a file, so a numeric
   # value here is a file called "0" rather than the epoch.
   defp parse_args(["--reference=" <> path | rest], opts), do: put_reference(path, rest, opts)
+  defp parse_args(["--reference", path | rest], opts), do: put_reference(path, rest, opts)
 
   # BSD date: -v adjusts a field of the date, as many times as given.
   defp parse_args(["-v"], _opts), do: {:error, missing_argument("-v")}
@@ -202,6 +223,14 @@ defmodule JustBash.Commands.Date do
   defp parse_args([<<?-, flag, rest::binary>> | args], opts)
        when flag in @no_argument_flags and rest != "" do
     parse_args([<<?-, flag>>, "-" <> rest | args], opts)
+  end
+
+  # A long option is named in full, as GNU words it, where a short one is named
+  # by its character. Either way "needs an argument" is a distinct error from
+  # "no such flag" — the point of refusing a flag is that the message says what
+  # to do differently.
+  defp parse_args([flag], _opts) when flag in ["--date", "--reference"] do
+    {:error, "date: option '#{flag}' requires an argument\n" <> usage()}
   end
 
   # When we have an input_format set (BSD -f flag) and encounter a non-option arg
@@ -276,6 +305,13 @@ defmodule JustBash.Commands.Date do
     end
   end
 
+  # A reference file and a spelled-out instant each answer "which instant", so
+  # giving both is an error rather than a silent choice between two answers. Two
+  # spellings of the *same* kind still compose the way real date lets them: the
+  # last one wins.
+  defp put_datetime(_date_str, _rest, %{reference: reference}) when reference != nil,
+    do: {:error, exclusive()}
+
   defp put_datetime(date_str, rest, opts) do
     case parse_date_string(date_str) do
       {:ok, datetime} -> parse_args(rest, %{opts | datetime: datetime})
@@ -294,6 +330,9 @@ defmodule JustBash.Commands.Date do
     end
   end
 
+  defp put_epoch(_seconds, _rest, %{reference: reference}) when reference != nil,
+    do: {:error, exclusive()}
+
   defp put_epoch(seconds, rest, opts) do
     case DateTime.from_unix(seconds) do
       {:ok, datetime} -> parse_args(rest, %{opts | datetime: datetime})
@@ -301,7 +340,12 @@ defmodule JustBash.Commands.Date do
     end
   end
 
+  defp put_reference(_path, _rest, %{datetime: datetime}) when datetime != nil,
+    do: {:error, exclusive()}
+
   defp put_reference(path, rest, opts), do: parse_args(rest, %{opts | reference: path})
+
+  defp exclusive, do: @exclusive <> usage()
 
   defp put_adjustment(spec, rest, opts) do
     case parse_adjustment(spec) do
@@ -423,8 +467,13 @@ defmodule JustBash.Commands.Date do
   end
 
   # `@N` is seconds since the epoch, the one -d form that is not a calendar date.
+  # Matching its shape says nothing about whether the number is a representable
+  # instant, so the conversion has to be allowed to refuse it.
   defp parse_epoch("@" <> seconds) do
-    {:ok, seconds |> String.to_integer() |> DateTime.from_unix!()}
+    case seconds |> String.to_integer() |> DateTime.from_unix() do
+      {:ok, datetime} -> {:ok, datetime}
+      {:error, _reason} -> {:error, :invalid_format}
+    end
   end
 
   defp parse_date_only(str) do
@@ -476,49 +525,50 @@ defmodule JustBash.Commands.Date do
   # GNU date. The scan is byte-wise, not codepoint-wise: format strings are raw
   # binaries and need not be valid UTF-8; every known directive is ASCII, and
   # passthrough reconstructs other bytes verbatim either way.
-  defp format_datetime(datetime, format), do: scan(format, datetime, [])
+  #
+  # `yr_spec` is the padding flag a compound conversion forwards to the year
+  # fields of its sub-format, and nil at the top level. See `yearish/3`.
+  defp format_datetime(datetime, format), do: scan(format, datetime, nil, [])
 
-  defp scan(<<>>, _datetime, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
+  defp scan(<<>>, _datetime, _yr_spec, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
 
   # A trailing bare `%` is literal, as in real date.
-  defp scan(<<?%>>, datetime, acc), do: scan(<<>>, datetime, ["%" | acc])
+  defp scan(<<?%>>, datetime, yr_spec, acc), do: scan(<<>>, datetime, yr_spec, ["%" | acc])
 
-  # GNU allows field flags and a width between the `%` and the conversion, so the
-  # conversion character is not at a fixed offset. The modifier run is collected
-  # first, then applied to whatever the conversion rendered.
-  defp scan(<<?%, rest::binary>>, datetime, acc) do
-    {emitted, rest} = conversion(rest, datetime)
-    scan(rest, datetime, [emitted | acc])
+  defp scan(<<?%, rest::binary>>, datetime, yr_spec, acc) do
+    {emitted, rest} = conversion(rest, datetime, yr_spec)
+    scan(rest, datetime, yr_spec, [emitted | acc])
   end
 
-  defp scan(<<char, rest::binary>>, datetime, acc) do
-    scan(rest, datetime, [<<char>> | acc])
+  defp scan(<<char, rest::binary>>, datetime, yr_spec, acc) do
+    scan(rest, datetime, yr_spec, [<<char>> | acc])
   end
 
-  # `%:z`, `%::z` and `%:::z` are the only conversions where colons are part of
-  # the directive rather than a modifier, so they are matched before flag parsing.
-  defp conversion(<<":::z", rest::binary>>, dt), do: {zone_offset(dt, :hours), rest}
-  defp conversion(<<"::z", rest::binary>>, dt), do: {zone_offset(dt, :seconds), rest}
-  defp conversion(<<":z", rest::binary>>, dt), do: {zone_offset(dt, :minutes), rest}
+  # A directive is `%`, field flags, an optional width, an optional locale
+  # modifier, then the conversion — so the conversion character is not at a fixed
+  # offset and the whole run has to be collected before anything can be rendered.
+  defp conversion(input, datetime, yr_spec) do
+    {flags, rest} = take_flags(input, [])
+    {width, rest} = take_width(rest, [])
+    {modifier, rest} = take_modifier(rest)
+    decorated? = flags != [] or width != [] or modifier != nil
 
-  defp conversion(input, dt) do
-    {flags, input} = take_flags(input, [])
-    {width, input} = take_width(input, [])
-    modified? = flags != [] or width != []
+    ctx = %{
+      flags: flags,
+      width: width,
+      modifier: modifier,
+      yr_spec: yr_spec,
+      prefix: [?%, flags, width, modifier || []]
+    }
 
-    case input do
-      # A flag run cannot take `%` as its conversion. GNU emits the flags
+    case rest do
+      # A decorated run cannot take `%` as its conversion. GNU emits the run
       # literally and begins a fresh directive at the `%`, so `%-%d` is `%-`
       # followed by `%d`, not a modified `%%`. The `%` is left unconsumed.
-      <<?%, _::binary>> when modified? ->
-        {IO.iodata_to_binary([?%, flags, width]), input}
-
-      # A trailing `%` — with any modifiers that followed it — is literal.
-      <<>> ->
-        {IO.iodata_to_binary([?%, flags, width]), <<>>}
-
-      <<char, rest::binary>> ->
-        {render(char, dt, flags, width), rest}
+      <<?%, _::binary>> when decorated? -> {IO.iodata_to_binary(ctx.prefix), rest}
+      # A run with no conversion at all is literal.
+      <<>> -> {IO.iodata_to_binary(ctx.prefix), <<>>}
+      _ -> render(rest, datetime, ctx)
     end
   end
 
@@ -534,137 +584,239 @@ defmodule JustBash.Commands.Date do
 
   defp take_width(input, acc), do: {Enum.reverse(acc), input}
 
-  # `%N` is a fractional-seconds field rather than a padded number, so a width
-  # truncates its nine digits instead of padding them (`%3N` is "000", not "000"
-  # widened) and the padding flags do not apply. GNU's handling of `_` and `-`
-  # here is stranger still — `%_N` right-pads with spaces — and is recorded as a
-  # known gap in the date matrix rather than guessed at.
-  defp render(?N, dt, _flags, []), do: nanoseconds(dt)
-  defp render(?N, dt, _flags, width), do: String.slice(nanoseconds(dt), 0, to_int(width))
+  # POSIX's alternate-representation modifiers. In the C locale they select
+  # nothing, but GNU still accepts them for some conversions and refuses them for
+  # others, and a refusal is a verbatim passthrough — see `accepts_modifier?/2`.
+  defp take_modifier(<<char, rest::binary>>) when char in [?E, ?O], do: {<<char>>, rest}
+  defp take_modifier(input), do: {nil, input}
 
-  # An unknown conversion is reconstructed verbatim, modifiers included, so the
-  # passthrough is byte-exact rather than approximately right.
-  defp render(char, dt, flags, width) do
-    case directive(char, dt) do
-      {:unknown, verbatim} -> IO.iodata_to_binary([?%, flags, width, verbatim])
-      rendered -> rendered |> pad(flags, width) |> upcase(flags)
+  # The colons of `%:z` belong to the directive rather than the flag run, and
+  # `%z` is the only conversion that takes them.
+  defp render(<<":::z", rest::binary>>, _dt, %{modifier: nil} = ctx),
+    do: {emit({:zone, "0", 3}, ?z, ctx), rest}
+
+  defp render(<<"::z", rest::binary>>, _dt, %{modifier: nil} = ctx),
+    do: {emit({:zone, "0:00:00", 9}, ?z, ctx), rest}
+
+  defp render(<<":z", rest::binary>>, _dt, %{modifier: nil} = ctx),
+    do: {emit({:zone, "0:00", 6}, ?z, ctx), rest}
+
+  defp render(<<char, rest::binary>>, dt, ctx), do: {convert(char, dt, ctx), rest}
+
+  defp convert(char, dt, ctx) do
+    case {field(char, dt, ctx), ctx.modifier} do
+      {:unknown, _modifier} ->
+        passthrough(char, ctx)
+
+      {spec, nil} ->
+        emit(spec, char, ctx)
+
+      {spec, modifier} ->
+        if accepts_modifier?(char, modifier) do
+          # A modifier makes the conversion render its default form: the padding
+          # flags are dropped and the width right-aligns whatever came out.
+          spec
+          |> emit(char, %{ctx | flags: Enum.reject(ctx.flags, &(&1 in [?-, ?_, ?0])), width: []})
+          |> pad_string(ctx.width, ?\s)
+        else
+          passthrough(char, ctx)
+        end
     end
   end
 
-  # Padding is decided once from the whole flag run rather than folded flag by
-  # flag. `-` strips the field's padding, so applying `0` afterwards would have
-  # nothing left to measure against — yet GNU renders `%-0d` as "05", because the
-  # last padding flag wins outright.
-  defp pad(rendered, flags, width) do
-    case padding_flag(flags) do
-      # `-` suppresses padding, and a width alongside it is ignored.
-      ?- -> unpadded(rendered)
-      ?_ -> String.pad_leading(unpadded(rendered), field_width(rendered, width), " ")
-      ?0 -> String.pad_leading(unpadded(rendered), field_width(rendered, width), "0")
-      # No padding flag: an explicit width still pads, with zeros. Without one the
-      # conversion's own padding stands, which is how `%e`, `%k` and `%l` keep the
-      # spaces that distinguish them from `%d`, `%H` and `%I`.
-      nil when width != [] -> String.pad_leading(unpadded(rendered), to_int(width), "0")
-      nil -> rendered
-    end
+  # An unknown conversion is reconstructed verbatim, every part of the run
+  # included, so the passthrough is byte-exact rather than approximately right.
+  # `^` still reaches it: GNU renders `%^Ea` as "%^EA".
+  defp passthrough(char, ctx) do
+    ctx.prefix |> IO.iodata_to_binary() |> Kernel.<>(<<char>>) |> upcase_if(?^ in ctx.flags)
   end
 
-  defp padding_flag(flags), do: flags |> Enum.filter(&(&1 in [?-, ?_, ?0])) |> List.last()
+  defp emit({:num, value, digits, pad}, char, ctx) do
+    value
+    |> pad_number(width_or(ctx.width, digits), padding_flag(ctx.flags) || pad)
+    |> apply_case(char, ctx.flags)
+  end
 
-  defp field_width(rendered, []), do: String.length(rendered)
-  defp field_width(_rendered, width), do: to_int(width)
+  defp emit({:zone, buf, digits}, char, ctx) do
+    buf
+    |> pad_zone(width_or(ctx.width, digits), padding_flag(ctx.flags) || ?0)
+    |> apply_case(char, ctx.flags)
+  end
+
+  defp emit({:text, string}, char, ctx) do
+    string
+    |> apply_case(char, ctx.flags)
+    |> pad_string(ctx.width, padding_flag(ctx.flags) || ?\s)
+  end
+
+  # A compound conversion is a sub-format, and its own padding flag reaches the
+  # year fields inside it and nothing else: `%-D` is "01/05/5", where the month
+  # and day keep the padding the year just lost.
+  defp emit({:sub, subformat, dt}, char, ctx) do
+    subformat
+    |> scan(dt, padding_flag(ctx.flags), [])
+    |> apply_case(char, ctx.flags)
+    |> pad_string(ctx.width, padding_flag(ctx.flags) || ?\s)
+  end
+
+  # `%N` is a fractional-seconds field rather than a padded number: a width says
+  # how many of its nine digits to print, extending with zeros past nine rather
+  # than stopping, and the padding flags do not apply. GNU's handling of `_` and
+  # `-` here is stranger still — `%_N` right-pads with spaces — and is recorded
+  # as a known gap in the date matrix rather than guessed at.
+  defp emit({:nanoseconds, dt}, _char, ctx), do: nanoseconds(dt, width_or(ctx.width, 9))
+
+  defp width_or([], digits), do: digits
+  defp width_or(width, _digits), do: to_int(width)
 
   defp to_int(width), do: width |> IO.iodata_to_binary() |> String.to_integer()
 
-  # The conversion's own padding, removed so a flag can restate it. A field that
-  # is all padding ("00" for midnight) still has to print one digit.
-  defp unpadded(rendered) do
-    case rendered |> String.trim_leading("0") |> String.trim_leading(" ") do
-      "" -> "0"
-      trimmed -> trimmed
+  # The last padding flag wins outright rather than folding one at a time: `-`
+  # strips a field's padding, so applying `0` afterwards would have nothing left
+  # to measure against — yet GNU renders `%-0d` as "05".
+  defp padding_flag(flags), do: flags |> Enum.filter(&(&1 in [?-, ?_, ?0])) |> List.last()
+
+  defp pad_number(value, digits, pad) do
+    {sign, magnitude} =
+      if value < 0,
+        do: {"-", Integer.to_string(-value)},
+        else: {"", Integer.to_string(value)}
+
+    case pad do
+      ?- -> sign <> magnitude
+      ?_ -> String.pad_leading(sign <> magnitude, digits, " ")
+      ?0 -> sign <> String.pad_leading(magnitude, max(digits - byte_size(sign), 0), "0")
     end
   end
 
-  # Both `^` and `#` upper-case here. GNU documents `#` as case-swapping, but
-  # every conversion whose default is mixed case (`%a`, `%A`, `%b`, `%B`, `%p`)
-  # swaps to upper, and the rest have no case to swap.
-  defp upcase(value, flags) do
-    if Enum.any?(flags, &(&1 in [?^, ?#])), do: String.upcase(value), else: value
+  # The zone offset carries a sign that is always printed, and the width covers
+  # it: `%_z` is "   +0" but `%0z` is "+0000", the same five columns filled from
+  # opposite sides of the sign.
+  defp pad_zone(buf, _digits, ?-), do: "+" <> buf
+  defp pad_zone(buf, digits, ?_), do: String.pad_leading("+" <> buf, digits, " ")
+  defp pad_zone(buf, digits, ?0), do: "+" <> String.pad_leading(buf, max(digits - 1, 0), "0")
+
+  # A width pads text and compound conversions too, where no padding flag does —
+  # except `-`, which suppresses padding here as everywhere.
+  defp pad_string(string, [], _pad), do: string
+  defp pad_string(string, _width, ?-), do: string
+  defp pad_string(string, width, ?0), do: String.pad_leading(string, to_int(width), "0")
+  defp pad_string(string, width, _pad), do: String.pad_leading(string, to_int(width), " ")
+
+  # `^` upper-cases; `#` swaps whatever case the conversion's default has, which
+  # is upper for the day and month names and lower for `%p` and `%Z`. `%P` is the
+  # deliberately-lowercase spelling of `%p` and neither flag disturbs it, and `#`
+  # does not reach `%c` though `^` does.
+  defp apply_case(value, char, flags) do
+    cond do
+      ?# in flags and char in ~c"pPZ" -> String.downcase(value)
+      ?# in flags and char in ~c"aAbBh" -> String.upcase(value)
+      ?^ in flags and char != ?P -> String.upcase(value)
+      true -> value
+    end
   end
 
-  # Compound directives are composed from their single-field parts so the two
-  # can't drift.
-  defp directive(?F, dt), do: "#{directive(?Y, dt)}-#{directive(?m, dt)}-#{directive(?d, dt)}"
-  defp directive(?T, dt), do: "#{directive(?H, dt)}:#{directive(?M, dt)}:#{directive(?S, dt)}"
-  defp directive(?R, dt), do: "#{directive(?H, dt)}:#{directive(?M, dt)}"
-  defp directive(?D, dt), do: "#{directive(?m, dt)}/#{directive(?d, dt)}/#{directive(?y, dt)}"
-  defp directive(?x, dt), do: directive(?D, dt)
-  defp directive(?X, dt), do: directive(?T, dt)
+  defp upcase_if(value, true), do: String.upcase(value)
+  defp upcase_if(value, false), do: value
 
-  defp directive(?r, dt),
-    do: "#{directive(?I, dt)}:#{directive(?M, dt)}:#{directive(?S, dt)} #{directive(?p, dt)}"
+  # Conversions GNU accepts each modifier for. Enumerated from real date in
+  # `test/fixtures/bash_cases/date_matrix.json` rather than derived: the two sets
+  # overlap without containing each other (`%Eq` renders, `%Oq` does not), and a
+  # wrong guess shows up as a directive printing itself at exit 0.
+  @e_conversions ~c"cCnpPqrRstTuxXyYzZ"
+  @o_conversions ~c"bBCdegGhHIjklmMnNpPrRsStTuUVwWyzZ"
 
-  defp directive(?c, dt) do
-    "#{directive(?a, dt)} #{directive(?b, dt)} #{directive(?e, dt)} #{directive(?T, dt)} #{directive(?Y, dt)}"
+  defp accepts_modifier?(char, "E"), do: char in @e_conversions
+  defp accepts_modifier?(char, "O"), do: char in @o_conversions
+
+  # Compound conversions built from a sub-format, so the two can't drift and so
+  # a forwarded padding flag reaches the same fields GNU's does.
+  defp field(?F, dt, _ctx), do: {:sub, "%Y-%m-%d", dt}
+  defp field(?D, dt, _ctx), do: {:sub, "%m/%d/%y", dt}
+  defp field(?T, dt, _ctx), do: {:sub, "%H:%M:%S", dt}
+  defp field(?R, dt, _ctx), do: {:sub, "%H:%M", dt}
+
+  # `%c`, `%x`, `%X` and `%r` come from the locale rather than a GNU sub-format,
+  # and no padding flag reaches them — `%-x` keeps the padding `%-D` drops, for
+  # the same "%m/%d/%y". The year in `%c` has no four-digit minimum either.
+  defp field(?c, dt, _ctx) do
+    {:text,
+     "#{short_day_name(dt)} #{short_month_name(dt)} #{space_pad2(dt.day)} " <>
+       "#{pad2(dt.hour)}:#{pad2(dt.minute)}:#{pad2(dt.second)} #{dt.year}"}
   end
 
-  defp directive(?Y, dt), do: dt.year |> Integer.to_string() |> String.pad_leading(4, "0")
-  defp directive(?m, dt), do: pad2(dt.month)
-  defp directive(?d, dt), do: pad2(dt.day)
-  defp directive(?H, dt), do: pad2(dt.hour)
-  defp directive(?M, dt), do: pad2(dt.minute)
-  defp directive(?S, dt), do: pad2(dt.second)
-  defp directive(?y, dt), do: dt.year |> rem(100) |> pad2()
-  defp directive(?C, dt), do: dt.year |> div(100) |> pad2()
-  # `%e` is space-padded rather than zero-padded — the one directive where the
-  # difference is visible in column-aligned output.
-  defp directive(?e, dt), do: dt.day |> Integer.to_string() |> String.pad_leading(2, " ")
-  defp directive(?I, dt), do: dt.hour |> twelve_hour() |> pad2()
-  defp directive(?p, dt), do: if(dt.hour < 12, do: "AM", else: "PM")
-  defp directive(?P, dt), do: ?p |> directive(dt) |> String.downcase()
-  defp directive(?Z, dt), do: dt.zone_abbr
+  defp field(?x, dt, _ctx),
+    do: {:text, "#{pad2(dt.month)}/#{pad2(dt.day)}/#{pad2(rem(dt.year, 100))}"}
 
-  defp directive(?N, dt), do: nanoseconds(dt)
+  defp field(?X, dt, _ctx), do: {:text, "#{pad2(dt.hour)}:#{pad2(dt.minute)}:#{pad2(dt.second)}"}
 
-  defp directive(?s, dt), do: Integer.to_string(DateTime.to_unix(dt))
-  defp directive(?a, dt), do: short_day_name(dt)
-  defp directive(?A, dt), do: full_day_name(dt)
-  defp directive(?b, dt), do: short_month_name(dt)
-  defp directive(?h, dt), do: short_month_name(dt)
-  defp directive(?B, dt), do: full_month_name(dt)
-  defp directive(?j, dt), do: day_of_year(dt)
-  defp directive(?u, dt), do: Integer.to_string(Date.day_of_week(dt))
-  defp directive(?w, dt), do: Integer.to_string(rem(Date.day_of_week(dt), 7))
-  defp directive(?q, dt), do: dt.month |> then(&(div(&1 - 1, 3) + 1)) |> Integer.to_string()
+  defp field(?r, dt, _ctx) do
+    {:text, "#{pad2(twelve_hour(dt.hour))}:#{pad2(dt.minute)}:#{pad2(dt.second)} #{meridiem(dt)}"}
+  end
 
-  # `%k` and `%l` are the space-padded counterparts of `%H` and `%I`.
-  defp directive(?k, dt), do: dt.hour |> Integer.to_string() |> String.pad_leading(2, " ")
+  defp field(?Y, dt, ctx), do: yearish(dt.year, 4, ctx)
+  defp field(?G, dt, ctx), do: dt |> iso_week() |> elem(0) |> yearish(4, ctx)
+  defp field(?y, dt, ctx), do: dt.year |> rem(100) |> yearish(2, ctx)
+  defp field(?g, dt, ctx), do: dt |> iso_week() |> elem(0) |> rem(100) |> yearish(2, ctx)
+  defp field(?C, dt, ctx), do: dt.year |> div(100) |> yearish(2, ctx)
 
-  defp directive(?l, dt),
-    do: dt.hour |> twelve_hour() |> Integer.to_string() |> String.pad_leading(2, " ")
+  defp field(?m, dt, _ctx), do: {:num, dt.month, 2, ?0}
+  defp field(?d, dt, _ctx), do: {:num, dt.day, 2, ?0}
+  defp field(?H, dt, _ctx), do: {:num, dt.hour, 2, ?0}
+  defp field(?M, dt, _ctx), do: {:num, dt.minute, 2, ?0}
+  defp field(?S, dt, _ctx), do: {:num, dt.second, 2, ?0}
+  defp field(?I, dt, _ctx), do: {:num, twelve_hour(dt.hour), 2, ?0}
+  defp field(?j, dt, _ctx), do: {:num, Date.day_of_year(dt), 3, ?0}
+  defp field(?u, dt, _ctx), do: {:num, Date.day_of_week(dt), 1, ?0}
+  defp field(?w, dt, _ctx), do: {:num, rem(Date.day_of_week(dt), 7), 1, ?0}
+  defp field(?q, dt, _ctx), do: {:num, div(dt.month - 1, 3) + 1, 1, ?0}
+  defp field(?s, dt, _ctx), do: {:num, DateTime.to_unix(dt), 1, ?0}
+  defp field(?V, dt, _ctx), do: {:num, dt |> iso_week() |> elem(1), 2, ?0}
+  defp field(?U, dt, _ctx), do: {:num, week_of_year(dt, :sunday), 2, ?0}
+  defp field(?W, dt, _ctx), do: {:num, week_of_year(dt, :monday), 2, ?0}
 
-  # ISO week numbering runs on its own year: 2019-12-30 is week 1 of 2020. Erlang
-  # already implements the rule, so %G/%V defer to it rather than restating it.
-  defp directive(?G, dt), do: dt |> iso_week() |> elem(0) |> Integer.to_string()
-  defp directive(?g, dt), do: dt |> iso_week() |> elem(0) |> rem(100) |> pad2()
-  defp directive(?V, dt), do: dt |> iso_week() |> elem(1) |> pad2()
+  # `%e`, `%k` and `%l` are the space-padded counterparts of `%d`, `%H` and `%I`.
+  # The difference is a default pad character, not a different rendering.
+  defp field(?e, dt, _ctx), do: {:num, dt.day, 2, ?_}
+  defp field(?k, dt, _ctx), do: {:num, dt.hour, 2, ?_}
+  defp field(?l, dt, _ctx), do: {:num, twelve_hour(dt.hour), 2, ?_}
 
-  # %U counts weeks from the first Sunday, %W from the first Monday. Both are
-  # plain division of the elapsed days, unlike the ISO rule above.
-  defp directive(?U, dt), do: dt |> week_of_year(:sunday) |> pad2()
-  defp directive(?W, dt), do: dt |> week_of_year(:monday) |> pad2()
+  defp field(?z, _dt, _ctx), do: {:zone, "0", 5}
 
-  defp directive(?z, dt), do: zone_offset(dt, :compact)
-  defp directive(?n, _dt), do: "\n"
-  defp directive(?t, _dt), do: "\t"
-  defp directive(?%, _dt), do: "%"
-  defp directive(other, _dt), do: {:unknown, <<other>>}
+  defp field(?a, dt, _ctx), do: {:text, short_day_name(dt)}
+  defp field(?A, dt, _ctx), do: {:text, full_day_name(dt)}
+  defp field(?b, dt, _ctx), do: {:text, short_month_name(dt)}
+  defp field(?h, dt, _ctx), do: {:text, short_month_name(dt)}
+  defp field(?B, dt, _ctx), do: {:text, full_month_name(dt)}
+  defp field(?p, dt, _ctx), do: {:text, meridiem(dt)}
+  defp field(?P, dt, _ctx), do: {:text, dt |> meridiem() |> String.downcase()}
+  defp field(?Z, dt, _ctx), do: {:text, dt.zone_abbr}
+  defp field(?N, dt, _ctx), do: {:nanoseconds, dt}
+  defp field(?n, _dt, _ctx), do: {:text, "\n"}
+  defp field(?t, _dt, _ctx), do: {:text, "\t"}
+  defp field(?%, _dt, _ctx), do: {:text, "%"}
+  defp field(_other, _dt, _ctx), do: :unknown
+
+  # A compound forwards its padding flag to the year fields of its sub-format,
+  # and `%Y` loses its four-digit minimum there as well: `%-F` is "5-01-05" and
+  # `%_F` is too, while `%_Y` on its own is "   5".
+  defp yearish(value, digits, %{yr_spec: nil}), do: {:num, value, digits, ?0}
+  defp yearish(value, 4, %{yr_spec: spec}), do: {:num, value, 0, spec}
+  defp yearish(value, digits, %{yr_spec: spec}), do: {:num, value, digits, spec}
 
   defp pad2(n), do: n |> Integer.to_string() |> String.pad_leading(2, "0")
+  defp space_pad2(n), do: n |> Integer.to_string() |> String.pad_leading(2, " ")
 
-  defp nanoseconds(dt) do
+  defp meridiem(dt), do: if(dt.hour < 12, do: "AM", else: "PM")
+
+  defp nanoseconds(dt, digits) do
     {microsecond, _precision} = dt.microsecond
-    (microsecond * 1_000) |> Integer.to_string() |> String.pad_leading(9, "0")
+
+    (microsecond * 1_000)
+    |> Integer.to_string()
+    |> String.pad_leading(9, "0")
+    |> String.pad_trailing(digits, "0")
+    |> binary_part(0, digits)
   end
 
   defp iso_week(dt), do: :calendar.iso_week_number({dt.year, dt.month, dt.day})
@@ -675,12 +827,6 @@ defmodule JustBash.Commands.Date do
     weekday = Date.day_of_week(dt, first_day) - 1
     div(Date.day_of_year(dt) - 1 + 7 - weekday, 7)
   end
-
-  # Output is always UTC, so the offset is fixed; only its spelling varies.
-  defp zone_offset(_dt, :compact), do: "+0000"
-  defp zone_offset(_dt, :minutes), do: "+00:00"
-  defp zone_offset(_dt, :seconds), do: "+00:00:00"
-  defp zone_offset(_dt, :hours), do: "+00"
 
   defp twelve_hour(0), do: 12
   defp twelve_hour(hour) when hour > 12, do: hour - 12
@@ -722,9 +868,5 @@ defmodule JustBash.Commands.Date do
       ~w(January February March April May June July August September October November December),
       dt.month - 1
     )
-  end
-
-  defp day_of_year(dt) do
-    Date.day_of_year(dt) |> Integer.to_string() |> String.pad_leading(3, "0")
   end
 end

--- a/lib/just_bash/commands/date.ex
+++ b/lib/just_bash/commands/date.ex
@@ -5,19 +5,31 @@ defmodule JustBash.Commands.Date do
   Output is always UTC. Supported directives:
 
     * compound — `%F` (`%Y-%m-%d`), `%T` (`%H:%M:%S`), `%R` (`%H:%M`),
-      `%D` (`%m/%d/%y`)
-    * date — `%Y`, `%y`, `%C`, `%m`, `%d`, `%e` (space-padded), `%j`,
-      `%a`, `%A`, `%b`, `%h`, `%B`, `%u`, `%w`
-    * time — `%H`, `%M`, `%S`, `%N`, `%I`, `%p`, `%P`, `%Z`, `%s`
+      `%D` (`%m/%d/%y`), `%c`, `%x`, `%X`, `%r`
+    * date — `%Y`, `%y`, `%C`, `%m`, `%d`, `%e` (space-padded), `%j`, `%q`,
+      `%a`, `%A`, `%b`, `%h`, `%B`, `%u`, `%w`, `%G`, `%g`, `%U`, `%V`, `%W`
+    * time — `%H`, `%M`, `%S`, `%N`, `%I`, `%k`, `%l`, `%p`, `%P`, `%Z`, `%s`
+    * zone offset — `%z` (`+0000`), `%:z`, `%::z`, `%:::z`
     * literal — `%%`, `%n`, `%t`
+
+  Directives accept GNU's field flags between the `%` and the conversion:
+  `-` (no padding), `_` (space padding), `0` (zero padding), `^` (upper case) and
+  `#` (also upper case, for conversions whose default is mixed case). A numeric
+  field width may follow the flags, as in `%03d`.
 
   An unrecognized directive is emitted verbatim (`%J` → `%J`), as GNU date does,
   so a caller can tell the difference between "not supported" and a real value.
+  That passthrough is only safe because the supported set is complete enough that
+  reaching it means the directive really does not exist: a directive that *is*
+  real but unimplemented would print itself at exit 0, and a caller cannot tell
+  that from a legitimate literal. `test/fixtures/bash_cases/date_matrix.json`
+  enumerates the whole conversion alphabet against real GNU date to keep it so.
 
-  Flags: `-d` / `--date=`, `-I[FMT]` / `--iso-8601[=FMT]`, `-u`, `-r SECONDS`,
-  the BSD `-v` adjustments, and the BSD `-j` / `-f` pair. Values may be attached
-  or separate (`-d2024-06-15`), no-argument flags may cluster (`-ju`), and `--`
-  ends option parsing — the getopt conventions real date inherits.
+  Flags: `-d` / `--date=`, `-I[FMT]` / `--iso-8601[=FMT]`, `-R` / `--rfc-email`,
+  `-u` / `--utc` / `--universal`, `-r SECONDS`, the BSD `-v` adjustments, and the
+  BSD `-j` / `-f` pair. Values may be attached or separate (`-d2024-06-15`),
+  no-argument flags may cluster (`-ju`), and `--` ends option parsing — the
+  getopt conventions real date inherits.
 
   Everything else is an error. An unimplemented flag must not be dropped:
   ignoring it would print the current date at exit 0, which a caller cannot
@@ -37,6 +49,11 @@ defmodule JustBash.Commands.Date do
   alias JustBash.Commands.Command
 
   @default_format "%a %b %d %H:%M:%S UTC %Y"
+  @rfc_format "%a, %d %b %Y %H:%M:%S %z"
+
+  # The flags that each name an output format. They compete rather than compose,
+  # so setting one when another is already set is an error however it arrived.
+  @format_keys [:format, :iso_format, :rfc_format]
 
   # `-v[+-]val[unit]`. The sign is what distinguishes an adjustment from BSD's
   # set-this-field form, which we do not implement.
@@ -47,7 +64,7 @@ defmodule JustBash.Commands.Date do
   @settable_time ~r/^(\d{2}){2,6}(\.\d{2})?$/
 
   # Short flags that take no value, and so may cluster: `-ju` is `-j -u`.
-  @no_argument_flags [?j, ?u]
+  @no_argument_flags [?j, ?u, ?R]
 
   # The ISO calendar spans fewer than 3.7M days, so no adjustment larger than
   # that lands inside it from any base.
@@ -72,7 +89,7 @@ defmodule JustBash.Commands.Date do
   def execute(bash, args, _stdin) do
     with {:ok, opts} <- parse_args(args),
          {:ok, datetime} <- adjust(opts.datetime || DateTime.utc_now(), opts.adjustments) do
-      format = opts.format || opts.iso_format || @default_format
+      format = opts.format || opts.iso_format || opts.rfc_format || @default_format
       {Command.ok(format_datetime(datetime, format) <> "\n"), bash}
     else
       {:error, msg} -> {Command.error(msg), bash}
@@ -83,6 +100,7 @@ defmodule JustBash.Commands.Date do
     parse_args(args, %{
       format: nil,
       iso_format: nil,
+      rfc_format: nil,
       datetime: nil,
       input_format: nil,
       adjustments: [],
@@ -93,7 +111,7 @@ defmodule JustBash.Commands.Date do
   defp parse_args([], opts), do: finish(opts)
 
   defp parse_args(["+" <> format | rest], opts),
-    do: put_format(format, rest, opts, &parse_args/2)
+    do: put_format(:format, format, rest, opts, &parse_args/2)
 
   defp parse_args(["-I" <> spec | rest], opts), do: put_iso_format(spec, rest, opts)
   defp parse_args(["--iso-8601" | rest], opts), do: put_iso_format("", rest, opts)
@@ -128,8 +146,13 @@ defmodule JustBash.Commands.Date do
     parse_args(rest, %{opts | input_format: input_format})
   end
 
-  defp parse_args(["-u" | rest], opts) do
+  # Output is always UTC, so -u is accepted and changes nothing.
+  defp parse_args([flag | rest], opts) when flag in ["-u", "--utc", "--universal"] do
     parse_args(rest, opts)
+  end
+
+  defp parse_args([flag | rest], opts) when flag in ["-R", "--rfc-email"] do
+    put_format(:rfc_format, @rfc_format, rest, opts, &parse_args/2)
   end
 
   # Inside a cluster the next character is an option character, and `-` is not
@@ -176,7 +199,7 @@ defmodule JustBash.Commands.Date do
   defp parse_operands([], opts), do: finish(opts)
 
   defp parse_operands(["+" <> format | rest], opts),
-    do: put_format(format, rest, opts, &parse_operands/2)
+    do: put_format(:format, format, rest, opts, &parse_operands/2)
 
   defp parse_operands([date_str | rest], %{input_format: input_format} = opts)
        when input_format != nil do
@@ -202,11 +225,15 @@ defmodule JustBash.Commands.Date do
     end
   end
 
-  # Real date rejects competing output formats rather than picking one.
-  defp put_format(_format, _rest, %{iso_format: iso}, _cont) when iso != nil,
-    do: {:error, "date: multiple output formats specified\n"}
-
-  defp put_format(format, rest, opts, cont), do: cont.(rest, %{opts | format: format})
+  # Real date rejects competing output formats rather than picking one, whichever
+  # pair of flags they arrived through.
+  defp put_format(key, format, rest, opts, cont) do
+    if Enum.any?(@format_keys, &(Map.fetch!(opts, &1) != nil)) do
+      {:error, "date: multiple output formats specified\n"}
+    else
+      cont.(rest, Map.put(opts, key, format))
+    end
+  end
 
   defp put_formatted_date(date_str, rest, %{input_format: input_format} = opts, cont) do
     case parse_formatted_date(date_str, input_format) do
@@ -318,13 +345,9 @@ defmodule JustBash.Commands.Date do
     %{dt | year: year, month: month, day: min(dt.day, Calendar.ISO.days_in_month(year, month))}
   end
 
-  defp put_iso_format(_spec, _rest, %{format: format}) when format != nil do
-    {:error, "date: multiple output formats specified\n"}
-  end
-
   defp put_iso_format(spec, rest, opts) do
     case iso_format(spec) do
-      {:ok, format} -> parse_args(rest, %{opts | iso_format: format})
+      {:ok, format} -> put_format(:iso_format, format, rest, opts, &parse_args/2)
       :error -> {:error, "date: invalid argument '#{spec}' for '--iso-8601'\n"}
     end
   end
@@ -347,11 +370,17 @@ defmodule JustBash.Commands.Date do
 
   defp parse_date_string(str) do
     cond do
+      str =~ ~r/^@-?\d+$/ -> parse_epoch(str)
       str =~ ~r/^\d{4}-\d{2}-\d{2}$/ -> parse_date_only(str)
       str =~ ~r/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/ -> parse_iso_datetime(str)
       str =~ ~r/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/ -> parse_space_datetime(str)
       true -> parse_relative_date(str)
     end
+  end
+
+  # `@N` is seconds since the epoch, the one -d form that is not a calendar date.
+  defp parse_epoch("@" <> seconds) do
+    {:ok, seconds |> String.to_integer() |> DateTime.from_unix!()}
   end
 
   defp parse_date_only(str) do
@@ -361,10 +390,20 @@ defmodule JustBash.Commands.Date do
     end
   end
 
+  # An ISO timestamp with no offset is UTC here, but DateTime.from_iso8601/1
+  # requires one, so supply it rather than rejecting the most common spelling.
   defp parse_iso_datetime(str) do
     case DateTime.from_iso8601(str) do
       {:ok, dt, _offset} -> {:ok, dt}
-      _ -> {:error, :invalid_format}
+      {:error, :missing_offset} -> parse_utc_datetime(str <> "Z")
+      _error -> {:error, :invalid_format}
+    end
+  end
+
+  defp parse_utc_datetime(str) do
+    case DateTime.from_iso8601(str) do
+      {:ok, dt, _offset} -> {:ok, dt}
+      _error -> {:error, :invalid_format}
     end
   end
 
@@ -400,12 +439,113 @@ defmodule JustBash.Commands.Date do
   # A trailing bare `%` is literal, as in real date.
   defp scan(<<?%>>, datetime, acc), do: scan(<<>>, datetime, ["%" | acc])
 
-  defp scan(<<?%, directive, rest::binary>>, datetime, acc) do
-    scan(rest, datetime, [directive(directive, datetime) | acc])
+  # GNU allows field flags and a width between the `%` and the conversion, so the
+  # conversion character is not at a fixed offset. The modifier run is collected
+  # first, then applied to whatever the conversion rendered.
+  defp scan(<<?%, rest::binary>>, datetime, acc) do
+    {emitted, rest} = conversion(rest, datetime)
+    scan(rest, datetime, [emitted | acc])
   end
 
   defp scan(<<char, rest::binary>>, datetime, acc) do
     scan(rest, datetime, [<<char>> | acc])
+  end
+
+  # `%:z`, `%::z` and `%:::z` are the only conversions where colons are part of
+  # the directive rather than a modifier, so they are matched before flag parsing.
+  defp conversion(<<":::z", rest::binary>>, dt), do: {zone_offset(dt, :hours), rest}
+  defp conversion(<<"::z", rest::binary>>, dt), do: {zone_offset(dt, :seconds), rest}
+  defp conversion(<<":z", rest::binary>>, dt), do: {zone_offset(dt, :minutes), rest}
+
+  defp conversion(input, dt) do
+    {flags, input} = take_flags(input, [])
+    {width, input} = take_width(input, [])
+    modified? = flags != [] or width != []
+
+    case input do
+      # A flag run cannot take `%` as its conversion. GNU emits the flags
+      # literally and begins a fresh directive at the `%`, so `%-%d` is `%-`
+      # followed by `%d`, not a modified `%%`. The `%` is left unconsumed.
+      <<?%, _::binary>> when modified? ->
+        {IO.iodata_to_binary([?%, flags, width]), input}
+
+      # A trailing `%` — with any modifiers that followed it — is literal.
+      <<>> ->
+        {IO.iodata_to_binary([?%, flags, width]), <<>>}
+
+      <<char, rest::binary>> ->
+        {render(char, dt, flags, width), rest}
+    end
+  end
+
+  defp take_flags(<<char, rest::binary>>, acc) when char in [?-, ?_, ?0, ?^, ?#] do
+    take_flags(rest, [char | acc])
+  end
+
+  defp take_flags(input, acc), do: {Enum.reverse(acc), input}
+
+  defp take_width(<<char, rest::binary>>, acc) when char in ?0..?9 do
+    take_width(rest, [char | acc])
+  end
+
+  defp take_width(input, acc), do: {Enum.reverse(acc), input}
+
+  # `%N` is a fractional-seconds field rather than a padded number, so a width
+  # truncates its nine digits instead of padding them (`%3N` is "000", not "000"
+  # widened) and the padding flags do not apply. GNU's handling of `_` and `-`
+  # here is stranger still — `%_N` right-pads with spaces — and is recorded as a
+  # known gap in the date matrix rather than guessed at.
+  defp render(?N, dt, _flags, []), do: nanoseconds(dt)
+  defp render(?N, dt, _flags, width), do: String.slice(nanoseconds(dt), 0, to_int(width))
+
+  # An unknown conversion is reconstructed verbatim, modifiers included, so the
+  # passthrough is byte-exact rather than approximately right.
+  defp render(char, dt, flags, width) do
+    case directive(char, dt) do
+      {:unknown, verbatim} -> IO.iodata_to_binary([?%, flags, width, verbatim])
+      rendered -> rendered |> pad(flags, width) |> upcase(flags)
+    end
+  end
+
+  # Padding is decided once from the whole flag run rather than folded flag by
+  # flag. `-` strips the field's padding, so applying `0` afterwards would have
+  # nothing left to measure against — yet GNU renders `%-0d` as "05", because the
+  # last padding flag wins outright.
+  defp pad(rendered, flags, width) do
+    case padding_flag(flags) do
+      # `-` suppresses padding, and a width alongside it is ignored.
+      ?- -> unpadded(rendered)
+      ?_ -> String.pad_leading(unpadded(rendered), field_width(rendered, width), " ")
+      ?0 -> String.pad_leading(unpadded(rendered), field_width(rendered, width), "0")
+      # No padding flag: an explicit width still pads, with zeros. Without one the
+      # conversion's own padding stands, which is how `%e`, `%k` and `%l` keep the
+      # spaces that distinguish them from `%d`, `%H` and `%I`.
+      nil when width != [] -> String.pad_leading(unpadded(rendered), to_int(width), "0")
+      nil -> rendered
+    end
+  end
+
+  defp padding_flag(flags), do: flags |> Enum.filter(&(&1 in [?-, ?_, ?0])) |> List.last()
+
+  defp field_width(rendered, []), do: String.length(rendered)
+  defp field_width(_rendered, width), do: to_int(width)
+
+  defp to_int(width), do: width |> IO.iodata_to_binary() |> String.to_integer()
+
+  # The conversion's own padding, removed so a flag can restate it. A field that
+  # is all padding ("00" for midnight) still has to print one digit.
+  defp unpadded(rendered) do
+    case rendered |> String.trim_leading("0") |> String.trim_leading(" ") do
+      "" -> "0"
+      trimmed -> trimmed
+    end
+  end
+
+  # Both `^` and `#` upper-case here. GNU documents `#` as case-swapping, but
+  # every conversion whose default is mixed case (`%a`, `%A`, `%b`, `%B`, `%p`)
+  # swaps to upper, and the rest have no case to swap.
+  defp upcase(value, flags) do
+    if Enum.any?(flags, &(&1 in [?^, ?#])), do: String.upcase(value), else: value
   end
 
   # Compound directives are composed from their single-field parts so the two
@@ -414,6 +554,15 @@ defmodule JustBash.Commands.Date do
   defp directive(?T, dt), do: "#{directive(?H, dt)}:#{directive(?M, dt)}:#{directive(?S, dt)}"
   defp directive(?R, dt), do: "#{directive(?H, dt)}:#{directive(?M, dt)}"
   defp directive(?D, dt), do: "#{directive(?m, dt)}/#{directive(?d, dt)}/#{directive(?y, dt)}"
+  defp directive(?x, dt), do: directive(?D, dt)
+  defp directive(?X, dt), do: directive(?T, dt)
+
+  defp directive(?r, dt),
+    do: "#{directive(?I, dt)}:#{directive(?M, dt)}:#{directive(?S, dt)} #{directive(?p, dt)}"
+
+  defp directive(?c, dt) do
+    "#{directive(?a, dt)} #{directive(?b, dt)} #{directive(?e, dt)} #{directive(?T, dt)} #{directive(?Y, dt)}"
+  end
 
   defp directive(?Y, dt), do: dt.year |> Integer.to_string() |> String.pad_leading(4, "0")
   defp directive(?m, dt), do: pad2(dt.month)
@@ -431,10 +580,7 @@ defmodule JustBash.Commands.Date do
   defp directive(?P, dt), do: ?p |> directive(dt) |> String.downcase()
   defp directive(?Z, dt), do: dt.zone_abbr
 
-  defp directive(?N, dt) do
-    {microsecond, _precision} = dt.microsecond
-    (microsecond * 1_000) |> Integer.to_string() |> String.pad_leading(9, "0")
-  end
+  defp directive(?N, dt), do: nanoseconds(dt)
 
   defp directive(?s, dt), do: Integer.to_string(DateTime.to_unix(dt))
   defp directive(?a, dt), do: short_day_name(dt)
@@ -445,12 +591,52 @@ defmodule JustBash.Commands.Date do
   defp directive(?j, dt), do: day_of_year(dt)
   defp directive(?u, dt), do: Integer.to_string(Date.day_of_week(dt))
   defp directive(?w, dt), do: Integer.to_string(rem(Date.day_of_week(dt), 7))
+  defp directive(?q, dt), do: dt.month |> then(&(div(&1 - 1, 3) + 1)) |> Integer.to_string()
+
+  # `%k` and `%l` are the space-padded counterparts of `%H` and `%I`.
+  defp directive(?k, dt), do: dt.hour |> Integer.to_string() |> String.pad_leading(2, " ")
+
+  defp directive(?l, dt),
+    do: dt.hour |> twelve_hour() |> Integer.to_string() |> String.pad_leading(2, " ")
+
+  # ISO week numbering runs on its own year: 2019-12-30 is week 1 of 2020. Erlang
+  # already implements the rule, so %G/%V defer to it rather than restating it.
+  defp directive(?G, dt), do: dt |> iso_week() |> elem(0) |> Integer.to_string()
+  defp directive(?g, dt), do: dt |> iso_week() |> elem(0) |> rem(100) |> pad2()
+  defp directive(?V, dt), do: dt |> iso_week() |> elem(1) |> pad2()
+
+  # %U counts weeks from the first Sunday, %W from the first Monday. Both are
+  # plain division of the elapsed days, unlike the ISO rule above.
+  defp directive(?U, dt), do: dt |> week_of_year(:sunday) |> pad2()
+  defp directive(?W, dt), do: dt |> week_of_year(:monday) |> pad2()
+
+  defp directive(?z, dt), do: zone_offset(dt, :compact)
   defp directive(?n, _dt), do: "\n"
   defp directive(?t, _dt), do: "\t"
   defp directive(?%, _dt), do: "%"
-  defp directive(other, _dt), do: <<?%, other>>
+  defp directive(other, _dt), do: {:unknown, <<other>>}
 
   defp pad2(n), do: n |> Integer.to_string() |> String.pad_leading(2, "0")
+
+  defp nanoseconds(dt) do
+    {microsecond, _precision} = dt.microsecond
+    (microsecond * 1_000) |> Integer.to_string() |> String.pad_leading(9, "0")
+  end
+
+  defp iso_week(dt), do: :calendar.iso_week_number({dt.year, dt.month, dt.day})
+
+  # Days elapsed since the first `first_day` of the year, in whole weeks. Day of
+  # year and day of week are both 1-based and the formula wants 0-based.
+  defp week_of_year(dt, first_day) do
+    weekday = Date.day_of_week(dt, first_day) - 1
+    div(Date.day_of_year(dt) - 1 + 7 - weekday, 7)
+  end
+
+  # Output is always UTC, so the offset is fixed; only its spelling varies.
+  defp zone_offset(_dt, :compact), do: "+0000"
+  defp zone_offset(_dt, :minutes), do: "+00:00"
+  defp zone_offset(_dt, :seconds), do: "+00:00:00"
+  defp zone_offset(_dt, :hours), do: "+00"
 
   defp twelve_hour(0), do: 12
   defp twelve_hour(hour) when hour > 12, do: hour - 12

--- a/lib/just_bash/fixtures.ex
+++ b/lib/just_bash/fixtures.ex
@@ -76,6 +76,14 @@ defmodule JustBash.Fixtures do
     content_hash(script, test_case["files"] || %{})
   end
 
+  # A case with no script cannot be hashed, run or recorded. Saying so beats a
+  # FunctionClauseError raised from inside `validate/2`, which reads as a bug in
+  # the checker rather than a malformed case file.
+  def hash_case(test_case) do
+    raise ArgumentError,
+          "fixture case has no \"script\" key: #{inspect(test_case, limit: 5)}"
+  end
+
   @doc """
   The exact bytes `content_hash/2` digests.
 

--- a/lib/just_bash/fixtures.ex
+++ b/lib/just_bash/fixtures.ex
@@ -1,0 +1,198 @@
+defmodule JustBash.Fixtures do
+  @moduledoc """
+  Content-addressing and integrity rules for the bash comparison fixture corpus.
+
+  Fixture cases live in `test/fixtures/bash_cases/<suite>.json`; the outputs real
+  bash produced for them live in `test/fixtures/bash_expected/<suite>.json`. The
+  two files are joined by `content_hash` — a digest of the case's *inputs*, so a
+  recording is addressed by the script that produced it rather than by its name.
+
+  That join only means anything if the hash is recomputed from the inputs on
+  every read. A stored hash that is never re-derived degrades into an opaque
+  label: edit the script, leave the hash, and the case keeps passing while
+  asserting against output recorded for a different script. `content_hash/2` is
+  the single definition both the recorder (`mix bash_fixtures`) and the test
+  (`JustBash.FixtureTest`) call, so the two cannot disagree.
+
+  ## The digest
+
+      content_hash = sha256(canonical(script, files)) |> hex |> first 16 chars
+
+      canonical = ~s({"files":) <> compact_json(files) <> ~s(,"script":) <>
+                  compact_json(script) <> ~s(})
+
+  Compact JSON means no insignificant whitespace, and non-ASCII is emitted as
+  raw UTF-8 rather than `\\uXXXX` escapes. `files` keys are sorted by path so the
+  digest never depends on map iteration order.
+
+  Only the fields that feed the recording — `script` and `files` — are hashed.
+  Comparison settings (`name`, `opts.ignore_exit`, `opts.ignore_stderr`) are
+  deliberately excluded: renaming a case or widening what it tolerates must not
+  invalidate a recording that is still byte-for-byte correct.
+
+  ## Versioning
+
+  `@hash_version` records the current canonicalization. Changing the digest
+  invalidates every recorded expectation at once, so it must be a deliberate,
+  greppable event rather than an accident: bump this, and re-record the corpus.
+  """
+
+  # Bump only alongside a full corpus re-record. See "Versioning" above.
+  @hash_version 1
+
+  @hash_chars 16
+
+  @doc "The canonicalization version this module implements."
+  @spec hash_version() :: pos_integer()
+  def hash_version, do: @hash_version
+
+  @doc """
+  Digests a case's inputs into its `content_hash`.
+
+  ## Examples
+
+      iex> JustBash.Fixtures.content_hash("echo 'hello world' | wc")
+      "d34a7800e7f5b693"
+
+      iex> JustBash.Fixtures.content_hash("echo hi") ==
+      ...>   JustBash.Fixtures.content_hash("echo hi", %{})
+      true
+  """
+  @spec content_hash(String.t(), map()) :: String.t()
+  def content_hash(script, files \\ %{}) when is_binary(script) and is_map(files) do
+    :crypto.hash(:sha256, canonical(script, files))
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, @hash_chars)
+  end
+
+  @doc """
+  Digests a decoded case map, tolerating an absent or null `"files"`.
+
+  Accepts the shape found in `bash_cases/*.json`, so callers that have just
+  decoded a suite file need not destructure it first.
+  """
+  @spec hash_case(map()) :: String.t()
+  def hash_case(%{"script" => script} = test_case) do
+    content_hash(script, test_case["files"] || %{})
+  end
+
+  @doc """
+  The exact bytes `content_hash/2` digests.
+
+  Exposed for diagnosing a hash mismatch: comparing canonical forms says *which*
+  input drifted, where comparing digests only says that something did.
+  """
+  @spec canonical(String.t(), map()) :: binary()
+  def canonical(script, files) when is_binary(script) and is_map(files) do
+    IO.iodata_to_binary([
+      ~s({"files":),
+      encode_files(files),
+      ~s(,"script":),
+      Jason.encode_to_iodata!(script),
+      ~s(})
+    ])
+  end
+
+  # Emitted by hand rather than via Jason.encode!/1 so key order is sorted by
+  # path instead of inheriting map iteration order, which is unspecified.
+  defp encode_files(files) do
+    inner =
+      files
+      |> Enum.sort_by(fn {path, _contents} -> path end)
+      |> Enum.map_intersperse(",", fn {path, contents} ->
+        [Jason.encode_to_iodata!(path), ":", Jason.encode_to_iodata!(contents)]
+      end)
+
+    ["{", inner, "}"]
+  end
+
+  @typedoc """
+  An integrity violation found by `validate/2`.
+
+  * `:stale_hash` — the stored hash is not the digest of the current inputs, so
+    the case is joined to a recording made from a different script
+  * `:missing_recording` — the case has no recorded expectation
+  * `:orphan_recording` — a recording whose hash matches no live case
+  * `:hash_collision` — one hash claimed by cases with differing inputs
+  """
+  @type problem ::
+          {:stale_hash, name :: String.t(), stored :: String.t() | nil, computed :: String.t()}
+          | {:missing_recording, name :: String.t(), computed :: String.t()}
+          | {:orphan_recording, hash :: String.t()}
+          | {:hash_collision, hash :: String.t(), names :: [String.t()]}
+
+  @doc """
+  Checks a decoded suite's cases against its decoded recordings.
+
+  Pure, so it runs both offline in `mix bash_fixtures.verify` and at compile
+  time in the fixture test. Returns `[]` when the suite is sound; problems are
+  returned rather than raised so a caller can report every one at once instead
+  of one per run.
+  """
+  @spec validate([map()], [map()]) :: [problem()]
+  def validate(cases, results) do
+    recorded = MapSet.new(results, & &1["content_hash"])
+    live = MapSet.new(cases, &hash_case/1)
+
+    Enum.concat([
+      case_problems(cases, recorded),
+      collision_problems(cases),
+      Enum.map(MapSet.difference(recorded, live), &{:orphan_recording, &1})
+    ])
+  end
+
+  defp case_problems(cases, recorded) do
+    Enum.flat_map(cases, fn test_case ->
+      %{"name" => name} = test_case
+      computed = hash_case(test_case)
+
+      cond do
+        test_case["content_hash"] != computed ->
+          [{:stale_hash, name, test_case["content_hash"], computed}]
+
+        not MapSet.member?(recorded, computed) ->
+          [{:missing_recording, name, computed}]
+
+        true ->
+          []
+      end
+    end)
+  end
+
+  # Two cases may legitimately share a hash when their inputs are byte-identical
+  # (the corpus has one such pair, differing only in name). Differing inputs
+  # under one hash would mean the recordings silently collapse.
+  defp collision_problems(cases) do
+    cases
+    |> Enum.group_by(&hash_case/1)
+    |> Enum.filter(fn {_hash, group} ->
+      group |> Enum.uniq_by(&{&1["script"], &1["files"]}) |> length() > 1
+    end)
+    |> Enum.map(fn {hash, group} -> {:hash_collision, hash, Enum.map(group, & &1["name"])} end)
+  end
+
+  @doc """
+  Renders a `t:problem/0` as a single actionable line.
+  """
+  @spec describe(problem()) :: String.t()
+  def describe({:stale_hash, name, stored, computed}) do
+    "stale hash: #{name}\n" <>
+      "    stored:   #{stored || "(none)"}\n" <>
+      "    computed: #{computed}\n" <>
+      "    The script changed after recording, so this case asserts against\n" <>
+      "    output recorded for a different script."
+  end
+
+  def describe({:missing_recording, name, computed}) do
+    "no recording for: #{name} (#{computed})"
+  end
+
+  def describe({:orphan_recording, hash}) do
+    "orphan recording, no live case: #{hash}"
+  end
+
+  def describe({:hash_collision, hash, names}) do
+    "hash #{hash} claimed by cases with differing inputs:\n" <>
+      Enum.map_join(names, "\n", &"    - #{&1}")
+  end
+end

--- a/lib/mix/tasks/bash_fixtures.ex
+++ b/lib/mix/tasks/bash_fixtures.ex
@@ -1,37 +1,53 @@
 defmodule Mix.Tasks.BashFixtures do
   @moduledoc """
-  Generates expected bash outputs for fixture-based comparison tests.
+  Records what real bash does for the fixture comparison corpus.
 
-  Reads JSON test case files from `test/fixtures/bash_cases/*.json`,
-  runs each script in an Ubuntu Docker container with real bash,
-  and writes expected outputs to `test/fixtures/bash_expected/*.json`.
+  Reads case files from `test/fixtures/bash_cases/*.json`, runs each script under
+  real bash in a Docker container, and writes the resulting stdout, stderr and
+  exit code to `test/fixtures/bash_expected/*.json`. `JustBash.FixtureTest` then
+  asserts JustBash produces the same bytes, offline.
 
-  Locked fixtures (results with `"locked": true`) are preserved during
-  re-recording. Use `--force` to overwrite locked fixtures.
+  A whole suite is recorded in a single container: startup dominates per-case
+  cost, so batching is what keeps recording the corpus tractable.
+
+  Cases and recordings are joined by `content_hash`, a digest of the case inputs
+  computed by `JustBash.Fixtures`. Editing a script therefore changes its hash
+  and orphans its recording, which `mix bash_fixtures.verify` detects offline —
+  no Docker needed on the PR path.
 
   ## Usage
 
-      # Generate all fixtures
+      # Record all suites
       mix bash_fixtures
 
-      # Generate specific suite(s)
+      # Record specific suites
       mix bash_fixtures wc sort arithmetic
 
-      # Rebuild Docker image first
+      # Rebuild the Docker image first
       mix bash_fixtures --rebuild
 
-      # Force overwrite locked fixtures
-      mix bash_fixtures --force
+  ## Related tasks
+
+    * `mix bash_fixtures.verify` — offline integrity check (no Docker)
+    * `mix bash_fixtures.rehash` — recompute stored hashes after a script edit
   """
 
   use Mix.Task
 
-  @shortdoc "Generate expected bash outputs via Docker"
+  alias JustBash.Fixtures
+
+  @shortdoc "Record expected bash outputs via Docker"
 
   @cases_dir Path.expand("../../../test/fixtures/bash_cases", __DIR__)
   @expected_dir Path.expand("../../../test/fixtures/bash_expected", __DIR__)
   @fixtures_dir Path.expand("../../../test/fixtures", __DIR__)
   @docker_image "just-bash-runner"
+
+  @doc false
+  def cases_dir, do: @cases_dir
+
+  @doc false
+  def expected_dir, do: @expected_dir
 
   @impl Mix.Task
   def run(args) do
@@ -39,38 +55,35 @@ defmodule Mix.Tasks.BashFixtures do
 
     ensure_docker_image(opts[:rebuild])
 
-    case_files = discover_case_files(suites)
+    case discover_case_files(suites) do
+      [] ->
+        Mix.shell().info("No case files found in #{@cases_dir}")
 
-    if case_files == [] do
-      Mix.shell().info("No case files found in #{@cases_dir}")
-      :ok
-    else
-      File.mkdir_p!(@expected_dir)
+      case_files ->
+        File.mkdir_p!(@expected_dir)
 
-      Enum.each(case_files, fn case_file ->
-        suite = Path.basename(case_file, ".json")
-        Mix.shell().info("Generating: #{suite}")
+        Enum.each(case_files, fn case_file ->
+          suite = Path.basename(case_file, ".json")
+          Mix.shell().info("Recording: #{suite}")
+          record_suite(case_file, Path.join(@expected_dir, "#{suite}.json"))
+        end)
 
-        expected_file = Path.join(@expected_dir, "#{suite}.json")
-        generate_expected(case_file, expected_file, opts[:force])
-      end)
-
-      Mix.shell().info("Done. Expected outputs in #{@expected_dir}")
+        Mix.shell().info("Done. Expected outputs in #{@expected_dir}")
     end
   end
 
   defp parse_args(args) do
-    {opts, suites, _} =
-      OptionParser.parse(args, switches: [rebuild: :boolean, force: :boolean])
-
+    {opts, suites, _} = OptionParser.parse(args, switches: [rebuild: :boolean])
     {opts, suites}
   end
 
-  defp discover_case_files([]) do
-    Path.wildcard(Path.join(@cases_dir, "*.json")) |> Enum.sort()
+  @doc false
+  @spec discover_case_files([String.t()]) :: [String.t()]
+  def discover_case_files([]) do
+    @cases_dir |> Path.join("*.json") |> Path.wildcard() |> Enum.sort()
   end
 
-  defp discover_case_files(suites) do
+  def discover_case_files(suites) do
     Enum.flat_map(suites, fn suite ->
       path = Path.join(@cases_dir, "#{suite}.json")
 
@@ -83,6 +96,14 @@ defmodule Mix.Tasks.BashFixtures do
     end)
   end
 
+  @doc false
+  @spec read_json!(String.t()) :: map()
+  def read_json!(path), do: path |> File.read!() |> Jason.decode!()
+
+  @doc false
+  @spec write_json!(String.t(), map()) :: :ok
+  def write_json!(path, data), do: File.write!(path, Jason.encode!(data, pretty: true) <> "\n")
+
   defp ensure_docker_image(rebuild) do
     if rebuild || !docker_image_exists?() do
       Mix.shell().info("Building Docker image: #{@docker_image}")
@@ -92,9 +113,7 @@ defmodule Mix.Tasks.BashFixtures do
           stderr_to_stdout: true
         )
 
-      if status != 0 do
-        Mix.raise("Docker build failed:\n#{output}")
-      end
+      if status != 0, do: Mix.raise("Docker build failed:\n#{output}")
     end
   end
 
@@ -105,69 +124,71 @@ defmodule Mix.Tasks.BashFixtures do
     end
   end
 
-  defp generate_expected(case_file, expected_file, force) do
-    # Load existing locked fixtures
-    locked_by_name = load_locked_fixtures(expected_file, force)
+  defp record_suite(case_file, expected_file) do
+    out_dir = Path.join(System.tmp_dir!(), "just_bash_fixtures_#{unique_suffix()}")
+    File.mkdir_p!(out_dir)
 
-    # Mount the cases file directly into the container and redirect to runner
-    {output, status} =
-      System.cmd(
-        "docker",
-        [
-          "run",
-          "--rm",
-          "--network=none",
-          "-v",
-          "#{@fixtures_dir}/runner.sh:/work/runner.sh:ro",
-          "-v",
-          "#{Path.expand(case_file)}:/work/cases.json:ro",
-          @docker_image,
-          "-c",
-          "/work/runner.sh < /work/cases.json"
-        ],
-        stderr_to_stdout: true
-      )
+    try do
+      case run_container(case_file, out_dir) do
+        {:ok, recorded} ->
+          verify_recorded!(case_file, recorded)
+          write_json!(expected_file, recorded)
 
-    if status != 0 do
-      Mix.shell().error(
-        "Runner failed for #{Path.basename(case_file)} (exit #{status}):\n#{output}"
-      )
-    else
-      decoded = Jason.decode!(output)
-      results = merge_locked_results(decoded["results"], locked_by_name)
-      merged = Map.put(decoded, "results", results)
-      pretty = Jason.encode!(merged, pretty: true)
-      File.write!(expected_file, pretty <> "\n")
-    end
-  end
-
-  defp load_locked_fixtures(expected_file, force) do
-    if force || !File.exists?(expected_file) do
-      %{}
-    else
-      expected_file
-      |> File.read!()
-      |> Jason.decode!()
-      |> Map.get("results", [])
-      |> Enum.filter(fn r -> r["locked"] == true end)
-      |> Enum.into(%{}, fn r -> {r["content_hash"], r} end)
-    end
-  end
-
-  defp merge_locked_results(new_results, locked_by_hash) when locked_by_hash == %{} do
-    new_results
-  end
-
-  defp merge_locked_results(new_results, locked_by_hash) do
-    Enum.map(new_results, fn result ->
-      case Map.get(locked_by_hash, result["content_hash"]) do
-        nil ->
-          result
-
-        locked ->
-          Mix.shell().info("  Keeping locked: #{result["name"]}")
-          locked
+        {:error, message} ->
+          Mix.shell().error("#{Path.basename(case_file)}: #{message}")
       end
-    end)
+    after
+      File.rm_rf!(out_dir)
+    end
   end
+
+  # The runner writes its payload to a mounted file rather than stdout. Docker
+  # itself writes to stderr (image platform mismatches, pull progress), and
+  # folding that into the payload would corrupt the JSON — silently, since a
+  # truncated parse fails far from its cause.
+  defp run_container(case_file, out_dir) do
+    args = [
+      "run",
+      "--rm",
+      "--network=none",
+      "-v",
+      "#{@fixtures_dir}/runner.sh:/work/runner.sh:ro",
+      "-v",
+      "#{Path.expand(case_file)}:/work/cases.json:ro",
+      "-v",
+      "#{out_dir}:/out",
+      @docker_image,
+      "-c",
+      "/work/runner.sh < /work/cases.json > /out/result.json"
+    ]
+
+    {diagnostics, status} = System.cmd("docker", args, stderr_to_stdout: true)
+    result_path = Path.join(out_dir, "result.json")
+
+    cond do
+      status != 0 -> {:error, "runner exited #{status}:\n#{diagnostics}"}
+      not File.exists?(result_path) -> {:error, "runner wrote no output:\n#{diagnostics}"}
+      true -> {:ok, read_json!(result_path)}
+    end
+  end
+
+  # A recording is only usable if every live case can find it. Checking here
+  # means a hash mismatch surfaces at record time, against the container we just
+  # ran, rather than as a puzzling compile error in the test suite later.
+  defp verify_recorded!(case_file, recorded) do
+    cases = case_file |> read_json!() |> Map.fetch!("cases")
+
+    case Fixtures.validate(cases, Map.get(recorded, "results", [])) do
+      [] ->
+        :ok
+
+      problems ->
+        Mix.shell().error(
+          "#{Path.basename(case_file)}: recorded output does not cover every case:\n" <>
+            Enum.map_join(problems, "\n", &"  - #{Fixtures.describe(&1)}")
+        )
+    end
+  end
+
+  defp unique_suffix, do: Integer.to_string(System.unique_integer([:positive]))
 end

--- a/lib/mix/tasks/bash_fixtures.ex
+++ b/lib/mix/tasks/bash_fixtures.ex
@@ -62,14 +62,29 @@ defmodule Mix.Tasks.BashFixtures do
       case_files ->
         File.mkdir_p!(@expected_dir)
 
-        Enum.each(case_files, fn case_file ->
+        case_files
+        |> Enum.flat_map(fn case_file ->
           suite = Path.basename(case_file, ".json")
           Mix.shell().info("Recording: #{suite}")
           record_suite(case_file, Path.join(@expected_dir, "#{suite}.json"))
         end)
-
-        Mix.shell().info("Done. Expected outputs in #{@expected_dir}")
+        |> finish()
     end
+  end
+
+  # A suite that failed to record leaves the corpus in a state the test suite
+  # cannot detect on its own — the expectation file it would have replaced is
+  # still there and still passing. Reporting it on stderr and exiting 0 makes a
+  # failed recording look like a successful one to everything downstream.
+  defp finish([]), do: Mix.shell().info("Done. Expected outputs in #{@expected_dir}")
+
+  defp finish(failures) do
+    Mix.raise("""
+
+    #{length(failures)} suite(s) were not recorded:
+
+    #{Enum.map_join(failures, "\n", &"  - #{&1}")}
+    """)
   end
 
   defp parse_args(args) do
@@ -129,13 +144,14 @@ defmodule Mix.Tasks.BashFixtures do
     File.mkdir_p!(out_dir)
 
     try do
-      case run_container(case_file, out_dir) do
-        {:ok, recorded} ->
-          verify_recorded!(case_file, recorded)
-          write_json!(expected_file, recorded)
-
+      with {:ok, recorded} <- run_container(case_file, out_dir),
+           :ok <- verify_recorded(case_file, recorded) do
+        write_json!(expected_file, recorded)
+        []
+      else
         {:error, message} ->
           Mix.shell().error("#{Path.basename(case_file)}: #{message}")
+          [Path.basename(case_file, ".json")]
       end
     after
       File.rm_rf!(out_dir)
@@ -174,8 +190,10 @@ defmodule Mix.Tasks.BashFixtures do
 
   # A recording is only usable if every live case can find it. Checking here
   # means a hash mismatch surfaces at record time, against the container we just
-  # ran, rather than as a puzzling compile error in the test suite later.
-  defp verify_recorded!(case_file, recorded) do
+  # ran, rather than as a puzzling compile error in the test suite later — and
+  # the unusable recording is not written, because a corpus that fails to record
+  # and a corpus that recorded cleanly must not look the same afterwards.
+  defp verify_recorded(case_file, recorded) do
     cases = case_file |> read_json!() |> Map.fetch!("cases")
 
     case Fixtures.validate(cases, Map.get(recorded, "results", [])) do
@@ -183,10 +201,10 @@ defmodule Mix.Tasks.BashFixtures do
         :ok
 
       problems ->
-        Mix.shell().error(
-          "#{Path.basename(case_file)}: recorded output does not cover every case:\n" <>
-            Enum.map_join(problems, "\n", &"  - #{Fixtures.describe(&1)}")
-        )
+        {:error,
+         "recorded output does not cover every case, so it was not written:\n" <>
+           Enum.map_join(problems, "\n", &"  - #{Fixtures.describe(&1)}") <>
+           "\n  Run `mix bash_fixtures.rehash #{Path.basename(case_file, ".json")}` first."}
     end
   end
 

--- a/lib/mix/tasks/bash_fixtures.gen.ex
+++ b/lib/mix/tasks/bash_fixtures.gen.ex
@@ -254,6 +254,24 @@ defmodule Mix.Tasks.BashFixtures.Gen do
         )
       end,
       [
+        # -r reads a file's mtime, which differs between the two engines' clocks,
+        # so only its deterministic paths are enumerated here. The success path is
+        # covered by a unit test against a seeded mtime.
+        one_case(
+          "reference -r on a missing file",
+          "TZ=UTC LC_ALL=C date -r /jb_definitely_missing '+%F'; echo rc=$?"
+        ),
+        # Both shells refuse the flag; only the wording of the refusal differs.
+        one_case(
+          "reference -r with no argument",
+          "TZ=UTC LC_ALL=C date -r; echo rc=$?",
+          @bsd_usage_gap
+        ),
+        one_case(
+          "date -d with no argument",
+          "TZ=UTC LC_ALL=C date -d; echo rc=$?",
+          @bsd_usage_gap
+        ),
         one_case("utc flag -u", "TZ=UTC LC_ALL=C date -u -d '#{@base}' '+%F %T %Z'; echo rc=$?"),
         one_case("rfc flag -R", "TZ=UTC LC_ALL=C date -R -d '#{@base}'; echo rc=$?"),
         one_case(

--- a/lib/mix/tasks/bash_fixtures.gen.ex
+++ b/lib/mix/tasks/bash_fixtures.gen.ex
@@ -23,8 +23,15 @@ defmodule Mix.Tasks.BashFixtures.Gen do
 
   ## Matrices
 
-    * `date` — every strftime directive alone and adjacently paired, `-I`
+    * `date` — every strftime conversion alone, adjacently paired, and crossed
+      with every field flag, locale modifier, width and compound form, plus `-I`
       granularities, `-d` input forms, and flags GNU date does not have
+
+  A list of conversions and a list of flags are each easy to write down. The
+  cross of the two is where the bugs live and is what nobody enumerates by hand:
+  the first version of this matrix listed both alphabets and still missed that
+  `%-T` rendered "9:05:03", because it never asked a flag and a conversion in the
+  same breath. Cross what you enumerate.
 
   ## Usage
 
@@ -47,7 +54,85 @@ defmodule Mix.Tasks.BashFixtures.Gen do
     a A b B c C d D e F g G h H I j k l m M n N p P q r R s S t T u U V w W x X y Y z Z
   )
 
+  # The five GNU field flags. Crossed with every conversion below rather than
+  # sampled: which conversions a flag reaches is exactly the fact no one writes
+  # down, and `%-T` rendered "9:05:03" for want of a case that asked.
+  @date_flags ["-", "_", "0", "^", "#"]
+
+  # POSIX's locale modifiers. GNU accepts them for some conversions and rejects
+  # them for others, and which is which is not guessable — enumerated so the
+  # recording decides.
+  @date_locale_modifiers ["E", "O"]
+
   @date_modifiers [":z", "::z", ":::z", "-d", "_d", "0d", "^a", "#a"]
+
+  # The timezone conversions are the only ones whose directive contains colons,
+  # so a flag run reaches them through a different path than every other
+  # conversion. GNU splits the field width across the sign, hours and minutes.
+  @date_zone_forms [
+    "%-:z",
+    "%_:z",
+    "%0:z",
+    "%3:z",
+    "%8:z",
+    "%-::z",
+    "%_::z",
+    "%-:::z",
+    "%^:z",
+    "%-z",
+    "%_z",
+    "%0z",
+    "%1z",
+    "%5z",
+    "%8z",
+    "%^z",
+    "%#z"
+  ]
+
+  # A width applies to text and compound conversions too, where no padding flag
+  # does. Both facts are only visible when the two are asked separately.
+  @date_string_widths [
+    "%5a",
+    "%_5a",
+    "%05a",
+    "%-5a",
+    "%^5a",
+    "%2a",
+    "%12D",
+    "%12T",
+    "%_12F",
+    "%012F",
+    "%20c",
+    "%6p",
+    "%6Z"
+  ]
+
+  # Modifier crossed with flags and widths. GNU drops the padding flag when a
+  # modifier is present and right-aligns the default rendering instead.
+  @date_modifier_forms [
+    "%-Od",
+    "%_5Od",
+    "%3Od",
+    "%05Ed",
+    "%0Ey",
+    "%5EY",
+    "%-Ey",
+    "%_5Ey",
+    "%-Oe",
+    "%_OH",
+    "%^Ec",
+    "%#Ec",
+    "%^Ea",
+    "%^Oa",
+    "%E",
+    "%O",
+    "%EJ",
+    "%OJ",
+    "%O%d",
+    "%E%d",
+    "%EOd",
+    "%OEd"
+  ]
 
   # Adjacent pairs catch a formatter that rescans its own output. A chain of
   # String.replace/3 ending in %% -> % turned %%Y into %2024, and no single
@@ -78,7 +163,19 @@ defmodule Mix.Tasks.BashFixtures.Gen do
     "%_",
     "%0",
     "%^",
-    "%^!"
+    "%^!",
+    # Passthrough is not inert: `^` upper-cases the reconstruction it emits, so
+    # `%^Ea` is "%^EA". Every flag is asked against an unknown conversion.
+    "%^J",
+    "%#J",
+    "%-J",
+    "%_J",
+    "%0J",
+    "%_3J",
+    "%0!",
+    "%^!x",
+    "%0d%-d",
+    "%_H:%-M"
   ]
 
   # Field width crossed with padding flags. Only meaningful at the single-digit
@@ -102,26 +199,43 @@ defmodule Mix.Tasks.BashFixtures.Gen do
     "%_e",
     "%0e",
     "%-I",
-    "%-j"
+    "%-j",
+    # A width narrower than the field is not a floor: GNU replaces the
+    # conversion's own width outright, so `%1d` is "5" and not "05".
+    "%1d",
+    "%1e",
+    "%1H",
+    "%0d",
+    "%5e",
+    "%5k",
+    "%5l",
+    "%5Y",
+    "%_5Y",
+    "%5s",
+    "%_5j",
+    "%_1j",
+    "%2j"
   ]
 
-  # %N is a fractional-seconds field: a width truncates its nine digits rather
-  # than padding them. GNU's handling of the space and no-pad flags here is
-  # stranger — `%_N` right-pads with spaces, which no other conversion does — so
-  # those combinations are recorded as gaps rather than imitated.
+  # %N is a fractional-seconds field: a width sets how many of its nine digits
+  # are printed, extending with zeros past nine rather than stopping. GNU's
+  # handling of the space and no-pad flags here is stranger — `%_N` right-pads
+  # with spaces, which no other conversion does — so those combinations are
+  # recorded as gaps rather than imitated.
   @nanosecond_gap "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
 
-  @date_nanoseconds [
-    {"%N", nil},
-    {"%-N", nil},
-    {"%0N", nil},
-    {"%^N", nil},
-    {"%3N", nil},
-    {"%6N", nil},
-    {"%_N", @nanosecond_gap},
-    {"%-3N", @nanosecond_gap},
-    {"%_6N", @nanosecond_gap}
-  ]
+  @date_nanoseconds ~w(%N %-N %0N %^N %#N %1N %3N %6N %9N %12N %_N %-3N %_6N %-12N)
+
+  # Gaps keyed by the format that provokes them, because the same format arrives
+  # through several enumerations — `%_N` is both a nanosecond case and a cell in
+  # the flag cross, and a gap marked in one place and not the other is a failure
+  # nobody can act on.
+  @format_gaps %{
+    "%_N" => @nanosecond_gap,
+    "%-3N" => @nanosecond_gap,
+    "%_6N" => @nanosecond_gap,
+    "%-12N" => @nanosecond_gap
+  }
 
   @date_iso ["-I", "-Idate", "-Ihours", "-Iminutes", "-Iseconds", "-Ins", "--iso-8601=date"]
 
@@ -135,6 +249,13 @@ defmodule Mix.Tasks.BashFixtures.Gen do
     {"2024-06-15 13:30:00", nil},
     {"2024-06-15T13:30:00", nil},
     {"@1718458200", nil},
+    {"@0", nil},
+    {"@-1", nil},
+    # Shape-checking `@N` with a regexp says nothing about whether the number is
+    # a representable instant. GNU refuses; a converter that trusts the shape
+    # raises out of the command instead.
+    {"@99999999999999999999", nil},
+    {"@-99999999999999999999", nil},
     {"2024-06-15 13:30:00 +1 day", @relative_gap},
     {"2024-06-15 13:30:00 1 day ago", @relative_gap},
     {"2024-06-15 13:30:00 +6 months", @relative_gap},
@@ -165,19 +286,47 @@ defmodule Mix.Tasks.BashFixtures.Gen do
     {"-v +6m", @bsd_adjust_gap},
     {"-v-1d", @bsd_adjust_gap},
     {"-j", @bsd_gap},
-    {"-jf %Y", @bsd_gap},
+    {"-j -f %Y", @bsd_gap},
+    # Not the `-j -f` pair above: a clustered `-jf` is one token. Both engines
+    # refuse it, but for different reasons and so in different words — GNU has
+    # no `-j` at all, where this one splits the cluster and then finds `-f` with
+    # nothing to parse.
+    {"-jf %Y", @bsd_usage_gap},
     {"--not-a-flag", @bsd_usage_gap},
     {"-Z", @bsd_usage_gap}
   ]
 
-  # Two base instants, because one cannot distinguish padding. At day 15 and hour
-  # 13, `%-d`, `%_d` and `%0d` all render "15" and every padding bug hides; at day
-  # 5 and hour 9 they render "5", " 5" and "05". The single-digit base also puts
-  # the hour before noon, so %I/%p/%P/%l/%k differ from the afternoon base.
+  # An operand that is not a `+FORMAT` is how BSD spells "set the system clock"
+  # and how GNU spells "extra operand". Both engines refuse it and neither runs;
+  # the recorded difference is only which of the two refusals is printed.
+  @operand_gap "an operand is refused as a BSD settable time, not as a GNU extra operand"
+
+  # Three base instants, because one cannot distinguish padding. At day 15 and
+  # hour 13, `%-d`, `%_d` and `%0d` all render "15" and every padding bug hides;
+  # at day 5 and hour 9 they render "5", " 5" and "05". The single-digit base also
+  # puts the hour before noon, so %I/%p/%P/%l/%k differ from the afternoon base.
+  #
+  # June cannot expose the year-relative fields: `%j`, `%U`, `%V` and `%W` are all
+  # three- or two-digit there whatever the flag. The January base is where their
+  # padding becomes visible.
   @base "2024-06-15 13:30:00"
   @base_single "2024-06-05 09:05:03"
+  @base_january "2005-01-05 09:05:03"
 
-  @bases [{"pm", @base}, {"am", @base_single}]
+  # A fourth, used only for the fields whose padding needs a year below 1000:
+  # `%Y`, `%G` and `%C` are already at their full width in any modern year.
+  @base_low_year "0005-01-05 09:05:03"
+
+  @low_year_forms ["%Y", "%-Y", "%_Y", "%0Y", "%5Y", "%G", "%-G", "%C", "%-C", "%y", "%-y", "%-g"]
+
+  # A compound conversion is a sub-format, and a padding flag reaches some of its
+  # fields and not others: `%-D` is "01/05/5" — the year loses its padding while
+  # the month and day keep theirs — but `%-x`, the same "%m/%d/%y", is untouched.
+  # Which compounds forward the flag is not derivable, so all of them are asked,
+  # at the one base where a four-digit year can lose padding.
+  @date_compounds ~w(F D T R c r x X)
+
+  @bases [{"pm", @base}, {"am", @base_single}, {"jan", @base_january}]
 
   @impl Mix.Task
   def run(args) do
@@ -216,25 +365,75 @@ defmodule Mix.Tasks.BashFixtures.Gen do
 
   defp date_cases do
     Enum.concat([
+      conversion_cases(),
+      cross_cases(),
+      shape_cases(),
+      argument_cases()
+    ])
+  end
+
+  # Each conversion on its own, at every base instant.
+  defp conversion_cases do
+    Enum.concat([
       for d <- @date_directives, {label, base} <- @bases do
         date_case("directive %#{d} (#{label})", "'+%#{d}'", base)
       end,
       for m <- @date_modifiers, {label, base} <- @bases do
         date_case("modifier %#{m} (#{label})", "'+%#{m}'", base)
       end,
+      for f <- @low_year_forms do
+        date_case("low year #{f}", "'+#{f}'", @base_low_year)
+      end,
+      for f <- @date_nanoseconds do
+        format_case("nanoseconds", f, @base_single)
+      end
+    ])
+  end
+
+  # The crosses. A flag list and a conversion list are each finite and each easy
+  # to write down; which pairs of them mean anything is neither, so every pair is
+  # asked rather than the interesting-looking ones.
+  defp cross_cases do
+    Enum.concat([
+      for flag <- @date_flags, d <- @date_directives do
+        format_case("flag", "%#{flag}#{d}", @base_january)
+      end,
+      # E and O are accepted for some conversions and refused for others, and the
+      # refusal is a verbatim passthrough at exit 0 — the failure this whole
+      # matrix exists to make impossible to ship unnoticed.
+      for mod <- @date_locale_modifiers, d <- @date_directives do
+        date_case("locale modifier %#{mod}#{d}", "'+%#{mod}#{d}'", @base_january)
+      end,
+      for flag <- @date_flags, c <- @date_compounds do
+        date_case("compound %#{flag}#{c}", "'+%#{flag}#{c}'", @base_low_year)
+      end
+    ])
+  end
+
+  # Directive shapes that are not a plain conversion: colons, widths, adjacency.
+  defp shape_cases do
+    Enum.concat([
+      for f <- @date_zone_forms do
+        date_case("zone #{f}", "'+#{f}'", @base_january)
+      end,
+      for f <- @date_string_widths do
+        date_case("string width #{f}", "'+#{f}'", @base_january)
+      end,
+      for f <- @date_modifier_forms do
+        date_case("modifier form #{f}", "'+#{f}'", @base_january)
+      end,
       for f <- @date_pairs do
         date_case("sequence #{f}", "'+#{f}'")
       end,
       for f <- @date_widths do
         date_case("width #{f}", "'+#{f}'", @base_single)
-      end,
-      for {f, gap} <- @date_nanoseconds do
-        one_case(
-          "nanoseconds #{f}",
-          "TZ=UTC LC_ALL=C date -d '#{@base_single}' '+#{f}'; echo rc=$?",
-          gap
-        )
-      end,
+      end
+    ])
+  end
+
+  # Everything before the format string: flags, their arguments, and operands.
+  defp argument_cases do
+    Enum.concat([
       for flag <- @date_iso do
         date_case("iso #{flag}", flag)
       end,
@@ -261,7 +460,8 @@ defmodule Mix.Tasks.BashFixtures.Gen do
           "reference -r on a missing file",
           "TZ=UTC LC_ALL=C date -r /jb_definitely_missing '+%F'; echo rc=$?"
         ),
-        # Both shells refuse the flag; only the wording of the refusal differs.
+        # Both engines refuse each of these; only the wording of the refusal
+        # differs, so the exit code is the assertion and the message is the gap.
         one_case(
           "reference -r with no argument",
           "TZ=UTC LC_ALL=C date -r; echo rc=$?",
@@ -271,6 +471,51 @@ defmodule Mix.Tasks.BashFixtures.Gen do
           "date -d with no argument",
           "TZ=UTC LC_ALL=C date -d; echo rc=$?",
           @bsd_usage_gap
+        ),
+        one_case(
+          "long --date with no argument",
+          "TZ=UTC LC_ALL=C date --date; echo rc=$?",
+          @bsd_usage_gap
+        ),
+        one_case(
+          "long --reference with no argument",
+          "TZ=UTC LC_ALL=C date --reference; echo rc=$?",
+          @bsd_usage_gap
+        ),
+        # -d and -r each name the instant to print, so asking for both is a
+        # question with two answers. Silently preferring one reports success.
+        one_case(
+          "reference -r and -d together",
+          "touch /tmp/jb_r_$$; TZ=UTC LC_ALL=C date -r /tmp/jb_r_$$ -d '#{@base}' '+%F'; echo rc=$?; rm -f /tmp/jb_r_$$",
+          @bsd_usage_gap
+        ),
+        # Refusing unknown flags must not also refuse the spellings GNU accepts.
+        one_case(
+          "end of options --",
+          "TZ=UTC LC_ALL=C date -d '#{@base}' -- '+%F'; echo rc=$?"
+        ),
+        one_case(
+          "long --date with a separate argument",
+          "TZ=UTC LC_ALL=C date --date '#{@base}' '+%F'; echo rc=$?"
+        ),
+        one_case(
+          "long --reference with a separate argument",
+          "touch /tmp/jb_l_$$; TZ=UTC LC_ALL=C date --reference /tmp/jb_l_$$ '+%Y' > /dev/null; echo rc=$?; rm -f /tmp/jb_l_$$"
+        ),
+        one_case(
+          "long --iso-8601 with a separate argument",
+          "TZ=UTC LC_ALL=C date -d '#{@base}' --iso-8601 hours; echo rc=$?",
+          @operand_gap
+        ),
+        one_case(
+          "bare - operand",
+          "TZ=UTC LC_ALL=C date -d '#{@base}' - '+%F'; echo rc=$?",
+          @operand_gap
+        ),
+        one_case(
+          "extra operand",
+          "TZ=UTC LC_ALL=C date -d '#{@base}' extra '+%F'; echo rc=$?",
+          @operand_gap
         ),
         one_case("utc flag -u", "TZ=UTC LC_ALL=C date -u -d '#{@base}' '+%F %T %Z'; echo rc=$?"),
         one_case("rfc flag -R", "TZ=UTC LC_ALL=C date -R -d '#{@base}'; echo rc=$?"),
@@ -285,6 +530,16 @@ defmodule Mix.Tasks.BashFixtures.Gen do
 
   defp date_case(name, arg, base \\ @base) do
     one_case(name, "TZ=UTC LC_ALL=C date -d '#{base}' #{arg}; echo rc=$?")
+  end
+
+  # A format case names itself, so the same format enumerated twice carries the
+  # same gap marker both times.
+  defp format_case(group, format, base) do
+    one_case(
+      "#{group} #{format}",
+      "TZ=UTC LC_ALL=C date -d '#{base}' '+#{format}'; echo rc=$?",
+      Map.get(@format_gaps, format)
+    )
   end
 
   # Every case ends in `echo rc=$?` so a wrong exit code shows up as a stdout

--- a/lib/mix/tasks/bash_fixtures.gen.ex
+++ b/lib/mix/tasks/bash_fixtures.gen.ex
@@ -1,0 +1,290 @@
+defmodule Mix.Tasks.BashFixtures.Gen do
+  @moduledoc """
+  Generates enumerated fixture matrices — the cases nobody thinks to write.
+
+  The corpus grew by example: someone fixed a bug, then wrote a case for the shape
+  they had just fixed. That leaves whole alphabets unexamined. `date.json` has 30
+  hand-written cases and covers none of `%F`, `%D`, `%T`, `%R`, `-I` or `-v` — the
+  exact directives that shipped emitting themselves literally at exit 0, which an
+  agent then used as if it were a date.
+
+  A command's flag and directive sets are *finite*. They are not a space to sample
+  with a fuzzer; they are a list to enumerate. This task writes that enumeration
+  out as ordinary case files, so recording and comparison work exactly as they do
+  for hand-written cases:
+
+      mix bash_fixtures.gen date       # write the matrix
+      mix bash_fixtures date_matrix    # record what real bash does
+      mix test --only suite:date_matrix
+
+  Generated suites are named `<matrix>_matrix` and are safe to regenerate: the
+  digest in `JustBash.Fixtures` is content-derived, so a case that did not change
+  keeps its recording.
+
+  ## Matrices
+
+    * `date` — every strftime directive alone and adjacently paired, `-I`
+      granularities, `-d` input forms, and flags GNU date does not have
+
+  ## Usage
+
+      mix bash_fixtures.gen              # every matrix
+      mix bash_fixtures.gen date         # one matrix
+      mix bash_fixtures.gen --dry-run    # report counts, write nothing
+  """
+
+  use Mix.Task
+
+  alias JustBash.Fixtures
+  alias Mix.Tasks.BashFixtures
+
+  @shortdoc "Generate enumerated fixture matrices"
+
+  # Every conversion GNU date documents, plus the padding and timezone-colon
+  # modifiers. Enumerated rather than curated: the point is that no human decides
+  # which of these is interesting.
+  @date_directives ~w(
+    a A b B c C d D e F g G h H I j k l m M n N p P q r R s S t T u U V w W x X y Y z Z
+  )
+
+  @date_modifiers [":z", "::z", ":::z", "-d", "_d", "0d", "^a", "#a"]
+
+  # Adjacent pairs catch a formatter that rescans its own output. A chain of
+  # String.replace/3 ending in %% -> % turned %%Y into %2024, and no single
+  # directive can expose that.
+  @date_pairs [
+    "%%F",
+    "%%%F",
+    "%F%T",
+    "%Y%m%d",
+    "%%",
+    "%%%%",
+    "%",
+    "%F%",
+    "%J",
+    "%%J",
+    "%F%J%T",
+    # A flag run cannot take `%` as its conversion, so these are not the modified
+    # `%%` they look like. Found by the existing composition property, pinned here.
+    "%#%!",
+    "%-%d",
+    "%#%%",
+    "%--d",
+    "%0-d",
+    "%^%a",
+    # A flag run with no conversion at all is literal.
+    "%#",
+    "%-",
+    "%_",
+    "%0",
+    "%^",
+    "%^!"
+  ]
+
+  # Field width crossed with padding flags. Only meaningful at the single-digit
+  # base, and only here is it visible that the last padding flag wins outright:
+  # `%-0d` is "05", not the "5" that folding the flags in order would give.
+  @date_widths [
+    "%3d",
+    "%03d",
+    "%_3d",
+    "%-3d",
+    "%_10d",
+    "%^3a",
+    "%-0d",
+    "%0_d",
+    "%_2H",
+    "%_3H",
+    "%-d",
+    "%-H",
+    "%-M",
+    "%-e",
+    "%_e",
+    "%0e",
+    "%-I",
+    "%-j"
+  ]
+
+  # %N is a fractional-seconds field: a width truncates its nine digits rather
+  # than padding them. GNU's handling of the space and no-pad flags here is
+  # stranger — `%_N` right-pads with spaces, which no other conversion does — so
+  # those combinations are recorded as gaps rather than imitated.
+  @nanosecond_gap "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+
+  @date_nanoseconds [
+    {"%N", nil},
+    {"%-N", nil},
+    {"%0N", nil},
+    {"%^N", nil},
+    {"%3N", nil},
+    {"%6N", nil},
+    {"%_N", @nanosecond_gap},
+    {"%-3N", @nanosecond_gap},
+    {"%_6N", @nanosecond_gap}
+  ]
+
+  @date_iso ["-I", "-Idate", "-Ihours", "-Iminutes", "-Iseconds", "-Ins", "--iso-8601=date"]
+
+  # -d forms an agent would plausibly reach for. Relative forms are anchored to a
+  # fixed base date so they stay deterministic. GNU accepts a whole date grammar
+  # here; the relative half is unimplemented, and these cases record what it owes.
+  @relative_gap "GNU relative date grammar for -d is not implemented"
+
+  @date_inputs [
+    {"2024-06-15", nil},
+    {"2024-06-15 13:30:00", nil},
+    {"2024-06-15T13:30:00", nil},
+    {"@1718458200", nil},
+    {"2024-06-15 13:30:00 +1 day", @relative_gap},
+    {"2024-06-15 13:30:00 1 day ago", @relative_gap},
+    {"2024-06-15 13:30:00 +6 months", @relative_gap},
+    {"2024-06-15 13:30:00 6 months ago", @relative_gap},
+    {"2024-06-15 13:30:00 next tuesday", @relative_gap},
+    {"2024-06-15 13:30:00 last monday", @relative_gap},
+    {"2024-06-15 13:30:00 +2 weeks", @relative_gap},
+    {"2024-06-15 13:30:00 -3 hours", @relative_gap}
+  ]
+
+  # A flag this shell does not implement must produce an error, not today's date
+  # at exit 0 — that is what these cases are for, and most of them assert it
+  # against GNU date directly.
+  #
+  # The exceptions are the BSD spellings JustBash documents as supported: it
+  # accepts what GNU refuses, so the recording is kept and the divergence named
+  # rather than silently tolerated.
+  @bsd_gap "-j/-f are supported as documented BSD spellings; GNU date rejects them"
+  @bsd_adjust_gap "-v is a supported BSD adjustment here; GNU date rejects it"
+
+  # Both shells refuse an unknown flag; only the wording differs. JustBash spells
+  # a short option's refusal the way BSD does, since that is the implementation
+  # that names the offending character.
+  @bsd_usage_gap "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
+
+  @date_absent_flags [
+    {"-v+6m", @bsd_adjust_gap},
+    {"-v +6m", @bsd_adjust_gap},
+    {"-v-1d", @bsd_adjust_gap},
+    {"-j", @bsd_gap},
+    {"-jf %Y", @bsd_gap},
+    {"--not-a-flag", @bsd_usage_gap},
+    {"-Z", @bsd_usage_gap}
+  ]
+
+  # Two base instants, because one cannot distinguish padding. At day 15 and hour
+  # 13, `%-d`, `%_d` and `%0d` all render "15" and every padding bug hides; at day
+  # 5 and hour 9 they render "5", " 5" and "05". The single-digit base also puts
+  # the hour before noon, so %I/%p/%P/%l/%k differ from the afternoon base.
+  @base "2024-06-15 13:30:00"
+  @base_single "2024-06-05 09:05:03"
+
+  @bases [{"pm", @base}, {"am", @base_single}]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, matrices, _} = OptionParser.parse(args, switches: [dry_run: :boolean])
+    dry_run? = Keyword.get(opts, :dry_run, false)
+
+    matrices
+    |> resolve()
+    |> Enum.each(&write_matrix(&1, dry_run?))
+  end
+
+  defp resolve([]), do: ["date"]
+
+  defp resolve(names) do
+    Enum.each(names, fn name ->
+      unless name in ["date"], do: Mix.raise("Unknown matrix: #{name}")
+    end)
+
+    names
+  end
+
+  defp write_matrix(name, dry_run?) do
+    suite = "#{name}_matrix"
+    cases = build(name)
+
+    Mix.shell().info("#{suite}: #{length(cases)} cases")
+
+    unless dry_run? do
+      path = Path.join(BashFixtures.cases_dir(), "#{suite}.json")
+      BashFixtures.write_json!(path, %{"suite" => suite, "cases" => cases})
+      Mix.shell().info("  wrote #{Path.relative_to_cwd(path)}")
+    end
+  end
+
+  defp build("date"), do: date_cases()
+
+  defp date_cases do
+    Enum.concat([
+      for d <- @date_directives, {label, base} <- @bases do
+        date_case("directive %#{d} (#{label})", "'+%#{d}'", base)
+      end,
+      for m <- @date_modifiers, {label, base} <- @bases do
+        date_case("modifier %#{m} (#{label})", "'+%#{m}'", base)
+      end,
+      for f <- @date_pairs do
+        date_case("sequence #{f}", "'+#{f}'")
+      end,
+      for f <- @date_widths do
+        date_case("width #{f}", "'+#{f}'", @base_single)
+      end,
+      for {f, gap} <- @date_nanoseconds do
+        one_case(
+          "nanoseconds #{f}",
+          "TZ=UTC LC_ALL=C date -d '#{@base_single}' '+#{f}'; echo rc=$?",
+          gap
+        )
+      end,
+      for flag <- @date_iso do
+        date_case("iso #{flag}", flag)
+      end,
+      for {flag, gap} <- @date_absent_flags do
+        # No -d: these must fail on the flag itself, not on date parsing.
+        one_case(
+          "absent flag #{flag}",
+          "TZ=UTC LC_ALL=C date #{flag} '+%Y-%m-%d'; echo rc=$?",
+          gap
+        )
+      end,
+      for {input, gap} <- @date_inputs do
+        one_case(
+          "input #{input}",
+          "TZ=UTC LC_ALL=C date -d '#{input}' '+%Y-%m-%d %H:%M:%S'; echo rc=$?",
+          gap
+        )
+      end,
+      [
+        one_case("utc flag -u", "TZ=UTC LC_ALL=C date -u -d '#{@base}' '+%F %T %Z'; echo rc=$?"),
+        one_case("rfc flag -R", "TZ=UTC LC_ALL=C date -R -d '#{@base}'; echo rc=$?"),
+        one_case(
+          "reads -f from a file",
+          "printf '%s\\n' '#{@base}' > /tmp/jb_d_$$; TZ=UTC LC_ALL=C date -f /tmp/jb_d_$$ '+%F'; echo rc=$?; rm -f /tmp/jb_d_$$",
+          "-f is the BSD input-format flag here; GNU reads dates from the named file"
+        )
+      ]
+    ])
+  end
+
+  defp date_case(name, arg, base \\ @base) do
+    one_case(name, "TZ=UTC LC_ALL=C date -d '#{base}' #{arg}; echo rc=$?")
+  end
+
+  # Every case ends in `echo rc=$?` so a wrong exit code shows up as a stdout
+  # difference too. The dominant failure in this corpus is exit 0 with a wrong
+  # answer, and a case that only compares stdout cannot see it.
+  #
+  # `known_gap` rides in opts, which the digest deliberately excludes: marking a
+  # gap, or closing one, must not invalidate a recording that is still correct.
+  defp one_case(name, script, known_gap \\ nil) do
+    test_case = %{
+      "name" => "date matrix: #{name}",
+      "script" => script,
+      "content_hash" => Fixtures.content_hash(script)
+    }
+
+    case known_gap do
+      nil -> test_case
+      reason -> Map.put(test_case, "opts", %{"known_gap" => reason})
+    end
+  end
+end

--- a/lib/mix/tasks/bash_fixtures.rehash.ex
+++ b/lib/mix/tasks/bash_fixtures.rehash.ex
@@ -1,0 +1,120 @@
+defmodule Mix.Tasks.BashFixtures.Rehash do
+  @moduledoc """
+  Rewrites stored `content_hash` values to match the current case inputs.
+
+  Only needed when a case's stored hash has drifted from its script — either
+  because the script was edited without re-recording, or because the hash predates
+  the canonicalization in `JustBash.Fixtures`.
+
+  Rehashing deliberately does **not** touch the recorded expectations. It makes
+  the drift visible instead of papering over it: after rehashing, the affected
+  cases have no recording, `mix bash_fixtures.verify` says so, and re-recording
+  produces a diff showing what those cases should have been asserting all along.
+
+      mix bash_fixtures.rehash wc      # adopt current scripts
+      mix bash_fixtures wc             # re-derive expectations from real bash
+      git diff test/fixtures           # read what changed, and why
+
+  ## Usage
+
+      mix bash_fixtures.rehash              # whole corpus
+      mix bash_fixtures.rehash wc cp        # specific suites
+      mix bash_fixtures.rehash --dry-run    # report drift, write nothing
+  """
+
+  use Mix.Task
+
+  alias JustBash.Fixtures
+  alias Mix.Tasks.BashFixtures
+
+  @shortdoc "Recompute stored fixture hashes after a script edit"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, suites, _} = OptionParser.parse(args, switches: [dry_run: :boolean])
+    dry_run? = Keyword.get(opts, :dry_run, false)
+
+    suites
+    |> BashFixtures.discover_case_files()
+    |> Enum.sum_by(&rehash_suite(&1, dry_run?))
+    |> report(dry_run?)
+  end
+
+  # Decoded as ordered objects so rewriting a hash preserves the file's authored
+  # key order. Re-encoding from a plain map would reorder every key in the suite,
+  # burying a handful of real changes in hundreds of lines of churn.
+  defp rehash_suite(case_file, dry_run) do
+    suite = Path.basename(case_file, ".json")
+    data = case_file |> File.read!() |> Jason.decode!(objects: :ordered_objects)
+    cases = fetch(data, "cases")
+
+    {rehashed, drifted} =
+      Enum.map_reduce(cases, [], fn test_case, drifted ->
+        computed = test_case |> inputs() |> Fixtures.hash_case()
+
+        case fetch(test_case, "content_hash") do
+          ^computed ->
+            {test_case, drifted}
+
+          stored ->
+            {put(test_case, "content_hash", computed),
+             [{fetch(test_case, "name"), stored, computed} | drifted]}
+        end
+      end)
+
+    drifted
+    |> Enum.reverse()
+    |> Enum.each(fn {name, stored, computed} ->
+      Mix.shell().info("  #{suite}: #{stored || "(none)"} -> #{computed}  #{name}")
+    end)
+
+    if drifted != [] and not dry_run do
+      BashFixtures.write_json!(case_file, put(data, "cases", rehashed))
+    end
+
+    length(drifted)
+  end
+
+  defp fetch(%Jason.OrderedObject{values: values}, key) do
+    case List.keyfind(values, key, 0) do
+      {^key, value} -> value
+      nil -> nil
+    end
+  end
+
+  # Replaces in place when present so position is kept, appends otherwise.
+  defp put(%Jason.OrderedObject{values: values} = object, key, value) do
+    values =
+      if List.keymember?(values, key, 0) do
+        List.keyreplace(values, key, 0, {key, value})
+      else
+        values ++ [{key, value}]
+      end
+
+    %{object | values: values}
+  end
+
+  # JustBash.Fixtures works on plain maps; only the two hashed fields are needed.
+  defp inputs(test_case) do
+    %{"script" => fetch(test_case, "script"), "files" => fetch(test_case, "files")}
+  end
+
+  defp report(0, _dry_run) do
+    Mix.shell().info("bash_fixtures.rehash: every stored hash already matches its inputs")
+  end
+
+  defp report(count, true) do
+    Mix.shell().info("\n#{count} case(s) would be rehashed. Re-run without --dry-run to apply.")
+  end
+
+  defp report(count, _dry_run) do
+    Mix.shell().info("""
+
+    Rehashed #{count} case(s). Their expectations are now unclaimed, by design.
+
+    Next:
+        mix bash_fixtures <suite>   # re-derive expectations from real bash
+        git diff test/fixtures      # the diff is the bug report
+    """)
+  end
+end

--- a/lib/mix/tasks/bash_fixtures.verify.ex
+++ b/lib/mix/tasks/bash_fixtures.verify.ex
@@ -1,0 +1,90 @@
+defmodule Mix.Tasks.BashFixtures.Verify do
+  @moduledoc """
+  Checks the fixture corpus for integrity. Offline — no Docker.
+
+  Cases in `test/fixtures/bash_cases/` are joined to the bash output recorded in
+  `test/fixtures/bash_expected/` by `content_hash`, a digest of the case inputs.
+  Because the hash is derived from the script, "someone edited a script but never
+  re-recorded it" is detectable without running bash at all — the recomputed hash
+  simply has no recording. That is what lets the PR pipeline stay hermetic while
+  still refusing to accept a stale corpus.
+
+  Reports, per suite:
+
+    * **stale hash** — the stored hash is not the digest of the current inputs,
+      so the case is joined to a recording made from a different script
+    * **no recording** — a case whose expectation was never recorded
+    * **orphan recording** — a recording no live case claims
+    * **hash collision** — one hash claimed by cases with differing inputs
+
+  ## Usage
+
+      mix bash_fixtures.verify              # whole corpus
+      mix bash_fixtures.verify wc cp        # specific suites
+
+  Exits non-zero when anything is wrong, so it can gate CI.
+  """
+
+  use Mix.Task
+
+  alias JustBash.Fixtures
+  alias Mix.Tasks.BashFixtures
+
+  @shortdoc "Check fixture corpus integrity (offline)"
+
+  @impl Mix.Task
+  def run(args) do
+    {_opts, suites, _} = OptionParser.parse(args, switches: [])
+
+    results =
+      suites
+      |> BashFixtures.discover_case_files()
+      |> Enum.map(&verify_suite/1)
+
+    report(results, Enum.sum_by(results, fn {_suite, problems} -> length(problems) end))
+  end
+
+  defp verify_suite(case_file) do
+    suite = Path.basename(case_file, ".json")
+    expected_file = Path.join(BashFixtures.expected_dir(), "#{suite}.json")
+
+    cases = case_file |> BashFixtures.read_json!() |> Map.fetch!("cases")
+
+    results =
+      if File.exists?(expected_file) do
+        expected_file |> BashFixtures.read_json!() |> Map.get("results", [])
+      else
+        []
+      end
+
+    {suite, Fixtures.validate(cases, results)}
+  end
+
+  defp report(results, 0) do
+    Mix.shell().info("bash_fixtures.verify: #{length(results)} suites sound")
+  end
+
+  defp report(results, total_problems) do
+    for {suite, problems} <- results, problems != [] do
+      Mix.shell().error("\n#{suite} (#{length(problems)}):")
+
+      for problem <- problems do
+        Mix.shell().error("  - #{Fixtures.describe(problem)}")
+      end
+    end
+
+    Mix.raise("""
+
+    #{total_problems} fixture integrity problem(s).
+
+    A stale hash means the script was edited after its expectation was recorded,
+    so the case is asserting against output for a different script. To adopt the
+    current scripts and re-derive their expectations from real bash:
+
+        mix bash_fixtures.rehash <suite>
+        mix bash_fixtures <suite>
+
+    Read the resulting diff: it shows what those cases should have been asserting.
+    """)
+  end
+end

--- a/test/bash_comparison/fixture_test.exs
+++ b/test/bash_comparison/fixture_test.exs
@@ -1,14 +1,25 @@
 defmodule JustBash.FixtureTest do
   @moduledoc """
-  Dynamically loads bash comparison test fixtures from JSON files.
+  Asserts JustBash matches real bash, byte for byte, on the recorded corpus.
 
-  Test cases are defined in `test/fixtures/bash_cases/*.json`.
-  Expected outputs are in `test/fixtures/bash_expected/*.json`.
+  Cases live in `test/fixtures/bash_cases/*.json`; what real bash produced for
+  them lives in `test/fixtures/bash_expected/*.json`. Recording needs Docker
+  (`mix bash_fixtures`), but this test compares against the recording, so it
+  runs offline.
 
-  Run `mix bash_fixtures` to regenerate expected outputs via Docker.
+  The two files are joined by `content_hash`, a digest of the case inputs. The
+  hash is **recomputed** here rather than read from the case file: a stored hash
+  that is never re-derived is just an opaque label, and a case whose script was
+  edited without re-recording would keep passing while asserting against output
+  recorded for a different script. Recomputing makes that a compile error.
+
+  See `mix bash_fixtures.verify` for the same checks as a friendly offline
+  report, and `mix bash_fixtures.rehash` to adopt edited scripts.
   """
 
   use ExUnit.Case, async: true
+
+  alias JustBash.Fixtures
 
   @cases_dir Path.expand("../fixtures/bash_cases", __DIR__)
   @expected_dir Path.expand("../fixtures/bash_expected", __DIR__)
@@ -22,14 +33,25 @@ defmodule JustBash.FixtureTest do
     if File.exists?(expected_file) do
       cases = case_file |> File.read!() |> Jason.decode!()
       expected = expected_file |> File.read!() |> Jason.decode!()
+      results = Map.get(expected, "results", [])
 
-      # Build a lookup from content_hash -> expected result.
-      # Content hash is a SHA-256 of the canonical {script, files} — immune
-      # to test renames, only invalidated when actual inputs change.
-      expected_by_hash =
-        expected
-        |> Map.get("results", [])
-        |> Enum.into(%{}, fn r -> {r["content_hash"], r} end)
+      # A broken join makes every assertion in the suite untrustworthy, so the
+      # two problems that corrupt it fail the build. A merely missing recording
+      # is reported per-case below, and orphans are left to bash_fixtures.verify.
+      fatal =
+        cases["cases"]
+        |> Fixtures.validate(results)
+        |> Enum.filter(&(elem(&1, 0) in [:stale_hash, :hash_collision]))
+
+      if fatal != [] do
+        raise CompileError,
+          description:
+            "Fixture corpus integrity failure in #{suite}:\n" <>
+              Enum.map_join(fatal, "\n", &"  - #{Fixtures.describe(&1)}") <>
+              "\n\nRun `mix bash_fixtures.verify` for the full report."
+      end
+
+      expected_by_hash = Map.new(results, fn r -> {r["content_hash"], r} end)
 
       describe suite do
         for test_case <- cases["cases"] do
@@ -37,17 +59,8 @@ defmodule JustBash.FixtureTest do
           script = test_case["script"]
           files = test_case["files"]
           opts = test_case["opts"] || %{}
-          content_hash = test_case["content_hash"]
-
-          expected_result =
-            if content_hash do
-              expected_by_hash[content_hash]
-            else
-              raise CompileError,
-                description:
-                  "Fixture case missing content_hash in #{suite}: #{name}. " <>
-                    "Regenerate cases with: mix run scripts/extract_bash_cases.exs"
-            end
+          content_hash = Fixtures.hash_case(test_case)
+          expected_result = expected_by_hash[content_hash]
 
           @tag suite: suite
           if expected_result do

--- a/test/bash_comparison/fixture_test.exs
+++ b/test/bash_comparison/fixture_test.exs
@@ -15,6 +15,13 @@ defmodule JustBash.FixtureTest do
 
   See `mix bash_fixtures.verify` for the same checks as a friendly offline
   report, and `mix bash_fixtures.rehash` to adopt edited scripts.
+
+  A case carrying `opts.known_gap` is one JustBash is known not to match yet. It
+  still runs, tagged `:known_gap`, with the assertion inverted: it fails when the
+  output *matches* the recording. A gap that is skipped instead can only report
+  the divergence someone wrote down and can never notice the divergence is gone,
+  so a gap closed by an unrelated fix would stay marked forever — and a count of
+  known gaps that includes closed ones is not a count of anything.
   """
 
   use ExUnit.Case, async: true
@@ -62,15 +69,11 @@ defmodule JustBash.FixtureTest do
           content_hash = Fixtures.hash_case(test_case)
           expected_result = expected_by_hash[content_hash]
 
-          # A recorded case JustBash is known not to match yet. The expectation
-          # stays recorded and the reason stays in the corpus, so the gap is
-          # visible and countable rather than absent — an unwritten case looks
-          # exactly like a passing one.
-          if gap = opts["known_gap"] do
-            @tag skip: "known gap: #{gap}"
-          end
+          known_gap = opts["known_gap"]
 
           @tag suite: suite
+          if known_gap, do: @tag(:known_gap)
+
           if expected_result do
             expected_stdout = expected_result["stdout"]
             expected_stderr = expected_result["stderr"]
@@ -80,42 +83,75 @@ defmodule JustBash.FixtureTest do
             ignore_exit = opts["ignore_exit"] == true
             ignore_stderr = opts["ignore_stderr"] == true
 
-            test "#{suite}: #{name}" do
-              bash =
-                if unquote(has_files) do
-                  JustBash.new(files: unquote(Macro.escape(files)))
-                else
-                  JustBash.new()
+            # A recorded case JustBash is known not to match yet. The expectation
+            # stays recorded and the reason stays in the corpus, so the gap is
+            # visible and countable rather than absent — an unwritten case looks
+            # exactly like a passing one.
+            #
+            # The assertion is inverted rather than skipped. A skipped gap can
+            # only ever report the divergence someone wrote down; it cannot
+            # notice that the divergence is gone, so a gap closed by an unrelated
+            # fix stays marked forever and the count stops meaning anything.
+            if known_gap do
+              test "#{suite}: #{name}" do
+                {result, _bash} =
+                  JustBash.exec(
+                    JustBash.new(files: unquote(Macro.escape(files || %{}))),
+                    unquote(script)
+                  )
+
+                actual = {result.exit_code, result.stdout, result.stderr}
+
+                recorded =
+                  {unquote(expected_exit), unquote(expected_stdout), unquote(expected_stderr)}
+
+                refute actual == recorded, """
+                Known gap has closed: #{unquote(name)}
+
+                  #{unquote(known_gap)}
+
+                JustBash now matches real bash here. Drop the `known_gap` opt from
+                the case so the match is asserted rather than assumed absent.
+                """
+              end
+            else
+              test "#{suite}: #{name}" do
+                bash =
+                  if unquote(has_files) do
+                    JustBash.new(files: unquote(Macro.escape(files)))
+                  else
+                    JustBash.new()
+                  end
+
+                {result, _bash} = JustBash.exec(bash, unquote(script))
+
+                unless unquote(ignore_exit) do
+                  assert result.exit_code == unquote(expected_exit),
+                         fixture_failure_message(
+                           unquote(script),
+                           "exit_code",
+                           unquote(expected_exit),
+                           result.exit_code
+                         )
                 end
 
-              {result, _bash} = JustBash.exec(bash, unquote(script))
-
-              unless unquote(ignore_exit) do
-                assert result.exit_code == unquote(expected_exit),
+                assert result.stdout == unquote(expected_stdout),
                        fixture_failure_message(
                          unquote(script),
-                         "exit_code",
-                         unquote(expected_exit),
-                         result.exit_code
+                         "stdout",
+                         unquote(expected_stdout),
+                         result.stdout
                        )
-              end
 
-              assert result.stdout == unquote(expected_stdout),
-                     fixture_failure_message(
-                       unquote(script),
-                       "stdout",
-                       unquote(expected_stdout),
-                       result.stdout
-                     )
-
-              unless unquote(ignore_stderr) do
-                assert result.stderr == unquote(expected_stderr),
-                       fixture_failure_message(
-                         unquote(script),
-                         "stderr",
-                         unquote(expected_stderr),
-                         result.stderr
-                       )
+                unless unquote(ignore_stderr) do
+                  assert result.stderr == unquote(expected_stderr),
+                         fixture_failure_message(
+                           unquote(script),
+                           "stderr",
+                           unquote(expected_stderr),
+                           result.stderr
+                         )
+                end
               end
             end
           else

--- a/test/bash_comparison/fixture_test.exs
+++ b/test/bash_comparison/fixture_test.exs
@@ -62,6 +62,14 @@ defmodule JustBash.FixtureTest do
           content_hash = Fixtures.hash_case(test_case)
           expected_result = expected_by_hash[content_hash]
 
+          # A recorded case JustBash is known not to match yet. The expectation
+          # stays recorded and the reason stays in the corpus, so the gap is
+          # visible and countable rather than absent — an unwritten case looks
+          # exactly like a passing one.
+          if gap = opts["known_gap"] do
+            @tag skip: "known gap: #{gap}"
+          end
+
           @tag suite: suite
           if expected_result do
             expected_stdout = expected_result["stdout"]

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -227,6 +227,52 @@ defmodule JustBash.Commands.UtilitiesTest do
     end
   end
 
+  describe "date -r" do
+    # The date matrix covers -r's error paths against real bash, but not its
+    # success path: the mtime of a file created during recording is the recording
+    # clock's, so the two engines cannot agree on it by construction. Seeding a
+    # known mtime is the only way to assert the value.
+    setup do
+      bash = JustBash.new()
+      {_result, bash} = JustBash.exec(bash, "echo hi > /ref.txt")
+
+      mtime = ~U[2021-03-04 05:06:07Z]
+      {:ok, fs} = JustBash.FS.write_file(bash.fs, "/ref.txt", "hi\n", mtime: mtime)
+
+      %{bash: %{bash | fs: fs}, mtime: mtime}
+    end
+
+    test "reports the reference file's modification time", %{bash: bash} do
+      {result, _} = JustBash.exec(bash, "date -r /ref.txt '+%F %T'")
+
+      assert result.exit_code == 0
+      assert result.stdout == "2021-03-04 05:06:07\n"
+    end
+
+    test "accepts the long spelling", %{bash: bash} do
+      {result, _} = JustBash.exec(bash, "date --reference=/ref.txt '+%F'")
+
+      assert result.exit_code == 0
+      assert result.stdout == "2021-03-04\n"
+    end
+
+    test "resolves a relative path against the working directory", %{bash: bash} do
+      {result, _} = JustBash.exec(bash, "cd / && date -r ref.txt '+%F'")
+
+      assert result.exit_code == 0
+      assert result.stdout == "2021-03-04\n"
+    end
+
+    test "reports the real error kind, not a hardcoded one", %{bash: bash} do
+      {result, _} = JustBash.exec(bash, "date -r /ref.txt/nope '+%F'")
+
+      assert result.exit_code == 1
+      # /ref.txt is a regular file, so descending through it is ENOTDIR — the
+      # message must not claim the file is merely absent.
+      assert result.stderr == "date: /ref.txt/nope: Not a directory\n"
+    end
+  end
+
   describe "date command" do
     test "date outputs current date" do
       bash = JustBash.new()
@@ -867,14 +913,22 @@ defmodule JustBash.Commands.UtilitiesTest do
       end
     end
 
-    # Real date also accepts a filename here; we do not, and say so rather than
-    # falling back to the current time.
-    test "a non-numeric -r argument is an error" do
+    # A non-numeric value is the other spelling of the same flag — a file to read
+    # a modification time from — so it is answered or refused as a file, never as
+    # a number that failed to parse.
+    test "a non-numeric -r argument names a file, not a malformed timestamp" do
       bash = JustBash.new(files: %{"/tmp/f.txt" => "hi"})
       {result, _} = JustBash.exec(bash, "date -r /tmp/f.txt '+%Y-%m-%d'")
+      assert result.exit_code == 0, result.stderr
+      refute result.stderr =~ "illegal time value"
+    end
+
+    test "a non-numeric -r argument that names nothing is an error, not the current date" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "date -r /tmp/absent.txt '+%Y-%m-%d'")
       assert result.exit_code == 1
       assert result.stdout == ""
-      assert result.stderr =~ "illegal time value -- /tmp/f.txt"
+      assert result.stderr == "date: /tmp/absent.txt: No such file or directory\n"
     end
   end
 

--- a/test/commands/utilities_test.exs
+++ b/test/commands/utilities_test.exs
@@ -271,6 +271,28 @@ defmodule JustBash.Commands.UtilitiesTest do
       # message must not claim the file is merely absent.
       assert result.stderr == "date: /ref.txt/nope: Not a directory\n"
     end
+
+    test "accepts the long spelling with a separate argument", %{bash: bash} do
+      {result, _} = JustBash.exec(bash, "date --reference /ref.txt '+%F'")
+
+      assert result.exit_code == 0
+      assert result.stdout == "2021-03-04\n"
+    end
+
+    # The matrix records the mutual exclusion against real bash, but only in the
+    # direction `-r` then `-d`; a reference the recorder can seed does not exist,
+    # so the other order is asserted here.
+    test "refuses -d after -r rather than picking one", %{bash: bash} do
+      {result, _} = JustBash.exec(bash, "date -d '2024-06-15' -r /ref.txt '+%F'")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+
+      assert result.stderr =~
+               "date: the options to specify dates for printing are mutually exclusive\n"
+
+      assert result.stderr =~ "usage: date"
+    end
   end
 
   describe "date command" do

--- a/test/fixtures/bash_cases/cp.json
+++ b/test/fixtures/bash_cases/cp.json
@@ -225,22 +225,22 @@
     {
       "name": "cp comparison: -r into a symlink pointing at the source is refused",
       "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir a; echo F > a/f.md; ln -s $D/a l; cp -r a l; echo rc=$?; cat a/f.md; rm -rf $D",
-      "content_hash": "e9450712650bb4a0"
+      "content_hash": "25486a1918ca99f1"
     },
     {
       "name": "cp comparison: a destination whose ancestor is a regular file cannot be stat'd",
       "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; echo A > a.md; echo X > f; cp a.md f/sub.md; echo rc=$?; rm -rf $D",
-      "content_hash": "77d202dbbde3dd3b"
+      "content_hash": "21356459cab5b2c7"
     },
     {
       "name": "cp comparison: -r onto a destination whose ancestor is a regular file cannot be stat'd",
       "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s; echo N > s/n.md; echo X > f; cp -r s f/sub; echo rc=$?; rm -rf $D",
-      "content_hash": "52a761acc5075034"
+      "content_hash": "14a536df09d1f593"
     },
     {
       "name": "cp comparison: -r onto an existing regular file cannot overwrite a non-directory",
       "script": "D=/tmp/jb_cp_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir s; echo N > s/n.md; echo X > f; cp -r s f; echo rc=$?; rm -rf $D",
-      "content_hash": "3ee5b4e3ffbbc648"
+      "content_hash": "4def2da60668382f"
     }
   ]
 }

--- a/test/fixtures/bash_cases/date_matrix.json
+++ b/test/fixtures/bash_cases/date_matrix.json
@@ -935,6 +935,27 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 -3 hours' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
     },
     {
+      "content_hash": "2c43bd0c3657225e",
+      "name": "date matrix: reference -r on a missing file",
+      "script": "TZ=UTC LC_ALL=C date -r /jb_definitely_missing '+%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "f1fe3a5838214f60",
+      "name": "date matrix: reference -r with no argument",
+      "opts": {
+        "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
+      },
+      "script": "TZ=UTC LC_ALL=C date -r; echo rc=$?"
+    },
+    {
+      "content_hash": "1310757f10875d1c",
+      "name": "date matrix: date -d with no argument",
+      "opts": {
+        "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d; echo rc=$?"
+    },
+    {
       "content_hash": "078461a27e682c98",
       "name": "date matrix: utc flag -u",
       "script": "TZ=UTC LC_ALL=C date -u -d '2024-06-15 13:30:00' '+%F %T %Z'; echo rc=$?"

--- a/test/fixtures/bash_cases/date_matrix.json
+++ b/test/fixtures/bash_cases/date_matrix.json
@@ -1,0 +1,957 @@
+{
+  "cases": [
+    {
+      "content_hash": "8a512421c503f1f6",
+      "name": "date matrix: directive %a (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%a'; echo rc=$?"
+    },
+    {
+      "content_hash": "dd87e162c7b9fe45",
+      "name": "date matrix: directive %a (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%a'; echo rc=$?"
+    },
+    {
+      "content_hash": "bd952c3ad83363ea",
+      "name": "date matrix: directive %A (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%A'; echo rc=$?"
+    },
+    {
+      "content_hash": "58ac9d25be86ee02",
+      "name": "date matrix: directive %A (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%A'; echo rc=$?"
+    },
+    {
+      "content_hash": "3bccf3cb091a0df4",
+      "name": "date matrix: directive %b (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%b'; echo rc=$?"
+    },
+    {
+      "content_hash": "48c2f1533e4edc90",
+      "name": "date matrix: directive %b (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%b'; echo rc=$?"
+    },
+    {
+      "content_hash": "b42f00344ba38511",
+      "name": "date matrix: directive %B (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%B'; echo rc=$?"
+    },
+    {
+      "content_hash": "27ea602ff75dbb76",
+      "name": "date matrix: directive %B (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%B'; echo rc=$?"
+    },
+    {
+      "content_hash": "e148e5d7269cc6f7",
+      "name": "date matrix: directive %c (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%c'; echo rc=$?"
+    },
+    {
+      "content_hash": "8170cd93b1ee3970",
+      "name": "date matrix: directive %c (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%c'; echo rc=$?"
+    },
+    {
+      "content_hash": "609c417d9eb36be8",
+      "name": "date matrix: directive %C (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%C'; echo rc=$?"
+    },
+    {
+      "content_hash": "8ed42a3fc85ee04b",
+      "name": "date matrix: directive %C (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%C'; echo rc=$?"
+    },
+    {
+      "content_hash": "9a0b9535ba5de345",
+      "name": "date matrix: directive %d (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "3b9fe013a4373c65",
+      "name": "date matrix: directive %d (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "4d092b7823d5509a",
+      "name": "date matrix: directive %D (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%D'; echo rc=$?"
+    },
+    {
+      "content_hash": "572da704437b15c6",
+      "name": "date matrix: directive %D (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%D'; echo rc=$?"
+    },
+    {
+      "content_hash": "2e652974ea03e3b6",
+      "name": "date matrix: directive %e (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%e'; echo rc=$?"
+    },
+    {
+      "content_hash": "c679b175dfc9da46",
+      "name": "date matrix: directive %e (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%e'; echo rc=$?"
+    },
+    {
+      "content_hash": "bdc3ff2379f61837",
+      "name": "date matrix: directive %F (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "6fa6074d14e7b962",
+      "name": "date matrix: directive %F (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "0eecc350b1f35b97",
+      "name": "date matrix: directive %g (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%g'; echo rc=$?"
+    },
+    {
+      "content_hash": "858671d4c811b091",
+      "name": "date matrix: directive %g (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%g'; echo rc=$?"
+    },
+    {
+      "content_hash": "47ac3d2e0f9d2716",
+      "name": "date matrix: directive %G (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%G'; echo rc=$?"
+    },
+    {
+      "content_hash": "0e188f1f98b57670",
+      "name": "date matrix: directive %G (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%G'; echo rc=$?"
+    },
+    {
+      "content_hash": "84f1b7701869bcde",
+      "name": "date matrix: directive %h (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%h'; echo rc=$?"
+    },
+    {
+      "content_hash": "8bcc542278a94e87",
+      "name": "date matrix: directive %h (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%h'; echo rc=$?"
+    },
+    {
+      "content_hash": "fadeb047a08c49a9",
+      "name": "date matrix: directive %H (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%H'; echo rc=$?"
+    },
+    {
+      "content_hash": "c7965c3eb24b29df",
+      "name": "date matrix: directive %H (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%H'; echo rc=$?"
+    },
+    {
+      "content_hash": "7b48191fb1a5b6e1",
+      "name": "date matrix: directive %I (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%I'; echo rc=$?"
+    },
+    {
+      "content_hash": "0356bc1b00d5d7cd",
+      "name": "date matrix: directive %I (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%I'; echo rc=$?"
+    },
+    {
+      "content_hash": "5f76f4e8a7710411",
+      "name": "date matrix: directive %j (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%j'; echo rc=$?"
+    },
+    {
+      "content_hash": "e58beffeef851e1f",
+      "name": "date matrix: directive %j (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%j'; echo rc=$?"
+    },
+    {
+      "content_hash": "660eaf3387141170",
+      "name": "date matrix: directive %k (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%k'; echo rc=$?"
+    },
+    {
+      "content_hash": "632fe732934bf946",
+      "name": "date matrix: directive %k (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%k'; echo rc=$?"
+    },
+    {
+      "content_hash": "da9e91385bcd9b4b",
+      "name": "date matrix: directive %l (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%l'; echo rc=$?"
+    },
+    {
+      "content_hash": "9d316b249d037cba",
+      "name": "date matrix: directive %l (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%l'; echo rc=$?"
+    },
+    {
+      "content_hash": "daf96127b6418ff3",
+      "name": "date matrix: directive %m (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%m'; echo rc=$?"
+    },
+    {
+      "content_hash": "e2241c81bb5421e5",
+      "name": "date matrix: directive %m (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%m'; echo rc=$?"
+    },
+    {
+      "content_hash": "c3ec8615e5a118d0",
+      "name": "date matrix: directive %M (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%M'; echo rc=$?"
+    },
+    {
+      "content_hash": "0767e07ab78c1866",
+      "name": "date matrix: directive %M (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%M'; echo rc=$?"
+    },
+    {
+      "content_hash": "719c85d03b940f5e",
+      "name": "date matrix: directive %n (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%n'; echo rc=$?"
+    },
+    {
+      "content_hash": "dff7a0b251ec631b",
+      "name": "date matrix: directive %n (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%n'; echo rc=$?"
+    },
+    {
+      "content_hash": "a3a907a330f4067e",
+      "name": "date matrix: directive %N (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%N'; echo rc=$?"
+    },
+    {
+      "content_hash": "3eae86bc7a2e37d4",
+      "name": "date matrix: directive %N (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%N'; echo rc=$?"
+    },
+    {
+      "content_hash": "79424f8605970eb7",
+      "name": "date matrix: directive %p (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%p'; echo rc=$?"
+    },
+    {
+      "content_hash": "c9463befa11f6f38",
+      "name": "date matrix: directive %p (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%p'; echo rc=$?"
+    },
+    {
+      "content_hash": "71ad8effb369c9c1",
+      "name": "date matrix: directive %P (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%P'; echo rc=$?"
+    },
+    {
+      "content_hash": "6b6b3a6c5184cdb3",
+      "name": "date matrix: directive %P (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%P'; echo rc=$?"
+    },
+    {
+      "content_hash": "791f14466df2dfba",
+      "name": "date matrix: directive %q (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%q'; echo rc=$?"
+    },
+    {
+      "content_hash": "07898ee3cfe3a06b",
+      "name": "date matrix: directive %q (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%q'; echo rc=$?"
+    },
+    {
+      "content_hash": "e6ef1b48a0f443a7",
+      "name": "date matrix: directive %r (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%r'; echo rc=$?"
+    },
+    {
+      "content_hash": "9ba578beaeb9caaa",
+      "name": "date matrix: directive %r (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%r'; echo rc=$?"
+    },
+    {
+      "content_hash": "cc32452e4893127c",
+      "name": "date matrix: directive %R (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%R'; echo rc=$?"
+    },
+    {
+      "content_hash": "5ac22ccbc33a7714",
+      "name": "date matrix: directive %R (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%R'; echo rc=$?"
+    },
+    {
+      "content_hash": "271379063d131a1b",
+      "name": "date matrix: directive %s (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%s'; echo rc=$?"
+    },
+    {
+      "content_hash": "e219273c7021b090",
+      "name": "date matrix: directive %s (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%s'; echo rc=$?"
+    },
+    {
+      "content_hash": "e1da279f3096227e",
+      "name": "date matrix: directive %S (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "ad0169d4ceaa89e7",
+      "name": "date matrix: directive %S (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "fc362ca8a86a8cb2",
+      "name": "date matrix: directive %t (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%t'; echo rc=$?"
+    },
+    {
+      "content_hash": "5a2df75753a2fbcd",
+      "name": "date matrix: directive %t (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%t'; echo rc=$?"
+    },
+    {
+      "content_hash": "b56ecdd6fca6eed8",
+      "name": "date matrix: directive %T (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%T'; echo rc=$?"
+    },
+    {
+      "content_hash": "0bd0bfc60fe97ab3",
+      "name": "date matrix: directive %T (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%T'; echo rc=$?"
+    },
+    {
+      "content_hash": "3675bace1c8ec962",
+      "name": "date matrix: directive %u (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%u'; echo rc=$?"
+    },
+    {
+      "content_hash": "1b1e5222a3b78309",
+      "name": "date matrix: directive %u (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%u'; echo rc=$?"
+    },
+    {
+      "content_hash": "e58e8b6022b29444",
+      "name": "date matrix: directive %U (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%U'; echo rc=$?"
+    },
+    {
+      "content_hash": "9951f88ca197b753",
+      "name": "date matrix: directive %U (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%U'; echo rc=$?"
+    },
+    {
+      "content_hash": "826a2a38c18df58d",
+      "name": "date matrix: directive %V (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%V'; echo rc=$?"
+    },
+    {
+      "content_hash": "7b98ed3a2a17a83a",
+      "name": "date matrix: directive %V (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%V'; echo rc=$?"
+    },
+    {
+      "content_hash": "2ca3916a701a047a",
+      "name": "date matrix: directive %w (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%w'; echo rc=$?"
+    },
+    {
+      "content_hash": "d4c53a88b8e7a6ba",
+      "name": "date matrix: directive %w (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%w'; echo rc=$?"
+    },
+    {
+      "content_hash": "75a718845d827205",
+      "name": "date matrix: directive %W (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%W'; echo rc=$?"
+    },
+    {
+      "content_hash": "a878077f0a57eb7d",
+      "name": "date matrix: directive %W (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%W'; echo rc=$?"
+    },
+    {
+      "content_hash": "5954a7be901a6c4c",
+      "name": "date matrix: directive %x (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%x'; echo rc=$?"
+    },
+    {
+      "content_hash": "8f9b16c5f1080215",
+      "name": "date matrix: directive %x (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%x'; echo rc=$?"
+    },
+    {
+      "content_hash": "152b36fbeb49a36f",
+      "name": "date matrix: directive %X (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%X'; echo rc=$?"
+    },
+    {
+      "content_hash": "f43c67c955e7269a",
+      "name": "date matrix: directive %X (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%X'; echo rc=$?"
+    },
+    {
+      "content_hash": "08afc71636bf9f82",
+      "name": "date matrix: directive %y (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%y'; echo rc=$?"
+    },
+    {
+      "content_hash": "8e3fe28f48e3d777",
+      "name": "date matrix: directive %y (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%y'; echo rc=$?"
+    },
+    {
+      "content_hash": "229b0f4f8cc45377",
+      "name": "date matrix: directive %Y (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "5f3de776c7224721",
+      "name": "date matrix: directive %Y (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "5afc4f2c3e44ff0e",
+      "name": "date matrix: directive %z (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%z'; echo rc=$?"
+    },
+    {
+      "content_hash": "3d5e0f401a55e41e",
+      "name": "date matrix: directive %z (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%z'; echo rc=$?"
+    },
+    {
+      "content_hash": "9dd7a235eb4e5d94",
+      "name": "date matrix: directive %Z (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "dace2b94dc0a864c",
+      "name": "date matrix: directive %Z (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "f3240fae37076edc",
+      "name": "date matrix: modifier %:z (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%:z'; echo rc=$?"
+    },
+    {
+      "content_hash": "6933c63c2d5f4a12",
+      "name": "date matrix: modifier %:z (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%:z'; echo rc=$?"
+    },
+    {
+      "content_hash": "ed6b7ad13ec47e70",
+      "name": "date matrix: modifier %::z (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%::z'; echo rc=$?"
+    },
+    {
+      "content_hash": "b2b0f809d217affc",
+      "name": "date matrix: modifier %::z (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%::z'; echo rc=$?"
+    },
+    {
+      "content_hash": "075e142ce0fa9942",
+      "name": "date matrix: modifier %:::z (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%:::z'; echo rc=$?"
+    },
+    {
+      "content_hash": "5849420cd1bf91a7",
+      "name": "date matrix: modifier %:::z (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%:::z'; echo rc=$?"
+    },
+    {
+      "content_hash": "7cd1652285503484",
+      "name": "date matrix: modifier %-d (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%-d'; echo rc=$?"
+    },
+    {
+      "content_hash": "91179ae7c00a3af6",
+      "name": "date matrix: modifier %-d (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-d'; echo rc=$?"
+    },
+    {
+      "content_hash": "f89ee1d2976a8689",
+      "name": "date matrix: modifier %_d (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%_d'; echo rc=$?"
+    },
+    {
+      "content_hash": "0fb029c7e0add102",
+      "name": "date matrix: modifier %_d (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_d'; echo rc=$?"
+    },
+    {
+      "content_hash": "c4dda1e428c67866",
+      "name": "date matrix: modifier %0d (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%0d'; echo rc=$?"
+    },
+    {
+      "content_hash": "94346ff6dfbe13e0",
+      "name": "date matrix: modifier %0d (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%0d'; echo rc=$?"
+    },
+    {
+      "content_hash": "5a6fe0fcac6631f1",
+      "name": "date matrix: modifier %^a (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%^a'; echo rc=$?"
+    },
+    {
+      "content_hash": "56690bb18e265c4a",
+      "name": "date matrix: modifier %^a (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%^a'; echo rc=$?"
+    },
+    {
+      "content_hash": "e693440e54e2530e",
+      "name": "date matrix: modifier %#a (pm)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%#a'; echo rc=$?"
+    },
+    {
+      "content_hash": "c4829e5b13f00357",
+      "name": "date matrix: modifier %#a (am)",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%#a'; echo rc=$?"
+    },
+    {
+      "content_hash": "48edbdf07a846391",
+      "name": "date matrix: sequence %%F",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "c9013071fb71b575",
+      "name": "date matrix: sequence %%%F",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%%%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "c69bcf0d89af124a",
+      "name": "date matrix: sequence %F%T",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%F%T'; echo rc=$?"
+    },
+    {
+      "content_hash": "4ddbd4f98603f2ab",
+      "name": "date matrix: sequence %Y%m%d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%Y%m%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "abdf09331b00ebe6",
+      "name": "date matrix: sequence %%",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%%'; echo rc=$?"
+    },
+    {
+      "content_hash": "fd5a9115d88d4190",
+      "name": "date matrix: sequence %%%%",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%%%%'; echo rc=$?"
+    },
+    {
+      "content_hash": "42cffd71070ce1e1",
+      "name": "date matrix: sequence %",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%'; echo rc=$?"
+    },
+    {
+      "content_hash": "002f9b3c53113712",
+      "name": "date matrix: sequence %F%",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%F%'; echo rc=$?"
+    },
+    {
+      "content_hash": "397f45f11970880b",
+      "name": "date matrix: sequence %J",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%J'; echo rc=$?"
+    },
+    {
+      "content_hash": "a543f6a69bf87053",
+      "name": "date matrix: sequence %%J",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%%J'; echo rc=$?"
+    },
+    {
+      "content_hash": "f77f349300cbffd1",
+      "name": "date matrix: sequence %F%J%T",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%F%J%T'; echo rc=$?"
+    },
+    {
+      "content_hash": "4c65d6e69f93fba9",
+      "name": "date matrix: sequence %#%!",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%#%!'; echo rc=$?"
+    },
+    {
+      "content_hash": "15c5ec781c0d815b",
+      "name": "date matrix: sequence %-%d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%-%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "cbf3a17d2580c73b",
+      "name": "date matrix: sequence %#%%",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%#%%'; echo rc=$?"
+    },
+    {
+      "content_hash": "0e29e7b180781137",
+      "name": "date matrix: sequence %--d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%--d'; echo rc=$?"
+    },
+    {
+      "content_hash": "942bd10ef2ec1c13",
+      "name": "date matrix: sequence %0-d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%0-d'; echo rc=$?"
+    },
+    {
+      "content_hash": "9e580938236787c7",
+      "name": "date matrix: sequence %^%a",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%^%a'; echo rc=$?"
+    },
+    {
+      "content_hash": "c34887335e1a489e",
+      "name": "date matrix: sequence %#",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%#'; echo rc=$?"
+    },
+    {
+      "content_hash": "7cae49cca129dabc",
+      "name": "date matrix: sequence %-",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%-'; echo rc=$?"
+    },
+    {
+      "content_hash": "07448cba5cb51935",
+      "name": "date matrix: sequence %_",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%_'; echo rc=$?"
+    },
+    {
+      "content_hash": "fb74626e515523a9",
+      "name": "date matrix: sequence %0",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%0'; echo rc=$?"
+    },
+    {
+      "content_hash": "46c200f56a5d2098",
+      "name": "date matrix: sequence %^",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%^'; echo rc=$?"
+    },
+    {
+      "content_hash": "ccff5030b14bab86",
+      "name": "date matrix: sequence %^!",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%^!'; echo rc=$?"
+    },
+    {
+      "content_hash": "b5d066f089dbf4aa",
+      "name": "date matrix: width %3d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%3d'; echo rc=$?"
+    },
+    {
+      "content_hash": "4b3428a2d17eab55",
+      "name": "date matrix: width %03d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%03d'; echo rc=$?"
+    },
+    {
+      "content_hash": "796c4afea8a20282",
+      "name": "date matrix: width %_3d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_3d'; echo rc=$?"
+    },
+    {
+      "content_hash": "4f1e4eff6077d5cb",
+      "name": "date matrix: width %-3d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-3d'; echo rc=$?"
+    },
+    {
+      "content_hash": "18a98b4727e1de45",
+      "name": "date matrix: width %_10d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_10d'; echo rc=$?"
+    },
+    {
+      "content_hash": "992f6e762d513467",
+      "name": "date matrix: width %^3a",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%^3a'; echo rc=$?"
+    },
+    {
+      "content_hash": "0aea9aaafcf3c704",
+      "name": "date matrix: width %-0d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-0d'; echo rc=$?"
+    },
+    {
+      "content_hash": "2ba86bfc2bec7580",
+      "name": "date matrix: width %0_d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%0_d'; echo rc=$?"
+    },
+    {
+      "content_hash": "01d474ef0f50a4b6",
+      "name": "date matrix: width %_2H",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_2H'; echo rc=$?"
+    },
+    {
+      "content_hash": "0e4b24f19f3e863d",
+      "name": "date matrix: width %_3H",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_3H'; echo rc=$?"
+    },
+    {
+      "content_hash": "91179ae7c00a3af6",
+      "name": "date matrix: width %-d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-d'; echo rc=$?"
+    },
+    {
+      "content_hash": "a738e8a06de22838",
+      "name": "date matrix: width %-H",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-H'; echo rc=$?"
+    },
+    {
+      "content_hash": "c63003a9b4ecfa83",
+      "name": "date matrix: width %-M",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-M'; echo rc=$?"
+    },
+    {
+      "content_hash": "d48bfaf8b016c0a9",
+      "name": "date matrix: width %-e",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-e'; echo rc=$?"
+    },
+    {
+      "content_hash": "c3062753465650c5",
+      "name": "date matrix: width %_e",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_e'; echo rc=$?"
+    },
+    {
+      "content_hash": "44ea476b5fb31d31",
+      "name": "date matrix: width %0e",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%0e'; echo rc=$?"
+    },
+    {
+      "content_hash": "4d0391419efaee45",
+      "name": "date matrix: width %-I",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-I'; echo rc=$?"
+    },
+    {
+      "content_hash": "ba54a2f29b2c6048",
+      "name": "date matrix: width %-j",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-j'; echo rc=$?"
+    },
+    {
+      "content_hash": "3eae86bc7a2e37d4",
+      "name": "date matrix: nanoseconds %N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%N'; echo rc=$?"
+    },
+    {
+      "content_hash": "4ed5c032daf57339",
+      "name": "date matrix: nanoseconds %-N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-N'; echo rc=$?"
+    },
+    {
+      "content_hash": "ddd7406e16565600",
+      "name": "date matrix: nanoseconds %0N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%0N'; echo rc=$?"
+    },
+    {
+      "content_hash": "c571c2da89e6886e",
+      "name": "date matrix: nanoseconds %^N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%^N'; echo rc=$?"
+    },
+    {
+      "content_hash": "75c7156a1bf629a7",
+      "name": "date matrix: nanoseconds %3N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%3N'; echo rc=$?"
+    },
+    {
+      "content_hash": "513512382567a1d8",
+      "name": "date matrix: nanoseconds %6N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%6N'; echo rc=$?"
+    },
+    {
+      "content_hash": "1e836116dc5c3c11",
+      "name": "date matrix: nanoseconds %_N",
+      "opts": {
+        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_N'; echo rc=$?"
+    },
+    {
+      "content_hash": "0514b760a2820297",
+      "name": "date matrix: nanoseconds %-3N",
+      "opts": {
+        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-3N'; echo rc=$?"
+    },
+    {
+      "content_hash": "fc387fb480e5d687",
+      "name": "date matrix: nanoseconds %_6N",
+      "opts": {
+        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_6N'; echo rc=$?"
+    },
+    {
+      "content_hash": "c6678c35339e5c11",
+      "name": "date matrix: iso -I",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' -I; echo rc=$?"
+    },
+    {
+      "content_hash": "7a7f5d0b21ac6a77",
+      "name": "date matrix: iso -Idate",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' -Idate; echo rc=$?"
+    },
+    {
+      "content_hash": "635ff93ef2156c55",
+      "name": "date matrix: iso -Ihours",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' -Ihours; echo rc=$?"
+    },
+    {
+      "content_hash": "459b35fb1d9b8b0c",
+      "name": "date matrix: iso -Iminutes",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' -Iminutes; echo rc=$?"
+    },
+    {
+      "content_hash": "7c0227ca707c26b2",
+      "name": "date matrix: iso -Iseconds",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' -Iseconds; echo rc=$?"
+    },
+    {
+      "content_hash": "840b099ca0fabb34",
+      "name": "date matrix: iso -Ins",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' -Ins; echo rc=$?"
+    },
+    {
+      "content_hash": "4f11cc12be3bc172",
+      "name": "date matrix: iso --iso-8601=date",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' --iso-8601=date; echo rc=$?"
+    },
+    {
+      "content_hash": "c84169ea50e52d6a",
+      "name": "date matrix: absent flag -v+6m",
+      "opts": {
+        "known_gap": "-v is a supported BSD adjustment here; GNU date rejects it"
+      },
+      "script": "TZ=UTC LC_ALL=C date -v+6m '+%Y-%m-%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "abb8f913c622f810",
+      "name": "date matrix: absent flag -v +6m",
+      "opts": {
+        "known_gap": "-v is a supported BSD adjustment here; GNU date rejects it"
+      },
+      "script": "TZ=UTC LC_ALL=C date -v +6m '+%Y-%m-%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "664b17e37dd38307",
+      "name": "date matrix: absent flag -v-1d",
+      "opts": {
+        "known_gap": "-v is a supported BSD adjustment here; GNU date rejects it"
+      },
+      "script": "TZ=UTC LC_ALL=C date -v-1d '+%Y-%m-%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "3424b4761e50bb0b",
+      "name": "date matrix: absent flag -j",
+      "opts": {
+        "known_gap": "-j/-f are supported as documented BSD spellings; GNU date rejects them"
+      },
+      "script": "TZ=UTC LC_ALL=C date -j '+%Y-%m-%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "af848d1644742c50",
+      "name": "date matrix: absent flag -jf %Y",
+      "opts": {
+        "known_gap": "-j/-f are supported as documented BSD spellings; GNU date rejects them"
+      },
+      "script": "TZ=UTC LC_ALL=C date -jf %Y '+%Y-%m-%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "71fe849c4622447d",
+      "name": "date matrix: absent flag --not-a-flag",
+      "opts": {
+        "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
+      },
+      "script": "TZ=UTC LC_ALL=C date --not-a-flag '+%Y-%m-%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "3b45b455bd05a440",
+      "name": "date matrix: absent flag -Z",
+      "opts": {
+        "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
+      },
+      "script": "TZ=UTC LC_ALL=C date -Z '+%Y-%m-%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "6d4acdf0797b483c",
+      "name": "date matrix: input 2024-06-15",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "5f093291eb930c27",
+      "name": "date matrix: input 2024-06-15 13:30:00",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "4756938c087e2646",
+      "name": "date matrix: input 2024-06-15T13:30:00",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15T13:30:00' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "7678424c6ef68df8",
+      "name": "date matrix: input @1718458200",
+      "script": "TZ=UTC LC_ALL=C date -d '@1718458200' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "7d29779998b12451",
+      "name": "date matrix: input 2024-06-15 13:30:00 +1 day",
+      "opts": {
+        "known_gap": "GNU relative date grammar for -d is not implemented"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 +1 day' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "ea28149f995dc2e0",
+      "name": "date matrix: input 2024-06-15 13:30:00 1 day ago",
+      "opts": {
+        "known_gap": "GNU relative date grammar for -d is not implemented"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 1 day ago' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "5f8d8bfedf84679e",
+      "name": "date matrix: input 2024-06-15 13:30:00 +6 months",
+      "opts": {
+        "known_gap": "GNU relative date grammar for -d is not implemented"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 +6 months' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "cedb8e27b704590a",
+      "name": "date matrix: input 2024-06-15 13:30:00 6 months ago",
+      "opts": {
+        "known_gap": "GNU relative date grammar for -d is not implemented"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 6 months ago' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "d63f27de2f944ae9",
+      "name": "date matrix: input 2024-06-15 13:30:00 next tuesday",
+      "opts": {
+        "known_gap": "GNU relative date grammar for -d is not implemented"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 next tuesday' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "e2d87faf59d17708",
+      "name": "date matrix: input 2024-06-15 13:30:00 last monday",
+      "opts": {
+        "known_gap": "GNU relative date grammar for -d is not implemented"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 last monday' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "56e4575071228587",
+      "name": "date matrix: input 2024-06-15 13:30:00 +2 weeks",
+      "opts": {
+        "known_gap": "GNU relative date grammar for -d is not implemented"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 +2 weeks' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "d2003f3c147e0007",
+      "name": "date matrix: input 2024-06-15 13:30:00 -3 hours",
+      "opts": {
+        "known_gap": "GNU relative date grammar for -d is not implemented"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00 -3 hours' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "078461a27e682c98",
+      "name": "date matrix: utc flag -u",
+      "script": "TZ=UTC LC_ALL=C date -u -d '2024-06-15 13:30:00' '+%F %T %Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "c2adae4be1a7309e",
+      "name": "date matrix: rfc flag -R",
+      "script": "TZ=UTC LC_ALL=C date -R -d '2024-06-15 13:30:00'; echo rc=$?"
+    },
+    {
+      "content_hash": "0cae21027fa38e87",
+      "name": "date matrix: reads -f from a file",
+      "opts": {
+        "known_gap": "-f is the BSD input-format flag here; GNU reads dates from the named file"
+      },
+      "script": "printf '%s\\n' '2024-06-15 13:30:00' > /tmp/jb_d_$$; TZ=UTC LC_ALL=C date -f /tmp/jb_d_$$ '+%F'; echo rc=$?; rm -f /tmp/jb_d_$$"
+    }
+  ],
+  "suite": "date_matrix"
+}

--- a/test/fixtures/bash_cases/date_matrix.json
+++ b/test/fixtures/bash_cases/date_matrix.json
@@ -11,6 +11,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%a'; echo rc=$?"
     },
     {
+      "content_hash": "009b15f92d736cda",
+      "name": "date matrix: directive %a (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%a'; echo rc=$?"
+    },
+    {
       "content_hash": "bd952c3ad83363ea",
       "name": "date matrix: directive %A (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%A'; echo rc=$?"
@@ -19,6 +24,11 @@
       "content_hash": "58ac9d25be86ee02",
       "name": "date matrix: directive %A (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%A'; echo rc=$?"
+    },
+    {
+      "content_hash": "f8f1bb8bb93c1b45",
+      "name": "date matrix: directive %A (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%A'; echo rc=$?"
     },
     {
       "content_hash": "3bccf3cb091a0df4",
@@ -31,6 +41,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%b'; echo rc=$?"
     },
     {
+      "content_hash": "0200a368463c1af1",
+      "name": "date matrix: directive %b (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%b'; echo rc=$?"
+    },
+    {
       "content_hash": "b42f00344ba38511",
       "name": "date matrix: directive %B (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%B'; echo rc=$?"
@@ -39,6 +54,11 @@
       "content_hash": "27ea602ff75dbb76",
       "name": "date matrix: directive %B (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%B'; echo rc=$?"
+    },
+    {
+      "content_hash": "235ce2e7fa904ac0",
+      "name": "date matrix: directive %B (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%B'; echo rc=$?"
     },
     {
       "content_hash": "e148e5d7269cc6f7",
@@ -51,6 +71,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%c'; echo rc=$?"
     },
     {
+      "content_hash": "b033a283a9d93525",
+      "name": "date matrix: directive %c (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%c'; echo rc=$?"
+    },
+    {
       "content_hash": "609c417d9eb36be8",
       "name": "date matrix: directive %C (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%C'; echo rc=$?"
@@ -59,6 +84,11 @@
       "content_hash": "8ed42a3fc85ee04b",
       "name": "date matrix: directive %C (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%C'; echo rc=$?"
+    },
+    {
+      "content_hash": "10f2c562c739e06a",
+      "name": "date matrix: directive %C (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%C'; echo rc=$?"
     },
     {
       "content_hash": "9a0b9535ba5de345",
@@ -71,6 +101,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%d'; echo rc=$?"
     },
     {
+      "content_hash": "58c8570753b70c7c",
+      "name": "date matrix: directive %d (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%d'; echo rc=$?"
+    },
+    {
       "content_hash": "4d092b7823d5509a",
       "name": "date matrix: directive %D (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%D'; echo rc=$?"
@@ -79,6 +114,11 @@
       "content_hash": "572da704437b15c6",
       "name": "date matrix: directive %D (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%D'; echo rc=$?"
+    },
+    {
+      "content_hash": "49c7f768f32942be",
+      "name": "date matrix: directive %D (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%D'; echo rc=$?"
     },
     {
       "content_hash": "2e652974ea03e3b6",
@@ -91,6 +131,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%e'; echo rc=$?"
     },
     {
+      "content_hash": "48b7add7083a0ebb",
+      "name": "date matrix: directive %e (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%e'; echo rc=$?"
+    },
+    {
       "content_hash": "bdc3ff2379f61837",
       "name": "date matrix: directive %F (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%F'; echo rc=$?"
@@ -99,6 +144,11 @@
       "content_hash": "6fa6074d14e7b962",
       "name": "date matrix: directive %F (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "4ca946135a859e71",
+      "name": "date matrix: directive %F (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%F'; echo rc=$?"
     },
     {
       "content_hash": "0eecc350b1f35b97",
@@ -111,6 +161,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%g'; echo rc=$?"
     },
     {
+      "content_hash": "919890df47a4a207",
+      "name": "date matrix: directive %g (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%g'; echo rc=$?"
+    },
+    {
       "content_hash": "47ac3d2e0f9d2716",
       "name": "date matrix: directive %G (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%G'; echo rc=$?"
@@ -119,6 +174,11 @@
       "content_hash": "0e188f1f98b57670",
       "name": "date matrix: directive %G (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%G'; echo rc=$?"
+    },
+    {
+      "content_hash": "3b7ae88587f17193",
+      "name": "date matrix: directive %G (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%G'; echo rc=$?"
     },
     {
       "content_hash": "84f1b7701869bcde",
@@ -131,6 +191,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%h'; echo rc=$?"
     },
     {
+      "content_hash": "c3b6e82930ead236",
+      "name": "date matrix: directive %h (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%h'; echo rc=$?"
+    },
+    {
       "content_hash": "fadeb047a08c49a9",
       "name": "date matrix: directive %H (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%H'; echo rc=$?"
@@ -139,6 +204,11 @@
       "content_hash": "c7965c3eb24b29df",
       "name": "date matrix: directive %H (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%H'; echo rc=$?"
+    },
+    {
+      "content_hash": "a0aa94d5a20b804f",
+      "name": "date matrix: directive %H (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%H'; echo rc=$?"
     },
     {
       "content_hash": "7b48191fb1a5b6e1",
@@ -151,6 +221,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%I'; echo rc=$?"
     },
     {
+      "content_hash": "f28cf6b977400f90",
+      "name": "date matrix: directive %I (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%I'; echo rc=$?"
+    },
+    {
       "content_hash": "5f76f4e8a7710411",
       "name": "date matrix: directive %j (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%j'; echo rc=$?"
@@ -159,6 +234,11 @@
       "content_hash": "e58beffeef851e1f",
       "name": "date matrix: directive %j (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%j'; echo rc=$?"
+    },
+    {
+      "content_hash": "f7139320e275a293",
+      "name": "date matrix: directive %j (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%j'; echo rc=$?"
     },
     {
       "content_hash": "660eaf3387141170",
@@ -171,6 +251,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%k'; echo rc=$?"
     },
     {
+      "content_hash": "f225cb3b89e22fcc",
+      "name": "date matrix: directive %k (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%k'; echo rc=$?"
+    },
+    {
       "content_hash": "da9e91385bcd9b4b",
       "name": "date matrix: directive %l (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%l'; echo rc=$?"
@@ -179,6 +264,11 @@
       "content_hash": "9d316b249d037cba",
       "name": "date matrix: directive %l (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%l'; echo rc=$?"
+    },
+    {
+      "content_hash": "1f65aadb83e97823",
+      "name": "date matrix: directive %l (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%l'; echo rc=$?"
     },
     {
       "content_hash": "daf96127b6418ff3",
@@ -191,6 +281,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%m'; echo rc=$?"
     },
     {
+      "content_hash": "6147afc349405983",
+      "name": "date matrix: directive %m (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%m'; echo rc=$?"
+    },
+    {
       "content_hash": "c3ec8615e5a118d0",
       "name": "date matrix: directive %M (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%M'; echo rc=$?"
@@ -199,6 +294,11 @@
       "content_hash": "0767e07ab78c1866",
       "name": "date matrix: directive %M (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%M'; echo rc=$?"
+    },
+    {
+      "content_hash": "4f94a1a3ccb01d45",
+      "name": "date matrix: directive %M (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%M'; echo rc=$?"
     },
     {
       "content_hash": "719c85d03b940f5e",
@@ -211,6 +311,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%n'; echo rc=$?"
     },
     {
+      "content_hash": "c1ab52f62211882f",
+      "name": "date matrix: directive %n (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%n'; echo rc=$?"
+    },
+    {
       "content_hash": "a3a907a330f4067e",
       "name": "date matrix: directive %N (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%N'; echo rc=$?"
@@ -219,6 +324,11 @@
       "content_hash": "3eae86bc7a2e37d4",
       "name": "date matrix: directive %N (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%N'; echo rc=$?"
+    },
+    {
+      "content_hash": "15cbc5c09fc4a632",
+      "name": "date matrix: directive %N (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%N'; echo rc=$?"
     },
     {
       "content_hash": "79424f8605970eb7",
@@ -231,6 +341,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%p'; echo rc=$?"
     },
     {
+      "content_hash": "1cab4a212f001661",
+      "name": "date matrix: directive %p (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%p'; echo rc=$?"
+    },
+    {
       "content_hash": "71ad8effb369c9c1",
       "name": "date matrix: directive %P (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%P'; echo rc=$?"
@@ -239,6 +354,11 @@
       "content_hash": "6b6b3a6c5184cdb3",
       "name": "date matrix: directive %P (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%P'; echo rc=$?"
+    },
+    {
+      "content_hash": "3a815456752dad0e",
+      "name": "date matrix: directive %P (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%P'; echo rc=$?"
     },
     {
       "content_hash": "791f14466df2dfba",
@@ -251,6 +371,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%q'; echo rc=$?"
     },
     {
+      "content_hash": "fcbe58d915f81614",
+      "name": "date matrix: directive %q (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%q'; echo rc=$?"
+    },
+    {
       "content_hash": "e6ef1b48a0f443a7",
       "name": "date matrix: directive %r (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%r'; echo rc=$?"
@@ -259,6 +384,11 @@
       "content_hash": "9ba578beaeb9caaa",
       "name": "date matrix: directive %r (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%r'; echo rc=$?"
+    },
+    {
+      "content_hash": "622bbecc8ca92fc0",
+      "name": "date matrix: directive %r (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%r'; echo rc=$?"
     },
     {
       "content_hash": "cc32452e4893127c",
@@ -271,6 +401,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%R'; echo rc=$?"
     },
     {
+      "content_hash": "aa0170fb95a1ad5b",
+      "name": "date matrix: directive %R (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%R'; echo rc=$?"
+    },
+    {
       "content_hash": "271379063d131a1b",
       "name": "date matrix: directive %s (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%s'; echo rc=$?"
@@ -279,6 +414,11 @@
       "content_hash": "e219273c7021b090",
       "name": "date matrix: directive %s (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%s'; echo rc=$?"
+    },
+    {
+      "content_hash": "94dc76ac6d785605",
+      "name": "date matrix: directive %s (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%s'; echo rc=$?"
     },
     {
       "content_hash": "e1da279f3096227e",
@@ -291,6 +431,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%S'; echo rc=$?"
     },
     {
+      "content_hash": "5265d621f2a9feb2",
+      "name": "date matrix: directive %S (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%S'; echo rc=$?"
+    },
+    {
       "content_hash": "fc362ca8a86a8cb2",
       "name": "date matrix: directive %t (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%t'; echo rc=$?"
@@ -299,6 +444,11 @@
       "content_hash": "5a2df75753a2fbcd",
       "name": "date matrix: directive %t (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%t'; echo rc=$?"
+    },
+    {
+      "content_hash": "348cfd17be46455a",
+      "name": "date matrix: directive %t (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%t'; echo rc=$?"
     },
     {
       "content_hash": "b56ecdd6fca6eed8",
@@ -311,6 +461,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%T'; echo rc=$?"
     },
     {
+      "content_hash": "51ff3cfae1b5538c",
+      "name": "date matrix: directive %T (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%T'; echo rc=$?"
+    },
+    {
       "content_hash": "3675bace1c8ec962",
       "name": "date matrix: directive %u (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%u'; echo rc=$?"
@@ -319,6 +474,11 @@
       "content_hash": "1b1e5222a3b78309",
       "name": "date matrix: directive %u (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%u'; echo rc=$?"
+    },
+    {
+      "content_hash": "25a928e9032d9fdb",
+      "name": "date matrix: directive %u (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%u'; echo rc=$?"
     },
     {
       "content_hash": "e58e8b6022b29444",
@@ -331,6 +491,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%U'; echo rc=$?"
     },
     {
+      "content_hash": "6b0c00f87ce57fa4",
+      "name": "date matrix: directive %U (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%U'; echo rc=$?"
+    },
+    {
       "content_hash": "826a2a38c18df58d",
       "name": "date matrix: directive %V (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%V'; echo rc=$?"
@@ -339,6 +504,11 @@
       "content_hash": "7b98ed3a2a17a83a",
       "name": "date matrix: directive %V (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%V'; echo rc=$?"
+    },
+    {
+      "content_hash": "d732d9bd8afaff20",
+      "name": "date matrix: directive %V (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%V'; echo rc=$?"
     },
     {
       "content_hash": "2ca3916a701a047a",
@@ -351,6 +521,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%w'; echo rc=$?"
     },
     {
+      "content_hash": "859f83f2ed5b61d2",
+      "name": "date matrix: directive %w (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%w'; echo rc=$?"
+    },
+    {
       "content_hash": "75a718845d827205",
       "name": "date matrix: directive %W (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%W'; echo rc=$?"
@@ -359,6 +534,11 @@
       "content_hash": "a878077f0a57eb7d",
       "name": "date matrix: directive %W (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%W'; echo rc=$?"
+    },
+    {
+      "content_hash": "02eee39ab4c8ef65",
+      "name": "date matrix: directive %W (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%W'; echo rc=$?"
     },
     {
       "content_hash": "5954a7be901a6c4c",
@@ -371,6 +551,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%x'; echo rc=$?"
     },
     {
+      "content_hash": "3e2b1820f9e49182",
+      "name": "date matrix: directive %x (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%x'; echo rc=$?"
+    },
+    {
       "content_hash": "152b36fbeb49a36f",
       "name": "date matrix: directive %X (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%X'; echo rc=$?"
@@ -379,6 +564,11 @@
       "content_hash": "f43c67c955e7269a",
       "name": "date matrix: directive %X (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%X'; echo rc=$?"
+    },
+    {
+      "content_hash": "ce37d75b00230db3",
+      "name": "date matrix: directive %X (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%X'; echo rc=$?"
     },
     {
       "content_hash": "08afc71636bf9f82",
@@ -391,6 +581,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%y'; echo rc=$?"
     },
     {
+      "content_hash": "89328ec85a736033",
+      "name": "date matrix: directive %y (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%y'; echo rc=$?"
+    },
+    {
       "content_hash": "229b0f4f8cc45377",
       "name": "date matrix: directive %Y (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%Y'; echo rc=$?"
@@ -399,6 +594,11 @@
       "content_hash": "5f3de776c7224721",
       "name": "date matrix: directive %Y (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "cd4c7f6bb55416a4",
+      "name": "date matrix: directive %Y (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Y'; echo rc=$?"
     },
     {
       "content_hash": "5afc4f2c3e44ff0e",
@@ -411,6 +611,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%z'; echo rc=$?"
     },
     {
+      "content_hash": "428c38f348c4e874",
+      "name": "date matrix: directive %z (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%z'; echo rc=$?"
+    },
+    {
       "content_hash": "9dd7a235eb4e5d94",
       "name": "date matrix: directive %Z (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%Z'; echo rc=$?"
@@ -419,6 +624,11 @@
       "content_hash": "dace2b94dc0a864c",
       "name": "date matrix: directive %Z (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "79af09e54ce01c09",
+      "name": "date matrix: directive %Z (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Z'; echo rc=$?"
     },
     {
       "content_hash": "f3240fae37076edc",
@@ -431,6 +641,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%:z'; echo rc=$?"
     },
     {
+      "content_hash": "dba9981e73ebfa03",
+      "name": "date matrix: modifier %:z (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%:z'; echo rc=$?"
+    },
+    {
       "content_hash": "ed6b7ad13ec47e70",
       "name": "date matrix: modifier %::z (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%::z'; echo rc=$?"
@@ -439,6 +654,11 @@
       "content_hash": "b2b0f809d217affc",
       "name": "date matrix: modifier %::z (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%::z'; echo rc=$?"
+    },
+    {
+      "content_hash": "e71a4b739bc77383",
+      "name": "date matrix: modifier %::z (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%::z'; echo rc=$?"
     },
     {
       "content_hash": "075e142ce0fa9942",
@@ -451,6 +671,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%:::z'; echo rc=$?"
     },
     {
+      "content_hash": "089736083bd619cb",
+      "name": "date matrix: modifier %:::z (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%:::z'; echo rc=$?"
+    },
+    {
       "content_hash": "7cd1652285503484",
       "name": "date matrix: modifier %-d (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%-d'; echo rc=$?"
@@ -459,6 +684,11 @@
       "content_hash": "91179ae7c00a3af6",
       "name": "date matrix: modifier %-d (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-d'; echo rc=$?"
+    },
+    {
+      "content_hash": "2288dbd043a7cc42",
+      "name": "date matrix: modifier %-d (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-d'; echo rc=$?"
     },
     {
       "content_hash": "f89ee1d2976a8689",
@@ -471,6 +701,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_d'; echo rc=$?"
     },
     {
+      "content_hash": "aa9be789eaa9e28d",
+      "name": "date matrix: modifier %_d (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_d'; echo rc=$?"
+    },
+    {
       "content_hash": "c4dda1e428c67866",
       "name": "date matrix: modifier %0d (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%0d'; echo rc=$?"
@@ -479,6 +714,11 @@
       "content_hash": "94346ff6dfbe13e0",
       "name": "date matrix: modifier %0d (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%0d'; echo rc=$?"
+    },
+    {
+      "content_hash": "7bd1275f5b2bc632",
+      "name": "date matrix: modifier %0d (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0d'; echo rc=$?"
     },
     {
       "content_hash": "5a6fe0fcac6631f1",
@@ -491,6 +731,11 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%^a'; echo rc=$?"
     },
     {
+      "content_hash": "ab405901da827a16",
+      "name": "date matrix: modifier %^a (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^a'; echo rc=$?"
+    },
+    {
       "content_hash": "e693440e54e2530e",
       "name": "date matrix: modifier %#a (pm)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%#a'; echo rc=$?"
@@ -499,6 +744,2086 @@
       "content_hash": "c4829e5b13f00357",
       "name": "date matrix: modifier %#a (am)",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%#a'; echo rc=$?"
+    },
+    {
+      "content_hash": "1a878fb99c2ff0cc",
+      "name": "date matrix: modifier %#a (jan)",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#a'; echo rc=$?"
+    },
+    {
+      "content_hash": "fe0dc4a145e5c0f6",
+      "name": "date matrix: low year %Y",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "7d287df9df7bec35",
+      "name": "date matrix: low year %-Y",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "7a36b7ba8a413067",
+      "name": "date matrix: low year %_Y",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "8fa5887a17c4cc97",
+      "name": "date matrix: low year %0Y",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "458c281a89c022ae",
+      "name": "date matrix: low year %5Y",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%5Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "2add3beecd78041f",
+      "name": "date matrix: low year %G",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%G'; echo rc=$?"
+    },
+    {
+      "content_hash": "d5026db82f56dc1f",
+      "name": "date matrix: low year %-G",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-G'; echo rc=$?"
+    },
+    {
+      "content_hash": "f4ef770ffe3e7da9",
+      "name": "date matrix: low year %C",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%C'; echo rc=$?"
+    },
+    {
+      "content_hash": "260bb979c9d41260",
+      "name": "date matrix: low year %-C",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-C'; echo rc=$?"
+    },
+    {
+      "content_hash": "7d5e5b35181ecf6c",
+      "name": "date matrix: low year %y",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%y'; echo rc=$?"
+    },
+    {
+      "content_hash": "5167af142dd16803",
+      "name": "date matrix: low year %-y",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-y'; echo rc=$?"
+    },
+    {
+      "content_hash": "7d8ea52883bcd59f",
+      "name": "date matrix: low year %-g",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-g'; echo rc=$?"
+    },
+    {
+      "content_hash": "3eae86bc7a2e37d4",
+      "name": "date matrix: nanoseconds %N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%N'; echo rc=$?"
+    },
+    {
+      "content_hash": "4ed5c032daf57339",
+      "name": "date matrix: nanoseconds %-N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-N'; echo rc=$?"
+    },
+    {
+      "content_hash": "ddd7406e16565600",
+      "name": "date matrix: nanoseconds %0N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%0N'; echo rc=$?"
+    },
+    {
+      "content_hash": "c571c2da89e6886e",
+      "name": "date matrix: nanoseconds %^N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%^N'; echo rc=$?"
+    },
+    {
+      "content_hash": "d58966d545232386",
+      "name": "date matrix: nanoseconds %#N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%#N'; echo rc=$?"
+    },
+    {
+      "content_hash": "123a38c093d374be",
+      "name": "date matrix: nanoseconds %1N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%1N'; echo rc=$?"
+    },
+    {
+      "content_hash": "75c7156a1bf629a7",
+      "name": "date matrix: nanoseconds %3N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%3N'; echo rc=$?"
+    },
+    {
+      "content_hash": "513512382567a1d8",
+      "name": "date matrix: nanoseconds %6N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%6N'; echo rc=$?"
+    },
+    {
+      "content_hash": "61fb5ef5307d5619",
+      "name": "date matrix: nanoseconds %9N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%9N'; echo rc=$?"
+    },
+    {
+      "content_hash": "c2015cf4e56d746c",
+      "name": "date matrix: nanoseconds %12N",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%12N'; echo rc=$?"
+    },
+    {
+      "content_hash": "1e836116dc5c3c11",
+      "name": "date matrix: nanoseconds %_N",
+      "opts": {
+        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_N'; echo rc=$?"
+    },
+    {
+      "content_hash": "0514b760a2820297",
+      "name": "date matrix: nanoseconds %-3N",
+      "opts": {
+        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-3N'; echo rc=$?"
+    },
+    {
+      "content_hash": "fc387fb480e5d687",
+      "name": "date matrix: nanoseconds %_6N",
+      "opts": {
+        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_6N'; echo rc=$?"
+    },
+    {
+      "content_hash": "6585315fe69eb54f",
+      "name": "date matrix: nanoseconds %-12N",
+      "opts": {
+        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-12N'; echo rc=$?"
+    },
+    {
+      "content_hash": "3532eff93c52798c",
+      "name": "date matrix: flag %-a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-a'; echo rc=$?"
+    },
+    {
+      "content_hash": "d00c44042e0cd839",
+      "name": "date matrix: flag %-A",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-A'; echo rc=$?"
+    },
+    {
+      "content_hash": "828ed1e9d1d72fd1",
+      "name": "date matrix: flag %-b",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-b'; echo rc=$?"
+    },
+    {
+      "content_hash": "4f7d52da2b79747b",
+      "name": "date matrix: flag %-B",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-B'; echo rc=$?"
+    },
+    {
+      "content_hash": "addbd4e7122372e7",
+      "name": "date matrix: flag %-c",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-c'; echo rc=$?"
+    },
+    {
+      "content_hash": "3345a60bed7e577f",
+      "name": "date matrix: flag %-C",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-C'; echo rc=$?"
+    },
+    {
+      "content_hash": "2288dbd043a7cc42",
+      "name": "date matrix: flag %-d",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-d'; echo rc=$?"
+    },
+    {
+      "content_hash": "c851e87066e99c90",
+      "name": "date matrix: flag %-D",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-D'; echo rc=$?"
+    },
+    {
+      "content_hash": "8563f4dc04e9aa85",
+      "name": "date matrix: flag %-e",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-e'; echo rc=$?"
+    },
+    {
+      "content_hash": "8c21f9fba092b63d",
+      "name": "date matrix: flag %-F",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-F'; echo rc=$?"
+    },
+    {
+      "content_hash": "91c9cecd444c68c2",
+      "name": "date matrix: flag %-g",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-g'; echo rc=$?"
+    },
+    {
+      "content_hash": "44e02fae323c9b33",
+      "name": "date matrix: flag %-G",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-G'; echo rc=$?"
+    },
+    {
+      "content_hash": "2e0b5b18a5eae89d",
+      "name": "date matrix: flag %-h",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-h'; echo rc=$?"
+    },
+    {
+      "content_hash": "78ab64141b80ab1b",
+      "name": "date matrix: flag %-H",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-H'; echo rc=$?"
+    },
+    {
+      "content_hash": "e7ab7e6d8f32aef4",
+      "name": "date matrix: flag %-I",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-I'; echo rc=$?"
+    },
+    {
+      "content_hash": "1d8a21095d858bf4",
+      "name": "date matrix: flag %-j",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-j'; echo rc=$?"
+    },
+    {
+      "content_hash": "b5e554a47e88cf58",
+      "name": "date matrix: flag %-k",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-k'; echo rc=$?"
+    },
+    {
+      "content_hash": "d155f10002729bed",
+      "name": "date matrix: flag %-l",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-l'; echo rc=$?"
+    },
+    {
+      "content_hash": "82de8109798f18e8",
+      "name": "date matrix: flag %-m",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-m'; echo rc=$?"
+    },
+    {
+      "content_hash": "806527d60f3af552",
+      "name": "date matrix: flag %-M",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-M'; echo rc=$?"
+    },
+    {
+      "content_hash": "c88982f0dce7501b",
+      "name": "date matrix: flag %-n",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-n'; echo rc=$?"
+    },
+    {
+      "content_hash": "5ccc1ff0726f52b5",
+      "name": "date matrix: flag %-N",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-N'; echo rc=$?"
+    },
+    {
+      "content_hash": "1dfc244fc1cb97be",
+      "name": "date matrix: flag %-p",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-p'; echo rc=$?"
+    },
+    {
+      "content_hash": "31b00e82db8201f4",
+      "name": "date matrix: flag %-P",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-P'; echo rc=$?"
+    },
+    {
+      "content_hash": "ac93edb8db4574a1",
+      "name": "date matrix: flag %-q",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-q'; echo rc=$?"
+    },
+    {
+      "content_hash": "fdec330651ac4368",
+      "name": "date matrix: flag %-r",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-r'; echo rc=$?"
+    },
+    {
+      "content_hash": "0f1e376900ba2ee4",
+      "name": "date matrix: flag %-R",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-R'; echo rc=$?"
+    },
+    {
+      "content_hash": "e05cf032cdca2b4e",
+      "name": "date matrix: flag %-s",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-s'; echo rc=$?"
+    },
+    {
+      "content_hash": "6e66865ae970e310",
+      "name": "date matrix: flag %-S",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-S'; echo rc=$?"
+    },
+    {
+      "content_hash": "e5f74caed3d7b49b",
+      "name": "date matrix: flag %-t",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-t'; echo rc=$?"
+    },
+    {
+      "content_hash": "4186456babea731f",
+      "name": "date matrix: flag %-T",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-T'; echo rc=$?"
+    },
+    {
+      "content_hash": "869877428d1556c0",
+      "name": "date matrix: flag %-u",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-u'; echo rc=$?"
+    },
+    {
+      "content_hash": "2e3ef1f5b21bebaa",
+      "name": "date matrix: flag %-U",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-U'; echo rc=$?"
+    },
+    {
+      "content_hash": "99f86434332c068e",
+      "name": "date matrix: flag %-V",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-V'; echo rc=$?"
+    },
+    {
+      "content_hash": "c1a4b03aa85b06bf",
+      "name": "date matrix: flag %-w",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-w'; echo rc=$?"
+    },
+    {
+      "content_hash": "dab37917eb8be403",
+      "name": "date matrix: flag %-W",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-W'; echo rc=$?"
+    },
+    {
+      "content_hash": "d293d0cfa4d11053",
+      "name": "date matrix: flag %-x",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-x'; echo rc=$?"
+    },
+    {
+      "content_hash": "04620cd4885772ad",
+      "name": "date matrix: flag %-X",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-X'; echo rc=$?"
+    },
+    {
+      "content_hash": "94390869d90ddbb4",
+      "name": "date matrix: flag %-y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-y'; echo rc=$?"
+    },
+    {
+      "content_hash": "4ccd5cbc9c906edc",
+      "name": "date matrix: flag %-Y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "16d879078262ca6d",
+      "name": "date matrix: flag %-z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-z'; echo rc=$?"
+    },
+    {
+      "content_hash": "a39916c58216299c",
+      "name": "date matrix: flag %-Z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "f578a474f5d791e2",
+      "name": "date matrix: flag %_a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_a'; echo rc=$?"
+    },
+    {
+      "content_hash": "1c080331493df33a",
+      "name": "date matrix: flag %_A",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_A'; echo rc=$?"
+    },
+    {
+      "content_hash": "84cd614e2c88dc13",
+      "name": "date matrix: flag %_b",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_b'; echo rc=$?"
+    },
+    {
+      "content_hash": "9d686eb0419a8031",
+      "name": "date matrix: flag %_B",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_B'; echo rc=$?"
+    },
+    {
+      "content_hash": "bc5e16e2ba7e1a82",
+      "name": "date matrix: flag %_c",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_c'; echo rc=$?"
+    },
+    {
+      "content_hash": "d8aea7d34d6cd8c5",
+      "name": "date matrix: flag %_C",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_C'; echo rc=$?"
+    },
+    {
+      "content_hash": "aa9be789eaa9e28d",
+      "name": "date matrix: flag %_d",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_d'; echo rc=$?"
+    },
+    {
+      "content_hash": "7d1cd74a814b1b88",
+      "name": "date matrix: flag %_D",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_D'; echo rc=$?"
+    },
+    {
+      "content_hash": "3f49ad8b9a1e599d",
+      "name": "date matrix: flag %_e",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_e'; echo rc=$?"
+    },
+    {
+      "content_hash": "8f861bbe1777efe7",
+      "name": "date matrix: flag %_F",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_F'; echo rc=$?"
+    },
+    {
+      "content_hash": "cd448c43f3aa6467",
+      "name": "date matrix: flag %_g",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_g'; echo rc=$?"
+    },
+    {
+      "content_hash": "985ddf80545fcbe4",
+      "name": "date matrix: flag %_G",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_G'; echo rc=$?"
+    },
+    {
+      "content_hash": "658df1ec0e12e62e",
+      "name": "date matrix: flag %_h",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_h'; echo rc=$?"
+    },
+    {
+      "content_hash": "25dd2f60e2b7421f",
+      "name": "date matrix: flag %_H",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_H'; echo rc=$?"
+    },
+    {
+      "content_hash": "4c40fbb38cdb711e",
+      "name": "date matrix: flag %_I",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_I'; echo rc=$?"
+    },
+    {
+      "content_hash": "bf088004ff76a6d2",
+      "name": "date matrix: flag %_j",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_j'; echo rc=$?"
+    },
+    {
+      "content_hash": "88451b9021e6d9a2",
+      "name": "date matrix: flag %_k",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_k'; echo rc=$?"
+    },
+    {
+      "content_hash": "2703fa89b1394a5c",
+      "name": "date matrix: flag %_l",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_l'; echo rc=$?"
+    },
+    {
+      "content_hash": "b64aced5be4d3a0b",
+      "name": "date matrix: flag %_m",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_m'; echo rc=$?"
+    },
+    {
+      "content_hash": "784cefaf729fec93",
+      "name": "date matrix: flag %_M",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_M'; echo rc=$?"
+    },
+    {
+      "content_hash": "065f251bad081f7f",
+      "name": "date matrix: flag %_n",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_n'; echo rc=$?"
+    },
+    {
+      "content_hash": "6480c1c8fb07829a",
+      "name": "date matrix: flag %_N",
+      "opts": {
+        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_N'; echo rc=$?"
+    },
+    {
+      "content_hash": "2b6d2304e88b99ff",
+      "name": "date matrix: flag %_p",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_p'; echo rc=$?"
+    },
+    {
+      "content_hash": "e943bb7ab5df165f",
+      "name": "date matrix: flag %_P",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_P'; echo rc=$?"
+    },
+    {
+      "content_hash": "d9b0ead4b1dfcc07",
+      "name": "date matrix: flag %_q",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_q'; echo rc=$?"
+    },
+    {
+      "content_hash": "8a30a4d55273a6ba",
+      "name": "date matrix: flag %_r",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_r'; echo rc=$?"
+    },
+    {
+      "content_hash": "74ae5cae568edbcb",
+      "name": "date matrix: flag %_R",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_R'; echo rc=$?"
+    },
+    {
+      "content_hash": "8d0ef708ab80b85e",
+      "name": "date matrix: flag %_s",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_s'; echo rc=$?"
+    },
+    {
+      "content_hash": "bdeffc511a33e104",
+      "name": "date matrix: flag %_S",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_S'; echo rc=$?"
+    },
+    {
+      "content_hash": "84a18384f1d66d71",
+      "name": "date matrix: flag %_t",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_t'; echo rc=$?"
+    },
+    {
+      "content_hash": "dc49d03daf139269",
+      "name": "date matrix: flag %_T",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_T'; echo rc=$?"
+    },
+    {
+      "content_hash": "f6ab09376ecc9473",
+      "name": "date matrix: flag %_u",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_u'; echo rc=$?"
+    },
+    {
+      "content_hash": "48fd2ed7478d55b3",
+      "name": "date matrix: flag %_U",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_U'; echo rc=$?"
+    },
+    {
+      "content_hash": "4be90851e07de7c4",
+      "name": "date matrix: flag %_V",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_V'; echo rc=$?"
+    },
+    {
+      "content_hash": "f420d890ea17ba7c",
+      "name": "date matrix: flag %_w",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_w'; echo rc=$?"
+    },
+    {
+      "content_hash": "ed75e80c3aa0ac2b",
+      "name": "date matrix: flag %_W",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_W'; echo rc=$?"
+    },
+    {
+      "content_hash": "38be8d2c377e6cb9",
+      "name": "date matrix: flag %_x",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_x'; echo rc=$?"
+    },
+    {
+      "content_hash": "085fc9e18119a966",
+      "name": "date matrix: flag %_X",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_X'; echo rc=$?"
+    },
+    {
+      "content_hash": "764199cb5c01f8c8",
+      "name": "date matrix: flag %_y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_y'; echo rc=$?"
+    },
+    {
+      "content_hash": "8508e7843cce687d",
+      "name": "date matrix: flag %_Y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "24e3e30259f9c4fd",
+      "name": "date matrix: flag %_z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_z'; echo rc=$?"
+    },
+    {
+      "content_hash": "28e37456d986601c",
+      "name": "date matrix: flag %_Z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "dffce02abe9f536f",
+      "name": "date matrix: flag %0a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0a'; echo rc=$?"
+    },
+    {
+      "content_hash": "130551ea8be4d359",
+      "name": "date matrix: flag %0A",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0A'; echo rc=$?"
+    },
+    {
+      "content_hash": "99495c24519babb2",
+      "name": "date matrix: flag %0b",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0b'; echo rc=$?"
+    },
+    {
+      "content_hash": "f5ef9045b24fde63",
+      "name": "date matrix: flag %0B",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0B'; echo rc=$?"
+    },
+    {
+      "content_hash": "6128e08445bc6794",
+      "name": "date matrix: flag %0c",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0c'; echo rc=$?"
+    },
+    {
+      "content_hash": "a82c9956f12663ba",
+      "name": "date matrix: flag %0C",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0C'; echo rc=$?"
+    },
+    {
+      "content_hash": "7bd1275f5b2bc632",
+      "name": "date matrix: flag %0d",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0d'; echo rc=$?"
+    },
+    {
+      "content_hash": "b60da9f87b22d21e",
+      "name": "date matrix: flag %0D",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0D'; echo rc=$?"
+    },
+    {
+      "content_hash": "6a6071ebb1b2091a",
+      "name": "date matrix: flag %0e",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0e'; echo rc=$?"
+    },
+    {
+      "content_hash": "579e503ec3508427",
+      "name": "date matrix: flag %0F",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0F'; echo rc=$?"
+    },
+    {
+      "content_hash": "982d96ddf611ba59",
+      "name": "date matrix: flag %0g",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0g'; echo rc=$?"
+    },
+    {
+      "content_hash": "b26e422239ca4fbc",
+      "name": "date matrix: flag %0G",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0G'; echo rc=$?"
+    },
+    {
+      "content_hash": "027fe63f295df6d6",
+      "name": "date matrix: flag %0h",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0h'; echo rc=$?"
+    },
+    {
+      "content_hash": "c8bc725ea912506e",
+      "name": "date matrix: flag %0H",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0H'; echo rc=$?"
+    },
+    {
+      "content_hash": "80b8523fd224b1f0",
+      "name": "date matrix: flag %0I",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0I'; echo rc=$?"
+    },
+    {
+      "content_hash": "c29f6fb6eb5251e6",
+      "name": "date matrix: flag %0j",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0j'; echo rc=$?"
+    },
+    {
+      "content_hash": "aa804e768622b488",
+      "name": "date matrix: flag %0k",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0k'; echo rc=$?"
+    },
+    {
+      "content_hash": "c87b2bae8395a8fa",
+      "name": "date matrix: flag %0l",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0l'; echo rc=$?"
+    },
+    {
+      "content_hash": "9b53be509d83d217",
+      "name": "date matrix: flag %0m",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0m'; echo rc=$?"
+    },
+    {
+      "content_hash": "38bb1d6d03174814",
+      "name": "date matrix: flag %0M",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0M'; echo rc=$?"
+    },
+    {
+      "content_hash": "d795d4f687140885",
+      "name": "date matrix: flag %0n",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0n'; echo rc=$?"
+    },
+    {
+      "content_hash": "a96424eb6f39541e",
+      "name": "date matrix: flag %0N",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0N'; echo rc=$?"
+    },
+    {
+      "content_hash": "7f93812405033564",
+      "name": "date matrix: flag %0p",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0p'; echo rc=$?"
+    },
+    {
+      "content_hash": "d6085bde043abc83",
+      "name": "date matrix: flag %0P",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0P'; echo rc=$?"
+    },
+    {
+      "content_hash": "9e39a4c3291a8d90",
+      "name": "date matrix: flag %0q",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0q'; echo rc=$?"
+    },
+    {
+      "content_hash": "e7b28f210db91a52",
+      "name": "date matrix: flag %0r",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0r'; echo rc=$?"
+    },
+    {
+      "content_hash": "8598262c112adefa",
+      "name": "date matrix: flag %0R",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0R'; echo rc=$?"
+    },
+    {
+      "content_hash": "2738f92d2943228f",
+      "name": "date matrix: flag %0s",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0s'; echo rc=$?"
+    },
+    {
+      "content_hash": "1e4b294cc2268c7d",
+      "name": "date matrix: flag %0S",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0S'; echo rc=$?"
+    },
+    {
+      "content_hash": "6743fcce4bbf2887",
+      "name": "date matrix: flag %0t",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0t'; echo rc=$?"
+    },
+    {
+      "content_hash": "bdaaceb44b702082",
+      "name": "date matrix: flag %0T",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0T'; echo rc=$?"
+    },
+    {
+      "content_hash": "7e8aa1aecb8296bb",
+      "name": "date matrix: flag %0u",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0u'; echo rc=$?"
+    },
+    {
+      "content_hash": "014435c117f879cf",
+      "name": "date matrix: flag %0U",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0U'; echo rc=$?"
+    },
+    {
+      "content_hash": "23b312eb34190ea7",
+      "name": "date matrix: flag %0V",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0V'; echo rc=$?"
+    },
+    {
+      "content_hash": "e78343ef6dcbd1f7",
+      "name": "date matrix: flag %0w",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0w'; echo rc=$?"
+    },
+    {
+      "content_hash": "519252fe13c6e350",
+      "name": "date matrix: flag %0W",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0W'; echo rc=$?"
+    },
+    {
+      "content_hash": "caacebcd05389228",
+      "name": "date matrix: flag %0x",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0x'; echo rc=$?"
+    },
+    {
+      "content_hash": "ae9af1e9c1c3f131",
+      "name": "date matrix: flag %0X",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0X'; echo rc=$?"
+    },
+    {
+      "content_hash": "dfccb362790b3258",
+      "name": "date matrix: flag %0y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0y'; echo rc=$?"
+    },
+    {
+      "content_hash": "e852cfb140d42d6d",
+      "name": "date matrix: flag %0Y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "792660f864e01fb0",
+      "name": "date matrix: flag %0z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0z'; echo rc=$?"
+    },
+    {
+      "content_hash": "7b68013f3dfa211c",
+      "name": "date matrix: flag %0Z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "ab405901da827a16",
+      "name": "date matrix: flag %^a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^a'; echo rc=$?"
+    },
+    {
+      "content_hash": "f14d37ce61c87d4b",
+      "name": "date matrix: flag %^A",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^A'; echo rc=$?"
+    },
+    {
+      "content_hash": "f3f1f3a5b76ee9f0",
+      "name": "date matrix: flag %^b",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^b'; echo rc=$?"
+    },
+    {
+      "content_hash": "2f8f0724d3091cac",
+      "name": "date matrix: flag %^B",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^B'; echo rc=$?"
+    },
+    {
+      "content_hash": "30bb09c0abdddba5",
+      "name": "date matrix: flag %^c",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^c'; echo rc=$?"
+    },
+    {
+      "content_hash": "1f7ec900a2b0309d",
+      "name": "date matrix: flag %^C",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^C'; echo rc=$?"
+    },
+    {
+      "content_hash": "618b2871d8392f08",
+      "name": "date matrix: flag %^d",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^d'; echo rc=$?"
+    },
+    {
+      "content_hash": "3f2ab8f1b125e5a8",
+      "name": "date matrix: flag %^D",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^D'; echo rc=$?"
+    },
+    {
+      "content_hash": "0f53162b2ebb4eb0",
+      "name": "date matrix: flag %^e",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^e'; echo rc=$?"
+    },
+    {
+      "content_hash": "12ee0b88c12ee689",
+      "name": "date matrix: flag %^F",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^F'; echo rc=$?"
+    },
+    {
+      "content_hash": "d64a75c6132da727",
+      "name": "date matrix: flag %^g",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^g'; echo rc=$?"
+    },
+    {
+      "content_hash": "cd3eed8319a0fe99",
+      "name": "date matrix: flag %^G",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^G'; echo rc=$?"
+    },
+    {
+      "content_hash": "0c629296c4a78a44",
+      "name": "date matrix: flag %^h",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^h'; echo rc=$?"
+    },
+    {
+      "content_hash": "fdc350bf8c1573a6",
+      "name": "date matrix: flag %^H",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^H'; echo rc=$?"
+    },
+    {
+      "content_hash": "d7332d58bc494b40",
+      "name": "date matrix: flag %^I",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^I'; echo rc=$?"
+    },
+    {
+      "content_hash": "41244cb0024e16bd",
+      "name": "date matrix: flag %^j",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^j'; echo rc=$?"
+    },
+    {
+      "content_hash": "459d1bfaff25dbb4",
+      "name": "date matrix: flag %^k",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^k'; echo rc=$?"
+    },
+    {
+      "content_hash": "d6376572782a387f",
+      "name": "date matrix: flag %^l",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^l'; echo rc=$?"
+    },
+    {
+      "content_hash": "bc33432ef38130d8",
+      "name": "date matrix: flag %^m",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^m'; echo rc=$?"
+    },
+    {
+      "content_hash": "76cb1d74982105be",
+      "name": "date matrix: flag %^M",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^M'; echo rc=$?"
+    },
+    {
+      "content_hash": "2d444f5be4f15a99",
+      "name": "date matrix: flag %^n",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^n'; echo rc=$?"
+    },
+    {
+      "content_hash": "c5ff6f30bc2e227e",
+      "name": "date matrix: flag %^N",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^N'; echo rc=$?"
+    },
+    {
+      "content_hash": "aabf90a25fdd49d4",
+      "name": "date matrix: flag %^p",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^p'; echo rc=$?"
+    },
+    {
+      "content_hash": "cd69d4eef64e547d",
+      "name": "date matrix: flag %^P",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^P'; echo rc=$?"
+    },
+    {
+      "content_hash": "2f41480d8b3d1465",
+      "name": "date matrix: flag %^q",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^q'; echo rc=$?"
+    },
+    {
+      "content_hash": "424bead86501d9ac",
+      "name": "date matrix: flag %^r",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^r'; echo rc=$?"
+    },
+    {
+      "content_hash": "5a8115afe7d15955",
+      "name": "date matrix: flag %^R",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^R'; echo rc=$?"
+    },
+    {
+      "content_hash": "d7d975fa5f3c1535",
+      "name": "date matrix: flag %^s",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^s'; echo rc=$?"
+    },
+    {
+      "content_hash": "dbcee95ee17c1bfd",
+      "name": "date matrix: flag %^S",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^S'; echo rc=$?"
+    },
+    {
+      "content_hash": "73214385332e3c12",
+      "name": "date matrix: flag %^t",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^t'; echo rc=$?"
+    },
+    {
+      "content_hash": "e5738b9fe3684c94",
+      "name": "date matrix: flag %^T",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^T'; echo rc=$?"
+    },
+    {
+      "content_hash": "c132772f9a46f479",
+      "name": "date matrix: flag %^u",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^u'; echo rc=$?"
+    },
+    {
+      "content_hash": "d3d20c920fefbddc",
+      "name": "date matrix: flag %^U",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^U'; echo rc=$?"
+    },
+    {
+      "content_hash": "b9cab9973568d685",
+      "name": "date matrix: flag %^V",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^V'; echo rc=$?"
+    },
+    {
+      "content_hash": "05fbc6817c7c1819",
+      "name": "date matrix: flag %^w",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^w'; echo rc=$?"
+    },
+    {
+      "content_hash": "936b92d72ac9c73f",
+      "name": "date matrix: flag %^W",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^W'; echo rc=$?"
+    },
+    {
+      "content_hash": "8a4ac30056195257",
+      "name": "date matrix: flag %^x",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^x'; echo rc=$?"
+    },
+    {
+      "content_hash": "d0ba2790c6047a04",
+      "name": "date matrix: flag %^X",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^X'; echo rc=$?"
+    },
+    {
+      "content_hash": "122801a4c0135656",
+      "name": "date matrix: flag %^y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^y'; echo rc=$?"
+    },
+    {
+      "content_hash": "e7e19c3e6a66c2b0",
+      "name": "date matrix: flag %^Y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "d3f4cf7534aecefb",
+      "name": "date matrix: flag %^z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^z'; echo rc=$?"
+    },
+    {
+      "content_hash": "2880f4f953a32524",
+      "name": "date matrix: flag %^Z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "1a878fb99c2ff0cc",
+      "name": "date matrix: flag %#a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#a'; echo rc=$?"
+    },
+    {
+      "content_hash": "557bcabb193e659e",
+      "name": "date matrix: flag %#A",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#A'; echo rc=$?"
+    },
+    {
+      "content_hash": "92b550f3cd7f654a",
+      "name": "date matrix: flag %#b",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#b'; echo rc=$?"
+    },
+    {
+      "content_hash": "2e169f1fd60285fb",
+      "name": "date matrix: flag %#B",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#B'; echo rc=$?"
+    },
+    {
+      "content_hash": "c5c9b673849db851",
+      "name": "date matrix: flag %#c",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#c'; echo rc=$?"
+    },
+    {
+      "content_hash": "aea8fb3b7d8aca65",
+      "name": "date matrix: flag %#C",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#C'; echo rc=$?"
+    },
+    {
+      "content_hash": "c3ccc7042dba0db3",
+      "name": "date matrix: flag %#d",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#d'; echo rc=$?"
+    },
+    {
+      "content_hash": "534914ec351738eb",
+      "name": "date matrix: flag %#D",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#D'; echo rc=$?"
+    },
+    {
+      "content_hash": "93334662e6c86337",
+      "name": "date matrix: flag %#e",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#e'; echo rc=$?"
+    },
+    {
+      "content_hash": "b1671f93d8aefbda",
+      "name": "date matrix: flag %#F",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#F'; echo rc=$?"
+    },
+    {
+      "content_hash": "2d4c7450104d89d0",
+      "name": "date matrix: flag %#g",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#g'; echo rc=$?"
+    },
+    {
+      "content_hash": "bac8cb661fecb3bc",
+      "name": "date matrix: flag %#G",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#G'; echo rc=$?"
+    },
+    {
+      "content_hash": "77eb0a176a381839",
+      "name": "date matrix: flag %#h",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#h'; echo rc=$?"
+    },
+    {
+      "content_hash": "2fcc1e1a94df49f5",
+      "name": "date matrix: flag %#H",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#H'; echo rc=$?"
+    },
+    {
+      "content_hash": "fb9a45d588b1d38c",
+      "name": "date matrix: flag %#I",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#I'; echo rc=$?"
+    },
+    {
+      "content_hash": "dae93da62a436b1e",
+      "name": "date matrix: flag %#j",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#j'; echo rc=$?"
+    },
+    {
+      "content_hash": "002d950e25a6f9ad",
+      "name": "date matrix: flag %#k",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#k'; echo rc=$?"
+    },
+    {
+      "content_hash": "6e6b8f6f3bb979cb",
+      "name": "date matrix: flag %#l",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#l'; echo rc=$?"
+    },
+    {
+      "content_hash": "3b2fb0ccd786d3ef",
+      "name": "date matrix: flag %#m",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#m'; echo rc=$?"
+    },
+    {
+      "content_hash": "2a918e84f2e26aae",
+      "name": "date matrix: flag %#M",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#M'; echo rc=$?"
+    },
+    {
+      "content_hash": "728f10c402800ebf",
+      "name": "date matrix: flag %#n",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#n'; echo rc=$?"
+    },
+    {
+      "content_hash": "bc7a931949a4c54c",
+      "name": "date matrix: flag %#N",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#N'; echo rc=$?"
+    },
+    {
+      "content_hash": "f9232be618071299",
+      "name": "date matrix: flag %#p",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#p'; echo rc=$?"
+    },
+    {
+      "content_hash": "c806656a45379dce",
+      "name": "date matrix: flag %#P",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#P'; echo rc=$?"
+    },
+    {
+      "content_hash": "4ff739f98be88934",
+      "name": "date matrix: flag %#q",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#q'; echo rc=$?"
+    },
+    {
+      "content_hash": "47fad51461d9953f",
+      "name": "date matrix: flag %#r",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#r'; echo rc=$?"
+    },
+    {
+      "content_hash": "9c31491156548bec",
+      "name": "date matrix: flag %#R",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#R'; echo rc=$?"
+    },
+    {
+      "content_hash": "8d482fb2f7626de7",
+      "name": "date matrix: flag %#s",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#s'; echo rc=$?"
+    },
+    {
+      "content_hash": "cf6824ebed1e6cff",
+      "name": "date matrix: flag %#S",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#S'; echo rc=$?"
+    },
+    {
+      "content_hash": "5dc20f56a3542c48",
+      "name": "date matrix: flag %#t",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#t'; echo rc=$?"
+    },
+    {
+      "content_hash": "1a72ccc4a9c46682",
+      "name": "date matrix: flag %#T",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#T'; echo rc=$?"
+    },
+    {
+      "content_hash": "c490b33ded7cf349",
+      "name": "date matrix: flag %#u",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#u'; echo rc=$?"
+    },
+    {
+      "content_hash": "c322bb6b2db8cab6",
+      "name": "date matrix: flag %#U",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#U'; echo rc=$?"
+    },
+    {
+      "content_hash": "44323ef2eb39e02b",
+      "name": "date matrix: flag %#V",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#V'; echo rc=$?"
+    },
+    {
+      "content_hash": "c771f9b5426fdd97",
+      "name": "date matrix: flag %#w",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#w'; echo rc=$?"
+    },
+    {
+      "content_hash": "d484cf9f554d8982",
+      "name": "date matrix: flag %#W",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#W'; echo rc=$?"
+    },
+    {
+      "content_hash": "29723d23c9f43e05",
+      "name": "date matrix: flag %#x",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#x'; echo rc=$?"
+    },
+    {
+      "content_hash": "3e5b8da8047c10ca",
+      "name": "date matrix: flag %#X",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#X'; echo rc=$?"
+    },
+    {
+      "content_hash": "e44f98612018fb5e",
+      "name": "date matrix: flag %#y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#y'; echo rc=$?"
+    },
+    {
+      "content_hash": "604ddecf1bf530bc",
+      "name": "date matrix: flag %#Y",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "a36885590aefc7f3",
+      "name": "date matrix: flag %#z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#z'; echo rc=$?"
+    },
+    {
+      "content_hash": "077360c2b061b56d",
+      "name": "date matrix: flag %#Z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "4f8d74c7f4ec0ff7",
+      "name": "date matrix: locale modifier %Ea",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ea'; echo rc=$?"
+    },
+    {
+      "content_hash": "c5a4dcb7c2d1bdfb",
+      "name": "date matrix: locale modifier %EA",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EA'; echo rc=$?"
+    },
+    {
+      "content_hash": "81302a6ffdc42d1e",
+      "name": "date matrix: locale modifier %Eb",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Eb'; echo rc=$?"
+    },
+    {
+      "content_hash": "175a3dcd1af0bb03",
+      "name": "date matrix: locale modifier %EB",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EB'; echo rc=$?"
+    },
+    {
+      "content_hash": "299e716895d0959c",
+      "name": "date matrix: locale modifier %Ec",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ec'; echo rc=$?"
+    },
+    {
+      "content_hash": "23a3825ec17a96c1",
+      "name": "date matrix: locale modifier %EC",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EC'; echo rc=$?"
+    },
+    {
+      "content_hash": "fa4c23b3c508b17e",
+      "name": "date matrix: locale modifier %Ed",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ed'; echo rc=$?"
+    },
+    {
+      "content_hash": "82a24db541c80742",
+      "name": "date matrix: locale modifier %ED",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%ED'; echo rc=$?"
+    },
+    {
+      "content_hash": "49e6de53dbc570e4",
+      "name": "date matrix: locale modifier %Ee",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ee'; echo rc=$?"
+    },
+    {
+      "content_hash": "f60e88173d28bc48",
+      "name": "date matrix: locale modifier %EF",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EF'; echo rc=$?"
+    },
+    {
+      "content_hash": "76c1acf3538a9557",
+      "name": "date matrix: locale modifier %Eg",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Eg'; echo rc=$?"
+    },
+    {
+      "content_hash": "31abf8f1703ca5ff",
+      "name": "date matrix: locale modifier %EG",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EG'; echo rc=$?"
+    },
+    {
+      "content_hash": "31b4bc1994cc769a",
+      "name": "date matrix: locale modifier %Eh",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Eh'; echo rc=$?"
+    },
+    {
+      "content_hash": "28e4e336ba516361",
+      "name": "date matrix: locale modifier %EH",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EH'; echo rc=$?"
+    },
+    {
+      "content_hash": "6eb0219741e66dad",
+      "name": "date matrix: locale modifier %EI",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EI'; echo rc=$?"
+    },
+    {
+      "content_hash": "6aba66c2b9e0af83",
+      "name": "date matrix: locale modifier %Ej",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ej'; echo rc=$?"
+    },
+    {
+      "content_hash": "48b241f732f2b8fc",
+      "name": "date matrix: locale modifier %Ek",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ek'; echo rc=$?"
+    },
+    {
+      "content_hash": "5cb1bc1b44e74f9b",
+      "name": "date matrix: locale modifier %El",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%El'; echo rc=$?"
+    },
+    {
+      "content_hash": "30de0f0cbbf23c2a",
+      "name": "date matrix: locale modifier %Em",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Em'; echo rc=$?"
+    },
+    {
+      "content_hash": "26fe9eb19183d21b",
+      "name": "date matrix: locale modifier %EM",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EM'; echo rc=$?"
+    },
+    {
+      "content_hash": "92432f541665777c",
+      "name": "date matrix: locale modifier %En",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%En'; echo rc=$?"
+    },
+    {
+      "content_hash": "e1748c8bc52ab8b0",
+      "name": "date matrix: locale modifier %EN",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EN'; echo rc=$?"
+    },
+    {
+      "content_hash": "fa83f0d99c1bdf35",
+      "name": "date matrix: locale modifier %Ep",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ep'; echo rc=$?"
+    },
+    {
+      "content_hash": "ac62f0350f2299ba",
+      "name": "date matrix: locale modifier %EP",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EP'; echo rc=$?"
+    },
+    {
+      "content_hash": "a860a6e1808d25ab",
+      "name": "date matrix: locale modifier %Eq",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Eq'; echo rc=$?"
+    },
+    {
+      "content_hash": "b5a2464de118ee1e",
+      "name": "date matrix: locale modifier %Er",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Er'; echo rc=$?"
+    },
+    {
+      "content_hash": "6ecd45cfefb4387b",
+      "name": "date matrix: locale modifier %ER",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%ER'; echo rc=$?"
+    },
+    {
+      "content_hash": "2e9412395d13f0dd",
+      "name": "date matrix: locale modifier %Es",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Es'; echo rc=$?"
+    },
+    {
+      "content_hash": "fb3d870041f14722",
+      "name": "date matrix: locale modifier %ES",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%ES'; echo rc=$?"
+    },
+    {
+      "content_hash": "8dcab8de7001b5c6",
+      "name": "date matrix: locale modifier %Et",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Et'; echo rc=$?"
+    },
+    {
+      "content_hash": "ba58d0cdff765ab6",
+      "name": "date matrix: locale modifier %ET",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%ET'; echo rc=$?"
+    },
+    {
+      "content_hash": "c386d9a19d744123",
+      "name": "date matrix: locale modifier %Eu",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Eu'; echo rc=$?"
+    },
+    {
+      "content_hash": "e9af76d9929adfa3",
+      "name": "date matrix: locale modifier %EU",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EU'; echo rc=$?"
+    },
+    {
+      "content_hash": "74a2829e548872dc",
+      "name": "date matrix: locale modifier %EV",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EV'; echo rc=$?"
+    },
+    {
+      "content_hash": "d55b6299395d5a33",
+      "name": "date matrix: locale modifier %Ew",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ew'; echo rc=$?"
+    },
+    {
+      "content_hash": "b6891efd30953667",
+      "name": "date matrix: locale modifier %EW",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EW'; echo rc=$?"
+    },
+    {
+      "content_hash": "a62624309e7efd64",
+      "name": "date matrix: locale modifier %Ex",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ex'; echo rc=$?"
+    },
+    {
+      "content_hash": "1256a1ffe4c0c633",
+      "name": "date matrix: locale modifier %EX",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EX'; echo rc=$?"
+    },
+    {
+      "content_hash": "4bfbb30c9d187d22",
+      "name": "date matrix: locale modifier %Ey",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ey'; echo rc=$?"
+    },
+    {
+      "content_hash": "028afdbc859f4e97",
+      "name": "date matrix: locale modifier %EY",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EY'; echo rc=$?"
+    },
+    {
+      "content_hash": "bb2dc44e2472530e",
+      "name": "date matrix: locale modifier %Ez",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ez'; echo rc=$?"
+    },
+    {
+      "content_hash": "c32bf4666c5e885b",
+      "name": "date matrix: locale modifier %EZ",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EZ'; echo rc=$?"
+    },
+    {
+      "content_hash": "4d16dd13e0eaf625",
+      "name": "date matrix: locale modifier %Oa",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Oa'; echo rc=$?"
+    },
+    {
+      "content_hash": "b146302a0719dc4a",
+      "name": "date matrix: locale modifier %OA",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OA'; echo rc=$?"
+    },
+    {
+      "content_hash": "043a8412b8d78cce",
+      "name": "date matrix: locale modifier %Ob",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ob'; echo rc=$?"
+    },
+    {
+      "content_hash": "b942eb74b8128e5a",
+      "name": "date matrix: locale modifier %OB",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OB'; echo rc=$?"
+    },
+    {
+      "content_hash": "bc3c4fea5ef39512",
+      "name": "date matrix: locale modifier %Oc",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Oc'; echo rc=$?"
+    },
+    {
+      "content_hash": "594ea446d1457795",
+      "name": "date matrix: locale modifier %OC",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OC'; echo rc=$?"
+    },
+    {
+      "content_hash": "592a38672bb6c04a",
+      "name": "date matrix: locale modifier %Od",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Od'; echo rc=$?"
+    },
+    {
+      "content_hash": "ea44801fae22013e",
+      "name": "date matrix: locale modifier %OD",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OD'; echo rc=$?"
+    },
+    {
+      "content_hash": "3e7a3011aceae9cb",
+      "name": "date matrix: locale modifier %Oe",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Oe'; echo rc=$?"
+    },
+    {
+      "content_hash": "3186d6c290757b44",
+      "name": "date matrix: locale modifier %OF",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OF'; echo rc=$?"
+    },
+    {
+      "content_hash": "cfa6bc7ed4711d4c",
+      "name": "date matrix: locale modifier %Og",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Og'; echo rc=$?"
+    },
+    {
+      "content_hash": "df789c6a20a1c1a6",
+      "name": "date matrix: locale modifier %OG",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OG'; echo rc=$?"
+    },
+    {
+      "content_hash": "12e40daf46fb5596",
+      "name": "date matrix: locale modifier %Oh",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Oh'; echo rc=$?"
+    },
+    {
+      "content_hash": "12a18c9bd01102c6",
+      "name": "date matrix: locale modifier %OH",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OH'; echo rc=$?"
+    },
+    {
+      "content_hash": "c93e48bfa96d6f67",
+      "name": "date matrix: locale modifier %OI",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OI'; echo rc=$?"
+    },
+    {
+      "content_hash": "afbbb5f9e671dd16",
+      "name": "date matrix: locale modifier %Oj",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Oj'; echo rc=$?"
+    },
+    {
+      "content_hash": "db2dedca7d367c7f",
+      "name": "date matrix: locale modifier %Ok",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ok'; echo rc=$?"
+    },
+    {
+      "content_hash": "33b768f627560356",
+      "name": "date matrix: locale modifier %Ol",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ol'; echo rc=$?"
+    },
+    {
+      "content_hash": "07ac09ea3a02ce74",
+      "name": "date matrix: locale modifier %Om",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Om'; echo rc=$?"
+    },
+    {
+      "content_hash": "3346162193a097ab",
+      "name": "date matrix: locale modifier %OM",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OM'; echo rc=$?"
+    },
+    {
+      "content_hash": "a322ad54a6fdf13c",
+      "name": "date matrix: locale modifier %On",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%On'; echo rc=$?"
+    },
+    {
+      "content_hash": "3d24784ef23e1fd3",
+      "name": "date matrix: locale modifier %ON",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%ON'; echo rc=$?"
+    },
+    {
+      "content_hash": "5f6ec320db686d7d",
+      "name": "date matrix: locale modifier %Op",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Op'; echo rc=$?"
+    },
+    {
+      "content_hash": "680670a5b8051ee2",
+      "name": "date matrix: locale modifier %OP",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OP'; echo rc=$?"
+    },
+    {
+      "content_hash": "c380e5369754fafe",
+      "name": "date matrix: locale modifier %Oq",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Oq'; echo rc=$?"
+    },
+    {
+      "content_hash": "3268d5de40b42440",
+      "name": "date matrix: locale modifier %Or",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Or'; echo rc=$?"
+    },
+    {
+      "content_hash": "c3fd34a3d67f050c",
+      "name": "date matrix: locale modifier %OR",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OR'; echo rc=$?"
+    },
+    {
+      "content_hash": "746d04f2b73512db",
+      "name": "date matrix: locale modifier %Os",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Os'; echo rc=$?"
+    },
+    {
+      "content_hash": "82e5a06d378a7c04",
+      "name": "date matrix: locale modifier %OS",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OS'; echo rc=$?"
+    },
+    {
+      "content_hash": "5b115c0ad7d7590f",
+      "name": "date matrix: locale modifier %Ot",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ot'; echo rc=$?"
+    },
+    {
+      "content_hash": "324848793be124cb",
+      "name": "date matrix: locale modifier %OT",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OT'; echo rc=$?"
+    },
+    {
+      "content_hash": "f45857ebfd823182",
+      "name": "date matrix: locale modifier %Ou",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ou'; echo rc=$?"
+    },
+    {
+      "content_hash": "3804a50fc07a198c",
+      "name": "date matrix: locale modifier %OU",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OU'; echo rc=$?"
+    },
+    {
+      "content_hash": "16cfc7e7d7b6d964",
+      "name": "date matrix: locale modifier %OV",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OV'; echo rc=$?"
+    },
+    {
+      "content_hash": "449616e1ad2d6f63",
+      "name": "date matrix: locale modifier %Ow",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ow'; echo rc=$?"
+    },
+    {
+      "content_hash": "f2d13cb664269952",
+      "name": "date matrix: locale modifier %OW",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OW'; echo rc=$?"
+    },
+    {
+      "content_hash": "9035b97c02d70f0e",
+      "name": "date matrix: locale modifier %Ox",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Ox'; echo rc=$?"
+    },
+    {
+      "content_hash": "88f8ad861b485185",
+      "name": "date matrix: locale modifier %OX",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OX'; echo rc=$?"
+    },
+    {
+      "content_hash": "8edaf716e7dd9859",
+      "name": "date matrix: locale modifier %Oy",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Oy'; echo rc=$?"
+    },
+    {
+      "content_hash": "8ef53bdaa49254c9",
+      "name": "date matrix: locale modifier %OY",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OY'; echo rc=$?"
+    },
+    {
+      "content_hash": "56eeac2868e9afdb",
+      "name": "date matrix: locale modifier %Oz",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%Oz'; echo rc=$?"
+    },
+    {
+      "content_hash": "7060068055714b19",
+      "name": "date matrix: locale modifier %OZ",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OZ'; echo rc=$?"
+    },
+    {
+      "content_hash": "eba05f52ff547b4b",
+      "name": "date matrix: compound %-F",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-F'; echo rc=$?"
+    },
+    {
+      "content_hash": "a7351926ae19e579",
+      "name": "date matrix: compound %-D",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-D'; echo rc=$?"
+    },
+    {
+      "content_hash": "05d99cc1d4636010",
+      "name": "date matrix: compound %-T",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-T'; echo rc=$?"
+    },
+    {
+      "content_hash": "4bf6ada66979991b",
+      "name": "date matrix: compound %-R",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-R'; echo rc=$?"
+    },
+    {
+      "content_hash": "5065c620714cac4f",
+      "name": "date matrix: compound %-c",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-c'; echo rc=$?"
+    },
+    {
+      "content_hash": "b5d4f8bd8adf5d09",
+      "name": "date matrix: compound %-r",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-r'; echo rc=$?"
+    },
+    {
+      "content_hash": "bf02e524b411ce7c",
+      "name": "date matrix: compound %-x",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-x'; echo rc=$?"
+    },
+    {
+      "content_hash": "896cded467fe9dbf",
+      "name": "date matrix: compound %-X",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%-X'; echo rc=$?"
+    },
+    {
+      "content_hash": "6877fa0ce66ff72f",
+      "name": "date matrix: compound %_F",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_F'; echo rc=$?"
+    },
+    {
+      "content_hash": "2e9a56152d85bd31",
+      "name": "date matrix: compound %_D",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_D'; echo rc=$?"
+    },
+    {
+      "content_hash": "8f808490c6659d94",
+      "name": "date matrix: compound %_T",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_T'; echo rc=$?"
+    },
+    {
+      "content_hash": "27b242fa3e04ad31",
+      "name": "date matrix: compound %_R",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_R'; echo rc=$?"
+    },
+    {
+      "content_hash": "a3d6ad842daf66c6",
+      "name": "date matrix: compound %_c",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_c'; echo rc=$?"
+    },
+    {
+      "content_hash": "3f795c0821ebaa54",
+      "name": "date matrix: compound %_r",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_r'; echo rc=$?"
+    },
+    {
+      "content_hash": "8eac3d5bcefff596",
+      "name": "date matrix: compound %_x",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_x'; echo rc=$?"
+    },
+    {
+      "content_hash": "1f2964bd747b1d77",
+      "name": "date matrix: compound %_X",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%_X'; echo rc=$?"
+    },
+    {
+      "content_hash": "e0b99a84e4e6d7ce",
+      "name": "date matrix: compound %0F",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0F'; echo rc=$?"
+    },
+    {
+      "content_hash": "f256d89ffcf52411",
+      "name": "date matrix: compound %0D",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0D'; echo rc=$?"
+    },
+    {
+      "content_hash": "ce64dc3bacea07d1",
+      "name": "date matrix: compound %0T",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0T'; echo rc=$?"
+    },
+    {
+      "content_hash": "e32ee5f4a2793d62",
+      "name": "date matrix: compound %0R",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0R'; echo rc=$?"
+    },
+    {
+      "content_hash": "f4fd9c609ad00ea0",
+      "name": "date matrix: compound %0c",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0c'; echo rc=$?"
+    },
+    {
+      "content_hash": "7f1d695214d6b21c",
+      "name": "date matrix: compound %0r",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0r'; echo rc=$?"
+    },
+    {
+      "content_hash": "dce863a6901234c0",
+      "name": "date matrix: compound %0x",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0x'; echo rc=$?"
+    },
+    {
+      "content_hash": "1da5303f4103d962",
+      "name": "date matrix: compound %0X",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%0X'; echo rc=$?"
+    },
+    {
+      "content_hash": "b9249f053d0bf0cb",
+      "name": "date matrix: compound %^F",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%^F'; echo rc=$?"
+    },
+    {
+      "content_hash": "e65332ca9b84883d",
+      "name": "date matrix: compound %^D",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%^D'; echo rc=$?"
+    },
+    {
+      "content_hash": "abc232a89f2866b7",
+      "name": "date matrix: compound %^T",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%^T'; echo rc=$?"
+    },
+    {
+      "content_hash": "355bd2d6b1bbb499",
+      "name": "date matrix: compound %^R",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%^R'; echo rc=$?"
+    },
+    {
+      "content_hash": "5576c76a46ba2be7",
+      "name": "date matrix: compound %^c",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%^c'; echo rc=$?"
+    },
+    {
+      "content_hash": "1a5932c2ff39e3a4",
+      "name": "date matrix: compound %^r",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%^r'; echo rc=$?"
+    },
+    {
+      "content_hash": "21c3648e11f7a593",
+      "name": "date matrix: compound %^x",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%^x'; echo rc=$?"
+    },
+    {
+      "content_hash": "621878f9b6b73627",
+      "name": "date matrix: compound %^X",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%^X'; echo rc=$?"
+    },
+    {
+      "content_hash": "cce045512c7bf171",
+      "name": "date matrix: compound %#F",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%#F'; echo rc=$?"
+    },
+    {
+      "content_hash": "7a30bef3cfddefd3",
+      "name": "date matrix: compound %#D",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%#D'; echo rc=$?"
+    },
+    {
+      "content_hash": "b5554097552abbed",
+      "name": "date matrix: compound %#T",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%#T'; echo rc=$?"
+    },
+    {
+      "content_hash": "90d5d446a5d72920",
+      "name": "date matrix: compound %#R",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%#R'; echo rc=$?"
+    },
+    {
+      "content_hash": "e3d39dbe4802417d",
+      "name": "date matrix: compound %#c",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%#c'; echo rc=$?"
+    },
+    {
+      "content_hash": "684bd469b15869e4",
+      "name": "date matrix: compound %#r",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%#r'; echo rc=$?"
+    },
+    {
+      "content_hash": "6f8a1fe644faec03",
+      "name": "date matrix: compound %#x",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%#x'; echo rc=$?"
+    },
+    {
+      "content_hash": "89553fba98012b57",
+      "name": "date matrix: compound %#X",
+      "script": "TZ=UTC LC_ALL=C date -d '0005-01-05 09:05:03' '+%#X'; echo rc=$?"
+    },
+    {
+      "content_hash": "a3fc3db7f11b6528",
+      "name": "date matrix: zone %-:z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-:z'; echo rc=$?"
+    },
+    {
+      "content_hash": "0e219599a6438436",
+      "name": "date matrix: zone %_:z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_:z'; echo rc=$?"
+    },
+    {
+      "content_hash": "be08864d1997c364",
+      "name": "date matrix: zone %0:z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0:z'; echo rc=$?"
+    },
+    {
+      "content_hash": "6b27735adbb22c3b",
+      "name": "date matrix: zone %3:z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%3:z'; echo rc=$?"
+    },
+    {
+      "content_hash": "5ce3dbdb215786c7",
+      "name": "date matrix: zone %8:z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%8:z'; echo rc=$?"
+    },
+    {
+      "content_hash": "2fa382f6f0f4e5ae",
+      "name": "date matrix: zone %-::z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-::z'; echo rc=$?"
+    },
+    {
+      "content_hash": "325c2edfd14a0bed",
+      "name": "date matrix: zone %_::z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_::z'; echo rc=$?"
+    },
+    {
+      "content_hash": "07c260c71da0034b",
+      "name": "date matrix: zone %-:::z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-:::z'; echo rc=$?"
+    },
+    {
+      "content_hash": "ab32088721d39e96",
+      "name": "date matrix: zone %^:z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^:z'; echo rc=$?"
+    },
+    {
+      "content_hash": "16d879078262ca6d",
+      "name": "date matrix: zone %-z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-z'; echo rc=$?"
+    },
+    {
+      "content_hash": "24e3e30259f9c4fd",
+      "name": "date matrix: zone %_z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_z'; echo rc=$?"
+    },
+    {
+      "content_hash": "792660f864e01fb0",
+      "name": "date matrix: zone %0z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0z'; echo rc=$?"
+    },
+    {
+      "content_hash": "5c18bde73424c811",
+      "name": "date matrix: zone %1z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%1z'; echo rc=$?"
+    },
+    {
+      "content_hash": "6babeeec90d1d5aa",
+      "name": "date matrix: zone %5z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%5z'; echo rc=$?"
+    },
+    {
+      "content_hash": "d993696d41af0d5d",
+      "name": "date matrix: zone %8z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%8z'; echo rc=$?"
+    },
+    {
+      "content_hash": "d3f4cf7534aecefb",
+      "name": "date matrix: zone %^z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^z'; echo rc=$?"
+    },
+    {
+      "content_hash": "a36885590aefc7f3",
+      "name": "date matrix: zone %#z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#z'; echo rc=$?"
+    },
+    {
+      "content_hash": "cdf1466c0a6cba1a",
+      "name": "date matrix: string width %5a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%5a'; echo rc=$?"
+    },
+    {
+      "content_hash": "08decb2cff2a59d9",
+      "name": "date matrix: string width %_5a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_5a'; echo rc=$?"
+    },
+    {
+      "content_hash": "7bedb784ab4b4576",
+      "name": "date matrix: string width %05a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%05a'; echo rc=$?"
+    },
+    {
+      "content_hash": "b055dc15fd75c2ed",
+      "name": "date matrix: string width %-5a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-5a'; echo rc=$?"
+    },
+    {
+      "content_hash": "6aac967ba6fc3791",
+      "name": "date matrix: string width %^5a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^5a'; echo rc=$?"
+    },
+    {
+      "content_hash": "38eb512ee121b10f",
+      "name": "date matrix: string width %2a",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%2a'; echo rc=$?"
+    },
+    {
+      "content_hash": "0427595ac9851b4d",
+      "name": "date matrix: string width %12D",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%12D'; echo rc=$?"
+    },
+    {
+      "content_hash": "5757f5846dcb289d",
+      "name": "date matrix: string width %12T",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%12T'; echo rc=$?"
+    },
+    {
+      "content_hash": "0d4d9bf5f6fede61",
+      "name": "date matrix: string width %_12F",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_12F'; echo rc=$?"
+    },
+    {
+      "content_hash": "22e78375c37104cd",
+      "name": "date matrix: string width %012F",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%012F'; echo rc=$?"
+    },
+    {
+      "content_hash": "63f7d849da268954",
+      "name": "date matrix: string width %20c",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%20c'; echo rc=$?"
+    },
+    {
+      "content_hash": "43ac513f77565329",
+      "name": "date matrix: string width %6p",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%6p'; echo rc=$?"
+    },
+    {
+      "content_hash": "2e4c8bc1569f6972",
+      "name": "date matrix: string width %6Z",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%6Z'; echo rc=$?"
+    },
+    {
+      "content_hash": "ea30e6f3c446de10",
+      "name": "date matrix: modifier form %-Od",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-Od'; echo rc=$?"
+    },
+    {
+      "content_hash": "5157ed575cd64f61",
+      "name": "date matrix: modifier form %_5Od",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_5Od'; echo rc=$?"
+    },
+    {
+      "content_hash": "17b4093d534da131",
+      "name": "date matrix: modifier form %3Od",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%3Od'; echo rc=$?"
+    },
+    {
+      "content_hash": "c8bd01d5a7b9bb86",
+      "name": "date matrix: modifier form %05Ed",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%05Ed'; echo rc=$?"
+    },
+    {
+      "content_hash": "a58bc9fba1e647f6",
+      "name": "date matrix: modifier form %0Ey",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%0Ey'; echo rc=$?"
+    },
+    {
+      "content_hash": "e49526c4279536f8",
+      "name": "date matrix: modifier form %5EY",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%5EY'; echo rc=$?"
+    },
+    {
+      "content_hash": "4eeafce1eb58b080",
+      "name": "date matrix: modifier form %-Ey",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-Ey'; echo rc=$?"
+    },
+    {
+      "content_hash": "6236caabc709ab75",
+      "name": "date matrix: modifier form %_5Ey",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_5Ey'; echo rc=$?"
+    },
+    {
+      "content_hash": "6ca10f36af4afae1",
+      "name": "date matrix: modifier form %-Oe",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%-Oe'; echo rc=$?"
+    },
+    {
+      "content_hash": "5c89d5c2b66a58d9",
+      "name": "date matrix: modifier form %_OH",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%_OH'; echo rc=$?"
+    },
+    {
+      "content_hash": "3dc84339bbf8909c",
+      "name": "date matrix: modifier form %^Ec",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^Ec'; echo rc=$?"
+    },
+    {
+      "content_hash": "74338fb7ec3faf87",
+      "name": "date matrix: modifier form %#Ec",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%#Ec'; echo rc=$?"
+    },
+    {
+      "content_hash": "09cf7a8bda1b1a8d",
+      "name": "date matrix: modifier form %^Ea",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^Ea'; echo rc=$?"
+    },
+    {
+      "content_hash": "aaf4049a15c31fcd",
+      "name": "date matrix: modifier form %^Oa",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%^Oa'; echo rc=$?"
+    },
+    {
+      "content_hash": "25c158802a479f43",
+      "name": "date matrix: modifier form %E",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%E'; echo rc=$?"
+    },
+    {
+      "content_hash": "dd6ea147efdc23db",
+      "name": "date matrix: modifier form %O",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%O'; echo rc=$?"
+    },
+    {
+      "content_hash": "eb31acc98805233d",
+      "name": "date matrix: modifier form %EJ",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EJ'; echo rc=$?"
+    },
+    {
+      "content_hash": "9a09816881ff1af5",
+      "name": "date matrix: modifier form %OJ",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OJ'; echo rc=$?"
+    },
+    {
+      "content_hash": "904aedd198290e83",
+      "name": "date matrix: modifier form %O%d",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%O%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "1a1e6f59a63311fe",
+      "name": "date matrix: modifier form %E%d",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%E%d'; echo rc=$?"
+    },
+    {
+      "content_hash": "07cfb2791f83a5b9",
+      "name": "date matrix: modifier form %EOd",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%EOd'; echo rc=$?"
+    },
+    {
+      "content_hash": "7b75ba26b911333d",
+      "name": "date matrix: modifier form %OEd",
+      "script": "TZ=UTC LC_ALL=C date -d '2005-01-05 09:05:03' '+%OEd'; echo rc=$?"
     },
     {
       "content_hash": "48edbdf07a846391",
@@ -616,6 +2941,56 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%^!'; echo rc=$?"
     },
     {
+      "content_hash": "20e42eca498d572c",
+      "name": "date matrix: sequence %^J",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%^J'; echo rc=$?"
+    },
+    {
+      "content_hash": "35e41054b53a4000",
+      "name": "date matrix: sequence %#J",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%#J'; echo rc=$?"
+    },
+    {
+      "content_hash": "f58218ab0fce7caf",
+      "name": "date matrix: sequence %-J",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%-J'; echo rc=$?"
+    },
+    {
+      "content_hash": "738a5e423600f56f",
+      "name": "date matrix: sequence %_J",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%_J'; echo rc=$?"
+    },
+    {
+      "content_hash": "c42447317b64381b",
+      "name": "date matrix: sequence %0J",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%0J'; echo rc=$?"
+    },
+    {
+      "content_hash": "05e5eec974ed85ac",
+      "name": "date matrix: sequence %_3J",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%_3J'; echo rc=$?"
+    },
+    {
+      "content_hash": "f9af83361ccb7191",
+      "name": "date matrix: sequence %0!",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%0!'; echo rc=$?"
+    },
+    {
+      "content_hash": "88653b7d296c2e9b",
+      "name": "date matrix: sequence %^!x",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%^!x'; echo rc=$?"
+    },
+    {
+      "content_hash": "86a9f6a982a03c51",
+      "name": "date matrix: sequence %0d%-d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%0d%-d'; echo rc=$?"
+    },
+    {
+      "content_hash": "34c05fcb91fe5543",
+      "name": "date matrix: sequence %_H:%-M",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' '+%_H:%-M'; echo rc=$?"
+    },
+    {
       "content_hash": "b5d066f089dbf4aa",
       "name": "date matrix: width %3d",
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%3d'; echo rc=$?"
@@ -706,58 +3081,69 @@
       "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-j'; echo rc=$?"
     },
     {
-      "content_hash": "3eae86bc7a2e37d4",
-      "name": "date matrix: nanoseconds %N",
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%N'; echo rc=$?"
+      "content_hash": "1c8ea06677be68d1",
+      "name": "date matrix: width %1d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%1d'; echo rc=$?"
     },
     {
-      "content_hash": "4ed5c032daf57339",
-      "name": "date matrix: nanoseconds %-N",
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-N'; echo rc=$?"
+      "content_hash": "ceb525deec3fc8e7",
+      "name": "date matrix: width %1e",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%1e'; echo rc=$?"
     },
     {
-      "content_hash": "ddd7406e16565600",
-      "name": "date matrix: nanoseconds %0N",
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%0N'; echo rc=$?"
+      "content_hash": "e27e2b9e83b8dfcc",
+      "name": "date matrix: width %1H",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%1H'; echo rc=$?"
     },
     {
-      "content_hash": "c571c2da89e6886e",
-      "name": "date matrix: nanoseconds %^N",
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%^N'; echo rc=$?"
+      "content_hash": "94346ff6dfbe13e0",
+      "name": "date matrix: width %0d",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%0d'; echo rc=$?"
     },
     {
-      "content_hash": "75c7156a1bf629a7",
-      "name": "date matrix: nanoseconds %3N",
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%3N'; echo rc=$?"
+      "content_hash": "b1a4e04fc989c8a2",
+      "name": "date matrix: width %5e",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%5e'; echo rc=$?"
     },
     {
-      "content_hash": "513512382567a1d8",
-      "name": "date matrix: nanoseconds %6N",
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%6N'; echo rc=$?"
+      "content_hash": "c94d64af145bad8b",
+      "name": "date matrix: width %5k",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%5k'; echo rc=$?"
     },
     {
-      "content_hash": "1e836116dc5c3c11",
-      "name": "date matrix: nanoseconds %_N",
-      "opts": {
-        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
-      },
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_N'; echo rc=$?"
+      "content_hash": "6dea9bbd52b5f4a0",
+      "name": "date matrix: width %5l",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%5l'; echo rc=$?"
     },
     {
-      "content_hash": "0514b760a2820297",
-      "name": "date matrix: nanoseconds %-3N",
-      "opts": {
-        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
-      },
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%-3N'; echo rc=$?"
+      "content_hash": "7f65c020804d2453",
+      "name": "date matrix: width %5Y",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%5Y'; echo rc=$?"
     },
     {
-      "content_hash": "fc387fb480e5d687",
-      "name": "date matrix: nanoseconds %_6N",
-      "opts": {
-        "known_gap": "GNU pads %N with trailing spaces under _ and -, unlike every other conversion"
-      },
-      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_6N'; echo rc=$?"
+      "content_hash": "9dd1a9f733cbebdf",
+      "name": "date matrix: width %_5Y",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_5Y'; echo rc=$?"
+    },
+    {
+      "content_hash": "9b5ebc760f292961",
+      "name": "date matrix: width %5s",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%5s'; echo rc=$?"
+    },
+    {
+      "content_hash": "00f2fd6f71f578ed",
+      "name": "date matrix: width %_5j",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_5j'; echo rc=$?"
+    },
+    {
+      "content_hash": "04c43fd8f8c7bcd9",
+      "name": "date matrix: width %_1j",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%_1j'; echo rc=$?"
+    },
+    {
+      "content_hash": "21e0bad557731b05",
+      "name": "date matrix: width %2j",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-05 09:05:03' '+%2j'; echo rc=$?"
     },
     {
       "content_hash": "c6678c35339e5c11",
@@ -827,10 +3213,18 @@
       "script": "TZ=UTC LC_ALL=C date -j '+%Y-%m-%d'; echo rc=$?"
     },
     {
+      "content_hash": "60d08fb452de1fe3",
+      "name": "date matrix: absent flag -j -f %Y",
+      "opts": {
+        "known_gap": "-j/-f are supported as documented BSD spellings; GNU date rejects them"
+      },
+      "script": "TZ=UTC LC_ALL=C date -j -f %Y '+%Y-%m-%d'; echo rc=$?"
+    },
+    {
       "content_hash": "af848d1644742c50",
       "name": "date matrix: absent flag -jf %Y",
       "opts": {
-        "known_gap": "-j/-f are supported as documented BSD spellings; GNU date rejects them"
+        "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
       },
       "script": "TZ=UTC LC_ALL=C date -jf %Y '+%Y-%m-%d'; echo rc=$?"
     },
@@ -869,6 +3263,26 @@
       "content_hash": "7678424c6ef68df8",
       "name": "date matrix: input @1718458200",
       "script": "TZ=UTC LC_ALL=C date -d '@1718458200' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "9f383ce19a5d671b",
+      "name": "date matrix: input @0",
+      "script": "TZ=UTC LC_ALL=C date -d '@0' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "c28f5f1ba4f6c97a",
+      "name": "date matrix: input @-1",
+      "script": "TZ=UTC LC_ALL=C date -d '@-1' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "56111777896aef17",
+      "name": "date matrix: input @99999999999999999999",
+      "script": "TZ=UTC LC_ALL=C date -d '@99999999999999999999' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
+    },
+    {
+      "content_hash": "5c7c5c6aabee439f",
+      "name": "date matrix: input @-99999999999999999999",
+      "script": "TZ=UTC LC_ALL=C date -d '@-99999999999999999999' '+%Y-%m-%d %H:%M:%S'; echo rc=$?"
     },
     {
       "content_hash": "7d29779998b12451",
@@ -954,6 +3368,69 @@
         "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
       },
       "script": "TZ=UTC LC_ALL=C date -d; echo rc=$?"
+    },
+    {
+      "content_hash": "96a320fc514e0bc6",
+      "name": "date matrix: long --date with no argument",
+      "opts": {
+        "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
+      },
+      "script": "TZ=UTC LC_ALL=C date --date; echo rc=$?"
+    },
+    {
+      "content_hash": "333fe6220aa6ca0e",
+      "name": "date matrix: long --reference with no argument",
+      "opts": {
+        "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
+      },
+      "script": "TZ=UTC LC_ALL=C date --reference; echo rc=$?"
+    },
+    {
+      "content_hash": "f9edbc49cb982e02",
+      "name": "date matrix: reference -r and -d together",
+      "opts": {
+        "known_gap": "the refusal is BSD-worded (illegal option, usage) where GNU says invalid option"
+      },
+      "script": "touch /tmp/jb_r_$$; TZ=UTC LC_ALL=C date -r /tmp/jb_r_$$ -d '2024-06-15 13:30:00' '+%F'; echo rc=$?; rm -f /tmp/jb_r_$$"
+    },
+    {
+      "content_hash": "2f3fe6a526b18fd6",
+      "name": "date matrix: end of options --",
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' -- '+%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "2e38f635541d8c9c",
+      "name": "date matrix: long --date with a separate argument",
+      "script": "TZ=UTC LC_ALL=C date --date '2024-06-15 13:30:00' '+%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "32006898d6eb11e0",
+      "name": "date matrix: long --reference with a separate argument",
+      "script": "touch /tmp/jb_l_$$; TZ=UTC LC_ALL=C date --reference /tmp/jb_l_$$ '+%Y' > /dev/null; echo rc=$?; rm -f /tmp/jb_l_$$"
+    },
+    {
+      "content_hash": "3600cd824c22b465",
+      "name": "date matrix: long --iso-8601 with a separate argument",
+      "opts": {
+        "known_gap": "an operand is refused as a BSD settable time, not as a GNU extra operand"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' --iso-8601 hours; echo rc=$?"
+    },
+    {
+      "content_hash": "924df887302ce0d4",
+      "name": "date matrix: bare - operand",
+      "opts": {
+        "known_gap": "an operand is refused as a BSD settable time, not as a GNU extra operand"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' - '+%F'; echo rc=$?"
+    },
+    {
+      "content_hash": "82d0225adb7b0429",
+      "name": "date matrix: extra operand",
+      "opts": {
+        "known_gap": "an operand is refused as a BSD settable time, not as a GNU extra operand"
+      },
+      "script": "TZ=UTC LC_ALL=C date -d '2024-06-15 13:30:00' extra '+%F'; echo rc=$?"
     },
     {
       "content_hash": "078461a27e682c98",

--- a/test/fixtures/bash_cases/head_tail.json
+++ b/test/fixtures/bash_cases/head_tail.json
@@ -29,62 +29,62 @@
     {
       "name": "head -c byte mode: first 5 bytes",
       "script": "echo -n 'Hello, World!' | head -c 5",
-      "content_hash": "a5922d6daf8dda41"
+      "content_hash": "91499b571209b0d1"
     },
     {
       "name": "head -c byte mode: from stdin pipe",
       "script": "echo -n 'abcdefghij' | head -c 3",
-      "content_hash": "f2cc07f2b479ff77"
+      "content_hash": "864eae7f738f5a1a"
     },
     {
       "name": "head -c byte mode: N larger than input",
       "script": "echo -n 'short' | head -c 500",
-      "content_hash": "74f4ff0916d80285"
+      "content_hash": "b64a0ce933b5357d"
     },
     {
       "name": "head -c byte mode: zero bytes",
       "script": "echo -n 'content' | head -c 0",
-      "content_hash": "c239fa665b670645"
+      "content_hash": "74a2f8e4e4bf61bf"
     },
     {
       "name": "head -c byte mode: empty input",
       "script": "echo -n '' | head -c 10",
-      "content_hash": "a9cfeb0cd1dbaa26"
+      "content_hash": "55ed0f84f48dbb88"
     },
     {
       "name": "head -c byte mode: includes newlines",
       "script": "printf 'line1\nline2\nline3\n' | head -c 8",
-      "content_hash": "c6d52634160a6c13"
+      "content_hash": "c0d83bd31ca4eb0f"
     },
     {
       "name": "tail -c byte mode: last 7 bytes",
       "script": "echo -n 'Hello, World!' | tail -c 6",
-      "content_hash": "ac6c29f2e051b845"
+      "content_hash": "8a706bb6d3f01cdd"
     },
     {
       "name": "tail -c byte mode: from stdin pipe",
       "script": "echo -n 'abcdefghij' | tail -c 4",
-      "content_hash": "cd8e1303f084b24b"
+      "content_hash": "4640623236d21a01"
     },
     {
       "name": "tail -c byte mode: N larger than input",
       "script": "echo -n 'short' | tail -c 500",
-      "content_hash": "5b4394666e2e4a52"
+      "content_hash": "8d99f00253524e93"
     },
     {
       "name": "tail -c byte mode: zero bytes",
       "script": "echo -n 'content' | tail -c 0",
-      "content_hash": "19681666c21ef715"
+      "content_hash": "686e4902cab2250d"
     },
     {
       "name": "tail -c byte mode: empty input",
       "script": "echo -n '' | tail -c 10",
-      "content_hash": "575c18be3c2725b7"
+      "content_hash": "cab1715d6c17e313"
     },
     {
       "name": "tail -c byte mode: includes newlines",
       "script": "printf 'line1\nline2\nline3\n' | tail -c 8",
-      "content_hash": "d0ef8df077e5a212"
+      "content_hash": "5a6082eb5e3b82ac"
     }
   ]
 }

--- a/test/fixtures/bash_cases/mv.json
+++ b/test/fixtures/bash_cases/mv.json
@@ -39,12 +39,12 @@
     {
       "name": "mv comparison: refuses to move into a symlink pointing at itself",
       "script": "D=/tmp/jb_mv_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir a; echo F > a/f.md; ln -s $D/a l; mv a l; echo rc=$?; cat a/f.md; rm -rf $D",
-      "content_hash": "62b26859204b5de7"
+      "content_hash": "561d53b939dce772"
     },
     {
       "name": "mv comparison: refuses to move beneath a symlink pointing at itself",
       "script": "D=/tmp/jb_mv_$$; rm -rf $D; mkdir -p $D; cd $D; mkdir a; echo F > a/f.md; ln -s $D/a l; mv a l/x; echo rc=$?; cat a/f.md; rm -rf $D",
-      "content_hash": "849325d826f72e28"
+      "content_hash": "8d1741056805202f"
     }
   ]
 }

--- a/test/fixtures/bash_cases/real_world.json
+++ b/test/fixtures/bash_cases/real_world.json
@@ -4,148 +4,150 @@
     {
       "name": "one-liner: head -c to extract prefix",
       "script": "echo 'abcdefghijklmnop' | head -c 8",
-      "content_hash": "eaacb08dc037c211"
+      "content_hash": "74c95df538c61f82"
     },
     {
       "name": "one-liner: wc -l on pipeline",
       "script": "echo -e 'a\\nb\\nc\\nd\\ne' | grep -v c | wc -l",
-      "content_hash": "083347a2abd71572"
+      "content_hash": "b76e1721be41059e"
     },
     {
       "name": "one-liner: sort | uniq -c pattern",
       "script": "echo -e 'apple\\nbanana\\napple\\ncherry\\napple\\nbanana' | sort | uniq -c | sort -rn",
-      "content_hash": "9d86b75c746af369"
+      "content_hash": "34b82bad77c9c42c"
     },
     {
       "name": "one-liner: grep -c count matches",
       "script": "echo -e 'foo\\nbar\\nfoo\\nbaz\\nfoo' | grep -c foo",
-      "content_hash": "3b79f7af0f85c70c"
+      "content_hash": "020d5d322c0af014"
     },
     {
       "name": "one-liner: awk field extraction",
       "script": "echo -e 'alice 30\\nbob 25\\ncharlie 35' | awk '{print $1}'",
-      "content_hash": "6eeff81a3301a492"
+      "content_hash": "f756a39f8eb28890"
     },
     {
       "name": "one-liner: tr squeeze whitespace",
       "script": "echo 'hello     world    foo' | tr -s ' '",
-      "content_hash": "c5ba448c28900215"
+      "content_hash": "a81b22adba9e637f"
     },
     {
       "name": "one-liner: cut -d and paste -d",
       "script": "echo -e 'a:1\\nb:2\\nc:3' | cut -d: -f2",
-      "content_hash": "2970dfa9a50ddb14"
+      "content_hash": "3ad319a4311151ec"
     },
     {
       "name": "one-liner: xargs -I replacement",
       "script": "echo -e 'one\\ntwo\\nthree' | xargs -I{} echo 'item: {}'",
-      "content_hash": "349023f7ed641054"
+      "content_hash": "c7e52bee6d3dbb72"
     },
     {
       "name": "one-liner: subshell variable isolation",
       "script": "X=outer; (X=inner; echo $X); echo $X",
-      "content_hash": "c628dcdbe4252c5f"
+      "content_hash": "05cc878852343c79"
     },
     {
       "name": "one-liner: while read loop with IFS",
       "script": "echo -e 'a,1\\nb,2\\nc,3' | while IFS=, read -r key val; do echo \"$key=$val\"; done",
-      "content_hash": "d14924a4f4853e17"
+      "content_hash": "e6c7ee4dc4861f7a"
     },
     {
       "name": "one-liner: printf format string",
       "script": "printf '%-10s %5d\\n' alice 30 bob 25 charlie 35",
-      "content_hash": "cddacda6f0b7191b"
+      "content_hash": "d11d335828ec5695"
     },
     {
       "name": "one-liner: seq into arithmetic",
       "script": "seq 1 5 | paste -sd+ | bc",
-      "opts": {"ignore_stderr": true},
-      "content_hash": "07110906f0b5c126"
+      "opts": {
+        "ignore_stderr": true
+      },
+      "content_hash": "f76e1c4f3128ece7"
     },
     {
       "name": "one-liner: nested pipelines",
       "script": "echo -e 'the quick brown fox\\njumps over the lazy dog' | tr ' ' '\\n' | sort | uniq | wc -l",
-      "content_hash": "6f0a7fdaffe87eeb"
+      "content_hash": "7044737c2b2abf72"
     },
     {
       "name": "one-liner: sed and grep pipeline",
       "script": "echo -e 'ERROR: disk full\\nINFO: started\\nERROR: timeout\\nINFO: done' | grep ERROR | sed 's/ERROR: //'",
-      "content_hash": "47e28e1f2ab57443"
+      "content_hash": "770504a919dba521"
     },
     {
       "name": "one-liner: awk sum column",
       "script": "echo -e '10\\n20\\n30\\n40' | awk '{s+=$1} END {print s}'",
-      "content_hash": "99756c361f26f918"
+      "content_hash": "fd6bbe23e5a96aaf"
     },
     {
       "name": "one-liner: head and tail to extract middle",
       "script": "echo -e '1\\n2\\n3\\n4\\n5\\n6\\n7\\n8\\n9\\n10' | head -7 | tail -3",
-      "content_hash": "00e6d02eceb4529d"
+      "content_hash": "0ff17388743835b3"
     },
     {
       "name": "one-liner: cat - for stdin in pipeline",
       "script": "echo hello | cat -",
-      "content_hash": "1f5fd4c459e3af9a"
+      "content_hash": "269f1d6add4855cb"
     },
     {
       "name": "one-liner: rev and cut for last field",
       "script": "echo '/path/to/some/file.txt' | rev | cut -d/ -f1 | rev",
-      "content_hash": "9cbf6b06d4af11ae"
+      "content_hash": "8264f067ed2932a1"
     },
     {
       "name": "one-liner: tr delete characters",
       "script": "echo 'Hello, World! 123' | tr -d '[:digit:][:punct:]'",
-      "content_hash": "803f68986f94d7ee"
+      "content_hash": "f08df403cb4ddb04"
     },
     {
       "name": "one-liner: sort -t -k field sort",
       "script": "echo -e 'c:3\\na:1\\nb:2' | sort -t: -k2 -n",
-      "content_hash": "1d1e66fd89e6a570"
+      "content_hash": "b24b8385f42442a7"
     },
     {
       "name": "one-liner: command substitution in echo",
       "script": "echo \"there are $(echo -e 'a\\nb\\nc' | wc -l | tr -d ' ') lines\"",
-      "content_hash": "df28220700b4bc69"
+      "content_hash": "04f7363563dc3773"
     },
     {
       "name": "one-liner: tail -c byte mode",
       "script": "echo -n 'abcdefghij' | tail -c 5",
-      "content_hash": "a4602a1af2bbb56d"
+      "content_hash": "194005786bf4019d"
     },
     {
       "name": "one-liner: multiple pipes with wc -lw",
       "script": "echo -e 'one two three\\nfour five' | wc -lw",
-      "content_hash": "4a9f5f03127723c0"
+      "content_hash": "bbb282486f87cb03"
     },
     {
       "name": "one-liner: for loop with seq",
       "script": "for i in $(seq 1 5); do echo \"num:$i\"; done",
-      "content_hash": "3419f4248a3df601"
+      "content_hash": "edc40e3dbaf083d5"
     },
     {
       "name": "one-liner: grep -v | sort -u dedup",
       "script": "echo -e 'apple\\n\\nbanana\\n\\napple\\ncherry' | grep -v '^$' | sort -u",
-      "content_hash": "0fdc8b2425e0deb0"
+      "content_hash": "da8c5d5aaa389136"
     },
     {
       "name": "one-liner: awk NR line numbers",
       "script": "echo -e 'first\\nsecond\\nthird' | awk '{print NR\": \"$0}'",
-      "content_hash": "efebc32e5cab5fe2"
+      "content_hash": "e868b1f67ac6c8c0"
     },
     {
       "name": "one-liner: tr character translation",
       "script": "echo 'hello world' | tr 'a-z' 'A-Z'",
-      "content_hash": "8dd4f831fccb49a1"
+      "content_hash": "c0abb65b0624a388"
     },
     {
       "name": "one-liner: head -c with wc -c to verify",
       "script": "echo -n 'abcdefghij' | head -c 5 | wc -c | tr -d ' '",
-      "content_hash": "5baf2740972bb77c"
+      "content_hash": "116f4177d21289bd"
     },
     {
       "name": "one-liner: nested command substitution",
       "script": "echo \"$(echo hello | tr 'a-z' 'A-Z') $(echo world | rev)\"",
-      "content_hash": "0a91498ee638b805"
+      "content_hash": "edef90d0772b5c0f"
     }
   ]
 }

--- a/test/fixtures/bash_cases/special_variables.json
+++ b/test/fixtures/bash_cases/special_variables.json
@@ -219,57 +219,57 @@
     {
       "name": "special var trailing text: $# followed by literal",
       "script": "echo $#args",
-      "content_hash": "4e0be3d964a9dc35"
+      "content_hash": "f9a035703a612267"
     },
     {
       "name": "special var trailing text: $? followed by literal",
       "script": "true; echo $?foo",
-      "content_hash": "f93a4db1b75def55"
+      "content_hash": "195cbbd549607bd6"
     },
     {
       "name": "special var trailing text: bare $ before space",
       "script": "echo $ end",
-      "content_hash": "4aa29b0ca8c839cd"
+      "content_hash": "e8696165992d6f4a"
     },
     {
       "name": "special var trailing text: bare $ at end of word",
       "script": "echo hello$",
-      "content_hash": "5764212ad8da2dc0"
+      "content_hash": "16d196e1707123d1"
     },
     {
       "name": "special var trailing text: $# in double quotes with trailing",
       "script": "echo \"$#items\"",
-      "content_hash": "88c458d384d8eeb9"
+      "content_hash": "96145d8724412328"
     },
     {
       "name": "special var trailing text: $? in double quotes with trailing",
       "script": "false; echo \"$?code\"",
-      "content_hash": "154514f76d1fabfb"
+      "content_hash": "934702a9133a94fe"
     },
     {
       "name": "special var trailing text: $# no args with text in function",
       "script": "f() { echo $#done; }; f",
-      "content_hash": "0b5535321931d845"
+      "content_hash": "655c8da00a65c3a5"
     },
     {
       "name": "special var trailing text: $# with args text in function",
       "script": "f() { echo $#done; }; f a b c",
-      "content_hash": "c8adc8afdbeef2dc"
+      "content_hash": "722a5a2f6ebe8047"
     },
     {
       "name": "special var trailing text: regular var consumes full identifier",
       "script": "FOO=hello; echo $FOObar",
-      "content_hash": "cbabebb75f046268"
+      "content_hash": "f66dc575dbdc263f"
     },
     {
       "name": "special var trailing text: regular var stopped by non-ident char",
       "script": "FOO=hello; echo $FOO/path",
-      "content_hash": "65d19613148cb12e"
+      "content_hash": "9e706a143cd1c56f"
     },
     {
       "name": "special var trailing text: $@ in function with trailing text",
       "script": "f() { echo \"$@\"end; }; f a b",
-      "content_hash": "2a41edd942666616"
+      "content_hash": "07ca1720edf65304"
     }
   ]
 }

--- a/test/fixtures/bash_cases/wc.json
+++ b/test/fixtures/bash_cases/wc.json
@@ -109,22 +109,22 @@
     {
       "name": "wc combined flags: -lw lines and words",
       "script": "echo -e 'one two\\nthree four five' | wc -lw",
-      "content_hash": "364ea40429bd538e"
+      "content_hash": "20074798e3e17a48"
     },
     {
       "name": "wc combined flags: -lc lines and bytes",
       "script": "echo 'hello' | wc -lc",
-      "content_hash": "44438c7f2ced5b1b"
+      "content_hash": "b4d38a44930be149"
     },
     {
       "name": "wc combined flags: -lwc all three",
       "script": "echo -e 'one two\\nthree' | wc -lwc",
-      "content_hash": "7981339a5ac59b1e"
+      "content_hash": "4ca6748c61836f69"
     },
     {
       "name": "wc combined flags: -wc words and bytes",
       "script": "echo 'hello world' | wc -wc",
-      "content_hash": "e53de18540523d34"
+      "content_hash": "3782a58db4103e82"
     }
   ]
 }

--- a/test/fixtures/bash_expected/cp.json
+++ b/test/fixtures/bash_expected/cp.json
@@ -302,28 +302,28 @@
       "stdout": "rc=1\n"
     },
     {
-      "content_hash": "e9450712650bb4a0",
+      "content_hash": "25486a1918ca99f1",
       "exit_code": 0,
       "name": "cp comparison: -r into a symlink pointing at the source is refused",
       "stderr": "cp: cannot copy a directory, 'a', into itself, 'l/a'\n",
       "stdout": "rc=1\nF\n"
     },
     {
-      "content_hash": "77d202dbbde3dd3b",
+      "content_hash": "21356459cab5b2c7",
       "exit_code": 0,
       "name": "cp comparison: a destination whose ancestor is a regular file cannot be stat'd",
       "stderr": "cp: cannot stat 'f/sub.md': Not a directory\n",
       "stdout": "rc=1\n"
     },
     {
-      "content_hash": "52a761acc5075034",
+      "content_hash": "14a536df09d1f593",
       "exit_code": 0,
       "name": "cp comparison: -r onto a destination whose ancestor is a regular file cannot be stat'd",
       "stderr": "cp: cannot stat 'f/sub': Not a directory\n",
       "stdout": "rc=1\n"
     },
     {
-      "content_hash": "3ee5b4e3ffbbc648",
+      "content_hash": "4def2da60668382f",
       "exit_code": 0,
       "name": "cp comparison: -r onto an existing regular file cannot overwrite a non-directory",
       "stderr": "cp: cannot overwrite non-directory 'f' with directory 's'\n",

--- a/test/fixtures/bash_expected/date_matrix.json
+++ b/test/fixtures/bash_expected/date_matrix.json
@@ -15,6 +15,13 @@
       "stdout": "Wed\nrc=0\n"
     },
     {
+      "content_hash": "009b15f92d736cda",
+      "exit_code": 0,
+      "name": "date matrix: directive %a (jan)",
+      "stderr": "",
+      "stdout": "Wed\nrc=0\n"
+    },
+    {
       "content_hash": "bd952c3ad83363ea",
       "exit_code": 0,
       "name": "date matrix: directive %A (pm)",
@@ -25,6 +32,13 @@
       "content_hash": "58ac9d25be86ee02",
       "exit_code": 0,
       "name": "date matrix: directive %A (am)",
+      "stderr": "",
+      "stdout": "Wednesday\nrc=0\n"
+    },
+    {
+      "content_hash": "f8f1bb8bb93c1b45",
+      "exit_code": 0,
+      "name": "date matrix: directive %A (jan)",
       "stderr": "",
       "stdout": "Wednesday\nrc=0\n"
     },
@@ -43,6 +57,13 @@
       "stdout": "Jun\nrc=0\n"
     },
     {
+      "content_hash": "0200a368463c1af1",
+      "exit_code": 0,
+      "name": "date matrix: directive %b (jan)",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
       "content_hash": "b42f00344ba38511",
       "exit_code": 0,
       "name": "date matrix: directive %B (pm)",
@@ -55,6 +76,13 @@
       "name": "date matrix: directive %B (am)",
       "stderr": "",
       "stdout": "June\nrc=0\n"
+    },
+    {
+      "content_hash": "235ce2e7fa904ac0",
+      "exit_code": 0,
+      "name": "date matrix: directive %B (jan)",
+      "stderr": "",
+      "stdout": "January\nrc=0\n"
     },
     {
       "content_hash": "e148e5d7269cc6f7",
@@ -71,6 +99,13 @@
       "stdout": "Wed Jun  5 09:05:03 2024\nrc=0\n"
     },
     {
+      "content_hash": "b033a283a9d93525",
+      "exit_code": 0,
+      "name": "date matrix: directive %c (jan)",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 2005\nrc=0\n"
+    },
+    {
       "content_hash": "609c417d9eb36be8",
       "exit_code": 0,
       "name": "date matrix: directive %C (pm)",
@@ -81,6 +116,13 @@
       "content_hash": "8ed42a3fc85ee04b",
       "exit_code": 0,
       "name": "date matrix: directive %C (am)",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "10f2c562c739e06a",
+      "exit_code": 0,
+      "name": "date matrix: directive %C (jan)",
       "stderr": "",
       "stdout": "20\nrc=0\n"
     },
@@ -99,6 +141,13 @@
       "stdout": "05\nrc=0\n"
     },
     {
+      "content_hash": "58c8570753b70c7c",
+      "exit_code": 0,
+      "name": "date matrix: directive %d (jan)",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
       "content_hash": "4d092b7823d5509a",
       "exit_code": 0,
       "name": "date matrix: directive %D (pm)",
@@ -113,6 +162,13 @@
       "stdout": "06/05/24\nrc=0\n"
     },
     {
+      "content_hash": "49c7f768f32942be",
+      "exit_code": 0,
+      "name": "date matrix: directive %D (jan)",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
       "content_hash": "2e652974ea03e3b6",
       "exit_code": 0,
       "name": "date matrix: directive %e (pm)",
@@ -123,6 +179,13 @@
       "content_hash": "c679b175dfc9da46",
       "exit_code": 0,
       "name": "date matrix: directive %e (am)",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "48b7add7083a0ebb",
+      "exit_code": 0,
+      "name": "date matrix: directive %e (jan)",
       "stderr": "",
       "stdout": " 5\nrc=0\n"
     },
@@ -141,6 +204,13 @@
       "stdout": "2024-06-05\nrc=0\n"
     },
     {
+      "content_hash": "4ca946135a859e71",
+      "exit_code": 0,
+      "name": "date matrix: directive %F (jan)",
+      "stderr": "",
+      "stdout": "2005-01-05\nrc=0\n"
+    },
+    {
       "content_hash": "0eecc350b1f35b97",
       "exit_code": 0,
       "name": "date matrix: directive %g (pm)",
@@ -153,6 +223,13 @@
       "name": "date matrix: directive %g (am)",
       "stderr": "",
       "stdout": "24\nrc=0\n"
+    },
+    {
+      "content_hash": "919890df47a4a207",
+      "exit_code": 0,
+      "name": "date matrix: directive %g (jan)",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
     },
     {
       "content_hash": "47ac3d2e0f9d2716",
@@ -169,6 +246,13 @@
       "stdout": "2024\nrc=0\n"
     },
     {
+      "content_hash": "3b7ae88587f17193",
+      "exit_code": 0,
+      "name": "date matrix: directive %G (jan)",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
       "content_hash": "84f1b7701869bcde",
       "exit_code": 0,
       "name": "date matrix: directive %h (pm)",
@@ -183,6 +267,13 @@
       "stdout": "Jun\nrc=0\n"
     },
     {
+      "content_hash": "c3b6e82930ead236",
+      "exit_code": 0,
+      "name": "date matrix: directive %h (jan)",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
       "content_hash": "fadeb047a08c49a9",
       "exit_code": 0,
       "name": "date matrix: directive %H (pm)",
@@ -193,6 +284,13 @@
       "content_hash": "c7965c3eb24b29df",
       "exit_code": 0,
       "name": "date matrix: directive %H (am)",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "a0aa94d5a20b804f",
+      "exit_code": 0,
+      "name": "date matrix: directive %H (jan)",
       "stderr": "",
       "stdout": "09\nrc=0\n"
     },
@@ -211,6 +309,13 @@
       "stdout": "09\nrc=0\n"
     },
     {
+      "content_hash": "f28cf6b977400f90",
+      "exit_code": 0,
+      "name": "date matrix: directive %I (jan)",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
       "content_hash": "5f76f4e8a7710411",
       "exit_code": 0,
       "name": "date matrix: directive %j (pm)",
@@ -225,6 +330,13 @@
       "stdout": "157\nrc=0\n"
     },
     {
+      "content_hash": "f7139320e275a293",
+      "exit_code": 0,
+      "name": "date matrix: directive %j (jan)",
+      "stderr": "",
+      "stdout": "005\nrc=0\n"
+    },
+    {
       "content_hash": "660eaf3387141170",
       "exit_code": 0,
       "name": "date matrix: directive %k (pm)",
@@ -235,6 +347,13 @@
       "content_hash": "632fe732934bf946",
       "exit_code": 0,
       "name": "date matrix: directive %k (am)",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "f225cb3b89e22fcc",
+      "exit_code": 0,
+      "name": "date matrix: directive %k (jan)",
       "stderr": "",
       "stdout": " 9\nrc=0\n"
     },
@@ -253,6 +372,13 @@
       "stdout": " 9\nrc=0\n"
     },
     {
+      "content_hash": "1f65aadb83e97823",
+      "exit_code": 0,
+      "name": "date matrix: directive %l (jan)",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
       "content_hash": "daf96127b6418ff3",
       "exit_code": 0,
       "name": "date matrix: directive %m (pm)",
@@ -267,6 +393,13 @@
       "stdout": "06\nrc=0\n"
     },
     {
+      "content_hash": "6147afc349405983",
+      "exit_code": 0,
+      "name": "date matrix: directive %m (jan)",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
       "content_hash": "c3ec8615e5a118d0",
       "exit_code": 0,
       "name": "date matrix: directive %M (pm)",
@@ -277,6 +410,13 @@
       "content_hash": "0767e07ab78c1866",
       "exit_code": 0,
       "name": "date matrix: directive %M (am)",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "4f94a1a3ccb01d45",
+      "exit_code": 0,
+      "name": "date matrix: directive %M (jan)",
       "stderr": "",
       "stdout": "05\nrc=0\n"
     },
@@ -295,6 +435,13 @@
       "stdout": "\n\nrc=0\n"
     },
     {
+      "content_hash": "c1ab52f62211882f",
+      "exit_code": 0,
+      "name": "date matrix: directive %n (jan)",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
       "content_hash": "a3a907a330f4067e",
       "exit_code": 0,
       "name": "date matrix: directive %N (pm)",
@@ -305,6 +452,13 @@
       "content_hash": "3eae86bc7a2e37d4",
       "exit_code": 0,
       "name": "date matrix: directive %N (am)",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "15cbc5c09fc4a632",
+      "exit_code": 0,
+      "name": "date matrix: directive %N (jan)",
       "stderr": "",
       "stdout": "000000000\nrc=0\n"
     },
@@ -323,6 +477,13 @@
       "stdout": "AM\nrc=0\n"
     },
     {
+      "content_hash": "1cab4a212f001661",
+      "exit_code": 0,
+      "name": "date matrix: directive %p (jan)",
+      "stderr": "",
+      "stdout": "AM\nrc=0\n"
+    },
+    {
       "content_hash": "71ad8effb369c9c1",
       "exit_code": 0,
       "name": "date matrix: directive %P (pm)",
@@ -333,6 +494,13 @@
       "content_hash": "6b6b3a6c5184cdb3",
       "exit_code": 0,
       "name": "date matrix: directive %P (am)",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "3a815456752dad0e",
+      "exit_code": 0,
+      "name": "date matrix: directive %P (jan)",
       "stderr": "",
       "stdout": "am\nrc=0\n"
     },
@@ -351,6 +519,13 @@
       "stdout": "2\nrc=0\n"
     },
     {
+      "content_hash": "fcbe58d915f81614",
+      "exit_code": 0,
+      "name": "date matrix: directive %q (jan)",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
       "content_hash": "e6ef1b48a0f443a7",
       "exit_code": 0,
       "name": "date matrix: directive %r (pm)",
@@ -361,6 +536,13 @@
       "content_hash": "9ba578beaeb9caaa",
       "exit_code": 0,
       "name": "date matrix: directive %r (am)",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "622bbecc8ca92fc0",
+      "exit_code": 0,
+      "name": "date matrix: directive %r (jan)",
       "stderr": "",
       "stdout": "09:05:03 AM\nrc=0\n"
     },
@@ -379,6 +561,13 @@
       "stdout": "09:05\nrc=0\n"
     },
     {
+      "content_hash": "aa0170fb95a1ad5b",
+      "exit_code": 0,
+      "name": "date matrix: directive %R (jan)",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
       "content_hash": "271379063d131a1b",
       "exit_code": 0,
       "name": "date matrix: directive %s (pm)",
@@ -393,6 +582,13 @@
       "stdout": "1717578303\nrc=0\n"
     },
     {
+      "content_hash": "94dc76ac6d785605",
+      "exit_code": 0,
+      "name": "date matrix: directive %s (jan)",
+      "stderr": "",
+      "stdout": "1104915903\nrc=0\n"
+    },
+    {
       "content_hash": "e1da279f3096227e",
       "exit_code": 0,
       "name": "date matrix: directive %S (pm)",
@@ -403,6 +599,13 @@
       "content_hash": "ad0169d4ceaa89e7",
       "exit_code": 0,
       "name": "date matrix: directive %S (am)",
+      "stderr": "",
+      "stdout": "03\nrc=0\n"
+    },
+    {
+      "content_hash": "5265d621f2a9feb2",
+      "exit_code": 0,
+      "name": "date matrix: directive %S (jan)",
       "stderr": "",
       "stdout": "03\nrc=0\n"
     },
@@ -421,6 +624,13 @@
       "stdout": "\t\nrc=0\n"
     },
     {
+      "content_hash": "348cfd17be46455a",
+      "exit_code": 0,
+      "name": "date matrix: directive %t (jan)",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
       "content_hash": "b56ecdd6fca6eed8",
       "exit_code": 0,
       "name": "date matrix: directive %T (pm)",
@@ -431,6 +641,13 @@
       "content_hash": "0bd0bfc60fe97ab3",
       "exit_code": 0,
       "name": "date matrix: directive %T (am)",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "51ff3cfae1b5538c",
+      "exit_code": 0,
+      "name": "date matrix: directive %T (jan)",
       "stderr": "",
       "stdout": "09:05:03\nrc=0\n"
     },
@@ -449,6 +666,13 @@
       "stdout": "3\nrc=0\n"
     },
     {
+      "content_hash": "25a928e9032d9fdb",
+      "exit_code": 0,
+      "name": "date matrix: directive %u (jan)",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
       "content_hash": "e58e8b6022b29444",
       "exit_code": 0,
       "name": "date matrix: directive %U (pm)",
@@ -461,6 +685,13 @@
       "name": "date matrix: directive %U (am)",
       "stderr": "",
       "stdout": "22\nrc=0\n"
+    },
+    {
+      "content_hash": "6b0c00f87ce57fa4",
+      "exit_code": 0,
+      "name": "date matrix: directive %U (jan)",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
     },
     {
       "content_hash": "826a2a38c18df58d",
@@ -477,6 +708,13 @@
       "stdout": "23\nrc=0\n"
     },
     {
+      "content_hash": "d732d9bd8afaff20",
+      "exit_code": 0,
+      "name": "date matrix: directive %V (jan)",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
       "content_hash": "2ca3916a701a047a",
       "exit_code": 0,
       "name": "date matrix: directive %w (pm)",
@@ -487,6 +725,13 @@
       "content_hash": "d4c53a88b8e7a6ba",
       "exit_code": 0,
       "name": "date matrix: directive %w (am)",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "859f83f2ed5b61d2",
+      "exit_code": 0,
+      "name": "date matrix: directive %w (jan)",
       "stderr": "",
       "stdout": "3\nrc=0\n"
     },
@@ -505,6 +750,13 @@
       "stdout": "23\nrc=0\n"
     },
     {
+      "content_hash": "02eee39ab4c8ef65",
+      "exit_code": 0,
+      "name": "date matrix: directive %W (jan)",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
       "content_hash": "5954a7be901a6c4c",
       "exit_code": 0,
       "name": "date matrix: directive %x (pm)",
@@ -519,6 +771,13 @@
       "stdout": "06/05/24\nrc=0\n"
     },
     {
+      "content_hash": "3e2b1820f9e49182",
+      "exit_code": 0,
+      "name": "date matrix: directive %x (jan)",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
       "content_hash": "152b36fbeb49a36f",
       "exit_code": 0,
       "name": "date matrix: directive %X (pm)",
@@ -529,6 +788,13 @@
       "content_hash": "f43c67c955e7269a",
       "exit_code": 0,
       "name": "date matrix: directive %X (am)",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "ce37d75b00230db3",
+      "exit_code": 0,
+      "name": "date matrix: directive %X (jan)",
       "stderr": "",
       "stdout": "09:05:03\nrc=0\n"
     },
@@ -547,6 +813,13 @@
       "stdout": "24\nrc=0\n"
     },
     {
+      "content_hash": "89328ec85a736033",
+      "exit_code": 0,
+      "name": "date matrix: directive %y (jan)",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
       "content_hash": "229b0f4f8cc45377",
       "exit_code": 0,
       "name": "date matrix: directive %Y (pm)",
@@ -561,6 +834,13 @@
       "stdout": "2024\nrc=0\n"
     },
     {
+      "content_hash": "cd4c7f6bb55416a4",
+      "exit_code": 0,
+      "name": "date matrix: directive %Y (jan)",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
       "content_hash": "5afc4f2c3e44ff0e",
       "exit_code": 0,
       "name": "date matrix: directive %z (pm)",
@@ -571,6 +851,13 @@
       "content_hash": "3d5e0f401a55e41e",
       "exit_code": 0,
       "name": "date matrix: directive %z (am)",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "428c38f348c4e874",
+      "exit_code": 0,
+      "name": "date matrix: directive %z (jan)",
       "stderr": "",
       "stdout": "+0000\nrc=0\n"
     },
@@ -589,6 +876,13 @@
       "stdout": "UTC\nrc=0\n"
     },
     {
+      "content_hash": "79af09e54ce01c09",
+      "exit_code": 0,
+      "name": "date matrix: directive %Z (jan)",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
       "content_hash": "f3240fae37076edc",
       "exit_code": 0,
       "name": "date matrix: modifier %:z (pm)",
@@ -599,6 +893,13 @@
       "content_hash": "6933c63c2d5f4a12",
       "exit_code": 0,
       "name": "date matrix: modifier %:z (am)",
+      "stderr": "",
+      "stdout": "+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "dba9981e73ebfa03",
+      "exit_code": 0,
+      "name": "date matrix: modifier %:z (jan)",
       "stderr": "",
       "stdout": "+00:00\nrc=0\n"
     },
@@ -617,6 +918,13 @@
       "stdout": "+00:00:00\nrc=0\n"
     },
     {
+      "content_hash": "e71a4b739bc77383",
+      "exit_code": 0,
+      "name": "date matrix: modifier %::z (jan)",
+      "stderr": "",
+      "stdout": "+00:00:00\nrc=0\n"
+    },
+    {
       "content_hash": "075e142ce0fa9942",
       "exit_code": 0,
       "name": "date matrix: modifier %:::z (pm)",
@@ -627,6 +935,13 @@
       "content_hash": "5849420cd1bf91a7",
       "exit_code": 0,
       "name": "date matrix: modifier %:::z (am)",
+      "stderr": "",
+      "stdout": "+00\nrc=0\n"
+    },
+    {
+      "content_hash": "089736083bd619cb",
+      "exit_code": 0,
+      "name": "date matrix: modifier %:::z (jan)",
       "stderr": "",
       "stdout": "+00\nrc=0\n"
     },
@@ -645,6 +960,13 @@
       "stdout": "5\nrc=0\n"
     },
     {
+      "content_hash": "2288dbd043a7cc42",
+      "exit_code": 0,
+      "name": "date matrix: modifier %-d (jan)",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
       "content_hash": "f89ee1d2976a8689",
       "exit_code": 0,
       "name": "date matrix: modifier %_d (pm)",
@@ -655,6 +977,13 @@
       "content_hash": "0fb029c7e0add102",
       "exit_code": 0,
       "name": "date matrix: modifier %_d (am)",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "aa9be789eaa9e28d",
+      "exit_code": 0,
+      "name": "date matrix: modifier %_d (jan)",
       "stderr": "",
       "stdout": " 5\nrc=0\n"
     },
@@ -673,6 +1002,13 @@
       "stdout": "05\nrc=0\n"
     },
     {
+      "content_hash": "7bd1275f5b2bc632",
+      "exit_code": 0,
+      "name": "date matrix: modifier %0d (jan)",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
       "content_hash": "5a6fe0fcac6631f1",
       "exit_code": 0,
       "name": "date matrix: modifier %^a (pm)",
@@ -683,6 +1019,13 @@
       "content_hash": "56690bb18e265c4a",
       "exit_code": 0,
       "name": "date matrix: modifier %^a (am)",
+      "stderr": "",
+      "stdout": "WED\nrc=0\n"
+    },
+    {
+      "content_hash": "ab405901da827a16",
+      "exit_code": 0,
+      "name": "date matrix: modifier %^a (jan)",
       "stderr": "",
       "stdout": "WED\nrc=0\n"
     },
@@ -699,6 +1042,2799 @@
       "name": "date matrix: modifier %#a (am)",
       "stderr": "",
       "stdout": "WED\nrc=0\n"
+    },
+    {
+      "content_hash": "1a878fb99c2ff0cc",
+      "exit_code": 0,
+      "name": "date matrix: modifier %#a (jan)",
+      "stderr": "",
+      "stdout": "WED\nrc=0\n"
+    },
+    {
+      "content_hash": "3532eff93c52798c",
+      "exit_code": 0,
+      "name": "date matrix: flag %-a",
+      "stderr": "",
+      "stdout": "Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "d00c44042e0cd839",
+      "exit_code": 0,
+      "name": "date matrix: flag %-A",
+      "stderr": "",
+      "stdout": "Wednesday\nrc=0\n"
+    },
+    {
+      "content_hash": "828ed1e9d1d72fd1",
+      "exit_code": 0,
+      "name": "date matrix: flag %-b",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
+      "content_hash": "4f7d52da2b79747b",
+      "exit_code": 0,
+      "name": "date matrix: flag %-B",
+      "stderr": "",
+      "stdout": "January\nrc=0\n"
+    },
+    {
+      "content_hash": "addbd4e7122372e7",
+      "exit_code": 0,
+      "name": "date matrix: flag %-c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "3345a60bed7e577f",
+      "exit_code": 0,
+      "name": "date matrix: flag %-C",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "2288dbd043a7cc42",
+      "exit_code": 0,
+      "name": "date matrix: flag %-d",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "c851e87066e99c90",
+      "exit_code": 0,
+      "name": "date matrix: flag %-D",
+      "stderr": "",
+      "stdout": "01/05/5\nrc=0\n"
+    },
+    {
+      "content_hash": "8563f4dc04e9aa85",
+      "exit_code": 0,
+      "name": "date matrix: flag %-e",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "8c21f9fba092b63d",
+      "exit_code": 0,
+      "name": "date matrix: flag %-F",
+      "stderr": "",
+      "stdout": "2005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "91c9cecd444c68c2",
+      "exit_code": 0,
+      "name": "date matrix: flag %-g",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "44e02fae323c9b33",
+      "exit_code": 0,
+      "name": "date matrix: flag %-G",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "2e0b5b18a5eae89d",
+      "exit_code": 0,
+      "name": "date matrix: flag %-h",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
+      "content_hash": "78ab64141b80ab1b",
+      "exit_code": 0,
+      "name": "date matrix: flag %-H",
+      "stderr": "",
+      "stdout": "9\nrc=0\n"
+    },
+    {
+      "content_hash": "e7ab7e6d8f32aef4",
+      "exit_code": 0,
+      "name": "date matrix: flag %-I",
+      "stderr": "",
+      "stdout": "9\nrc=0\n"
+    },
+    {
+      "content_hash": "1d8a21095d858bf4",
+      "exit_code": 0,
+      "name": "date matrix: flag %-j",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "b5e554a47e88cf58",
+      "exit_code": 0,
+      "name": "date matrix: flag %-k",
+      "stderr": "",
+      "stdout": "9\nrc=0\n"
+    },
+    {
+      "content_hash": "d155f10002729bed",
+      "exit_code": 0,
+      "name": "date matrix: flag %-l",
+      "stderr": "",
+      "stdout": "9\nrc=0\n"
+    },
+    {
+      "content_hash": "82de8109798f18e8",
+      "exit_code": 0,
+      "name": "date matrix: flag %-m",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "806527d60f3af552",
+      "exit_code": 0,
+      "name": "date matrix: flag %-M",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "c88982f0dce7501b",
+      "exit_code": 0,
+      "name": "date matrix: flag %-n",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "5ccc1ff0726f52b5",
+      "exit_code": 0,
+      "name": "date matrix: flag %-N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "1dfc244fc1cb97be",
+      "exit_code": 0,
+      "name": "date matrix: flag %-p",
+      "stderr": "",
+      "stdout": "AM\nrc=0\n"
+    },
+    {
+      "content_hash": "31b00e82db8201f4",
+      "exit_code": 0,
+      "name": "date matrix: flag %-P",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "ac93edb8db4574a1",
+      "exit_code": 0,
+      "name": "date matrix: flag %-q",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "fdec330651ac4368",
+      "exit_code": 0,
+      "name": "date matrix: flag %-r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "0f1e376900ba2ee4",
+      "exit_code": 0,
+      "name": "date matrix: flag %-R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "e05cf032cdca2b4e",
+      "exit_code": 0,
+      "name": "date matrix: flag %-s",
+      "stderr": "",
+      "stdout": "1104915903\nrc=0\n"
+    },
+    {
+      "content_hash": "6e66865ae970e310",
+      "exit_code": 0,
+      "name": "date matrix: flag %-S",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "e5f74caed3d7b49b",
+      "exit_code": 0,
+      "name": "date matrix: flag %-t",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "4186456babea731f",
+      "exit_code": 0,
+      "name": "date matrix: flag %-T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "869877428d1556c0",
+      "exit_code": 0,
+      "name": "date matrix: flag %-u",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "2e3ef1f5b21bebaa",
+      "exit_code": 0,
+      "name": "date matrix: flag %-U",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "99f86434332c068e",
+      "exit_code": 0,
+      "name": "date matrix: flag %-V",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "c1a4b03aa85b06bf",
+      "exit_code": 0,
+      "name": "date matrix: flag %-w",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "dab37917eb8be403",
+      "exit_code": 0,
+      "name": "date matrix: flag %-W",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "d293d0cfa4d11053",
+      "exit_code": 0,
+      "name": "date matrix: flag %-x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "04620cd4885772ad",
+      "exit_code": 0,
+      "name": "date matrix: flag %-X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "94390869d90ddbb4",
+      "exit_code": 0,
+      "name": "date matrix: flag %-y",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "4ccd5cbc9c906edc",
+      "exit_code": 0,
+      "name": "date matrix: flag %-Y",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "16d879078262ca6d",
+      "exit_code": 0,
+      "name": "date matrix: flag %-z",
+      "stderr": "",
+      "stdout": "+0\nrc=0\n"
+    },
+    {
+      "content_hash": "a39916c58216299c",
+      "exit_code": 0,
+      "name": "date matrix: flag %-Z",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "f578a474f5d791e2",
+      "exit_code": 0,
+      "name": "date matrix: flag %_a",
+      "stderr": "",
+      "stdout": "Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "1c080331493df33a",
+      "exit_code": 0,
+      "name": "date matrix: flag %_A",
+      "stderr": "",
+      "stdout": "Wednesday\nrc=0\n"
+    },
+    {
+      "content_hash": "84cd614e2c88dc13",
+      "exit_code": 0,
+      "name": "date matrix: flag %_b",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
+      "content_hash": "9d686eb0419a8031",
+      "exit_code": 0,
+      "name": "date matrix: flag %_B",
+      "stderr": "",
+      "stdout": "January\nrc=0\n"
+    },
+    {
+      "content_hash": "bc5e16e2ba7e1a82",
+      "exit_code": 0,
+      "name": "date matrix: flag %_c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "d8aea7d34d6cd8c5",
+      "exit_code": 0,
+      "name": "date matrix: flag %_C",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "aa9be789eaa9e28d",
+      "exit_code": 0,
+      "name": "date matrix: flag %_d",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "7d1cd74a814b1b88",
+      "exit_code": 0,
+      "name": "date matrix: flag %_D",
+      "stderr": "",
+      "stdout": "01/05/ 5\nrc=0\n"
+    },
+    {
+      "content_hash": "3f49ad8b9a1e599d",
+      "exit_code": 0,
+      "name": "date matrix: flag %_e",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "8f861bbe1777efe7",
+      "exit_code": 0,
+      "name": "date matrix: flag %_F",
+      "stderr": "",
+      "stdout": "2005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "cd448c43f3aa6467",
+      "exit_code": 0,
+      "name": "date matrix: flag %_g",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "985ddf80545fcbe4",
+      "exit_code": 0,
+      "name": "date matrix: flag %_G",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "658df1ec0e12e62e",
+      "exit_code": 0,
+      "name": "date matrix: flag %_h",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
+      "content_hash": "25dd2f60e2b7421f",
+      "exit_code": 0,
+      "name": "date matrix: flag %_H",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "4c40fbb38cdb711e",
+      "exit_code": 0,
+      "name": "date matrix: flag %_I",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "bf088004ff76a6d2",
+      "exit_code": 0,
+      "name": "date matrix: flag %_j",
+      "stderr": "",
+      "stdout": "  5\nrc=0\n"
+    },
+    {
+      "content_hash": "88451b9021e6d9a2",
+      "exit_code": 0,
+      "name": "date matrix: flag %_k",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "2703fa89b1394a5c",
+      "exit_code": 0,
+      "name": "date matrix: flag %_l",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "b64aced5be4d3a0b",
+      "exit_code": 0,
+      "name": "date matrix: flag %_m",
+      "stderr": "",
+      "stdout": " 1\nrc=0\n"
+    },
+    {
+      "content_hash": "784cefaf729fec93",
+      "exit_code": 0,
+      "name": "date matrix: flag %_M",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "065f251bad081f7f",
+      "exit_code": 0,
+      "name": "date matrix: flag %_n",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "6480c1c8fb07829a",
+      "exit_code": 0,
+      "name": "date matrix: flag %_N",
+      "stderr": "",
+      "stdout": "0        \nrc=0\n"
+    },
+    {
+      "content_hash": "2b6d2304e88b99ff",
+      "exit_code": 0,
+      "name": "date matrix: flag %_p",
+      "stderr": "",
+      "stdout": "AM\nrc=0\n"
+    },
+    {
+      "content_hash": "e943bb7ab5df165f",
+      "exit_code": 0,
+      "name": "date matrix: flag %_P",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "d9b0ead4b1dfcc07",
+      "exit_code": 0,
+      "name": "date matrix: flag %_q",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "8a30a4d55273a6ba",
+      "exit_code": 0,
+      "name": "date matrix: flag %_r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "74ae5cae568edbcb",
+      "exit_code": 0,
+      "name": "date matrix: flag %_R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "8d0ef708ab80b85e",
+      "exit_code": 0,
+      "name": "date matrix: flag %_s",
+      "stderr": "",
+      "stdout": "1104915903\nrc=0\n"
+    },
+    {
+      "content_hash": "bdeffc511a33e104",
+      "exit_code": 0,
+      "name": "date matrix: flag %_S",
+      "stderr": "",
+      "stdout": " 3\nrc=0\n"
+    },
+    {
+      "content_hash": "84a18384f1d66d71",
+      "exit_code": 0,
+      "name": "date matrix: flag %_t",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "dc49d03daf139269",
+      "exit_code": 0,
+      "name": "date matrix: flag %_T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "f6ab09376ecc9473",
+      "exit_code": 0,
+      "name": "date matrix: flag %_u",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "48fd2ed7478d55b3",
+      "exit_code": 0,
+      "name": "date matrix: flag %_U",
+      "stderr": "",
+      "stdout": " 1\nrc=0\n"
+    },
+    {
+      "content_hash": "4be90851e07de7c4",
+      "exit_code": 0,
+      "name": "date matrix: flag %_V",
+      "stderr": "",
+      "stdout": " 1\nrc=0\n"
+    },
+    {
+      "content_hash": "f420d890ea17ba7c",
+      "exit_code": 0,
+      "name": "date matrix: flag %_w",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "ed75e80c3aa0ac2b",
+      "exit_code": 0,
+      "name": "date matrix: flag %_W",
+      "stderr": "",
+      "stdout": " 1\nrc=0\n"
+    },
+    {
+      "content_hash": "38be8d2c377e6cb9",
+      "exit_code": 0,
+      "name": "date matrix: flag %_x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "085fc9e18119a966",
+      "exit_code": 0,
+      "name": "date matrix: flag %_X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "764199cb5c01f8c8",
+      "exit_code": 0,
+      "name": "date matrix: flag %_y",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "8508e7843cce687d",
+      "exit_code": 0,
+      "name": "date matrix: flag %_Y",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "24e3e30259f9c4fd",
+      "exit_code": 0,
+      "name": "date matrix: flag %_z",
+      "stderr": "",
+      "stdout": "   +0\nrc=0\n"
+    },
+    {
+      "content_hash": "28e37456d986601c",
+      "exit_code": 0,
+      "name": "date matrix: flag %_Z",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "dffce02abe9f536f",
+      "exit_code": 0,
+      "name": "date matrix: flag %0a",
+      "stderr": "",
+      "stdout": "Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "130551ea8be4d359",
+      "exit_code": 0,
+      "name": "date matrix: flag %0A",
+      "stderr": "",
+      "stdout": "Wednesday\nrc=0\n"
+    },
+    {
+      "content_hash": "99495c24519babb2",
+      "exit_code": 0,
+      "name": "date matrix: flag %0b",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
+      "content_hash": "f5ef9045b24fde63",
+      "exit_code": 0,
+      "name": "date matrix: flag %0B",
+      "stderr": "",
+      "stdout": "January\nrc=0\n"
+    },
+    {
+      "content_hash": "6128e08445bc6794",
+      "exit_code": 0,
+      "name": "date matrix: flag %0c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "a82c9956f12663ba",
+      "exit_code": 0,
+      "name": "date matrix: flag %0C",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "7bd1275f5b2bc632",
+      "exit_code": 0,
+      "name": "date matrix: flag %0d",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "b60da9f87b22d21e",
+      "exit_code": 0,
+      "name": "date matrix: flag %0D",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "6a6071ebb1b2091a",
+      "exit_code": 0,
+      "name": "date matrix: flag %0e",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "579e503ec3508427",
+      "exit_code": 0,
+      "name": "date matrix: flag %0F",
+      "stderr": "",
+      "stdout": "2005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "982d96ddf611ba59",
+      "exit_code": 0,
+      "name": "date matrix: flag %0g",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "b26e422239ca4fbc",
+      "exit_code": 0,
+      "name": "date matrix: flag %0G",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "027fe63f295df6d6",
+      "exit_code": 0,
+      "name": "date matrix: flag %0h",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
+      "content_hash": "c8bc725ea912506e",
+      "exit_code": 0,
+      "name": "date matrix: flag %0H",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "80b8523fd224b1f0",
+      "exit_code": 0,
+      "name": "date matrix: flag %0I",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "c29f6fb6eb5251e6",
+      "exit_code": 0,
+      "name": "date matrix: flag %0j",
+      "stderr": "",
+      "stdout": "005\nrc=0\n"
+    },
+    {
+      "content_hash": "aa804e768622b488",
+      "exit_code": 0,
+      "name": "date matrix: flag %0k",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "c87b2bae8395a8fa",
+      "exit_code": 0,
+      "name": "date matrix: flag %0l",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "9b53be509d83d217",
+      "exit_code": 0,
+      "name": "date matrix: flag %0m",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "38bb1d6d03174814",
+      "exit_code": 0,
+      "name": "date matrix: flag %0M",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "d795d4f687140885",
+      "exit_code": 0,
+      "name": "date matrix: flag %0n",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "a96424eb6f39541e",
+      "exit_code": 0,
+      "name": "date matrix: flag %0N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "7f93812405033564",
+      "exit_code": 0,
+      "name": "date matrix: flag %0p",
+      "stderr": "",
+      "stdout": "AM\nrc=0\n"
+    },
+    {
+      "content_hash": "d6085bde043abc83",
+      "exit_code": 0,
+      "name": "date matrix: flag %0P",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "9e39a4c3291a8d90",
+      "exit_code": 0,
+      "name": "date matrix: flag %0q",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "e7b28f210db91a52",
+      "exit_code": 0,
+      "name": "date matrix: flag %0r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "8598262c112adefa",
+      "exit_code": 0,
+      "name": "date matrix: flag %0R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "2738f92d2943228f",
+      "exit_code": 0,
+      "name": "date matrix: flag %0s",
+      "stderr": "",
+      "stdout": "1104915903\nrc=0\n"
+    },
+    {
+      "content_hash": "1e4b294cc2268c7d",
+      "exit_code": 0,
+      "name": "date matrix: flag %0S",
+      "stderr": "",
+      "stdout": "03\nrc=0\n"
+    },
+    {
+      "content_hash": "6743fcce4bbf2887",
+      "exit_code": 0,
+      "name": "date matrix: flag %0t",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "bdaaceb44b702082",
+      "exit_code": 0,
+      "name": "date matrix: flag %0T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "7e8aa1aecb8296bb",
+      "exit_code": 0,
+      "name": "date matrix: flag %0u",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "014435c117f879cf",
+      "exit_code": 0,
+      "name": "date matrix: flag %0U",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "23b312eb34190ea7",
+      "exit_code": 0,
+      "name": "date matrix: flag %0V",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "e78343ef6dcbd1f7",
+      "exit_code": 0,
+      "name": "date matrix: flag %0w",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "519252fe13c6e350",
+      "exit_code": 0,
+      "name": "date matrix: flag %0W",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "caacebcd05389228",
+      "exit_code": 0,
+      "name": "date matrix: flag %0x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "ae9af1e9c1c3f131",
+      "exit_code": 0,
+      "name": "date matrix: flag %0X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "dfccb362790b3258",
+      "exit_code": 0,
+      "name": "date matrix: flag %0y",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "e852cfb140d42d6d",
+      "exit_code": 0,
+      "name": "date matrix: flag %0Y",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "792660f864e01fb0",
+      "exit_code": 0,
+      "name": "date matrix: flag %0z",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "7b68013f3dfa211c",
+      "exit_code": 0,
+      "name": "date matrix: flag %0Z",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "ab405901da827a16",
+      "exit_code": 0,
+      "name": "date matrix: flag %^a",
+      "stderr": "",
+      "stdout": "WED\nrc=0\n"
+    },
+    {
+      "content_hash": "f14d37ce61c87d4b",
+      "exit_code": 0,
+      "name": "date matrix: flag %^A",
+      "stderr": "",
+      "stdout": "WEDNESDAY\nrc=0\n"
+    },
+    {
+      "content_hash": "f3f1f3a5b76ee9f0",
+      "exit_code": 0,
+      "name": "date matrix: flag %^b",
+      "stderr": "",
+      "stdout": "JAN\nrc=0\n"
+    },
+    {
+      "content_hash": "2f8f0724d3091cac",
+      "exit_code": 0,
+      "name": "date matrix: flag %^B",
+      "stderr": "",
+      "stdout": "JANUARY\nrc=0\n"
+    },
+    {
+      "content_hash": "30bb09c0abdddba5",
+      "exit_code": 0,
+      "name": "date matrix: flag %^c",
+      "stderr": "",
+      "stdout": "WED JAN  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "1f7ec900a2b0309d",
+      "exit_code": 0,
+      "name": "date matrix: flag %^C",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "618b2871d8392f08",
+      "exit_code": 0,
+      "name": "date matrix: flag %^d",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "3f2ab8f1b125e5a8",
+      "exit_code": 0,
+      "name": "date matrix: flag %^D",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "0f53162b2ebb4eb0",
+      "exit_code": 0,
+      "name": "date matrix: flag %^e",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "12ee0b88c12ee689",
+      "exit_code": 0,
+      "name": "date matrix: flag %^F",
+      "stderr": "",
+      "stdout": "2005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "d64a75c6132da727",
+      "exit_code": 0,
+      "name": "date matrix: flag %^g",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "cd3eed8319a0fe99",
+      "exit_code": 0,
+      "name": "date matrix: flag %^G",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "0c629296c4a78a44",
+      "exit_code": 0,
+      "name": "date matrix: flag %^h",
+      "stderr": "",
+      "stdout": "JAN\nrc=0\n"
+    },
+    {
+      "content_hash": "fdc350bf8c1573a6",
+      "exit_code": 0,
+      "name": "date matrix: flag %^H",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "d7332d58bc494b40",
+      "exit_code": 0,
+      "name": "date matrix: flag %^I",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "41244cb0024e16bd",
+      "exit_code": 0,
+      "name": "date matrix: flag %^j",
+      "stderr": "",
+      "stdout": "005\nrc=0\n"
+    },
+    {
+      "content_hash": "459d1bfaff25dbb4",
+      "exit_code": 0,
+      "name": "date matrix: flag %^k",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "d6376572782a387f",
+      "exit_code": 0,
+      "name": "date matrix: flag %^l",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "bc33432ef38130d8",
+      "exit_code": 0,
+      "name": "date matrix: flag %^m",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "76cb1d74982105be",
+      "exit_code": 0,
+      "name": "date matrix: flag %^M",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "2d444f5be4f15a99",
+      "exit_code": 0,
+      "name": "date matrix: flag %^n",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "c5ff6f30bc2e227e",
+      "exit_code": 0,
+      "name": "date matrix: flag %^N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "aabf90a25fdd49d4",
+      "exit_code": 0,
+      "name": "date matrix: flag %^p",
+      "stderr": "",
+      "stdout": "AM\nrc=0\n"
+    },
+    {
+      "content_hash": "cd69d4eef64e547d",
+      "exit_code": 0,
+      "name": "date matrix: flag %^P",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "2f41480d8b3d1465",
+      "exit_code": 0,
+      "name": "date matrix: flag %^q",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "424bead86501d9ac",
+      "exit_code": 0,
+      "name": "date matrix: flag %^r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "5a8115afe7d15955",
+      "exit_code": 0,
+      "name": "date matrix: flag %^R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "d7d975fa5f3c1535",
+      "exit_code": 0,
+      "name": "date matrix: flag %^s",
+      "stderr": "",
+      "stdout": "1104915903\nrc=0\n"
+    },
+    {
+      "content_hash": "dbcee95ee17c1bfd",
+      "exit_code": 0,
+      "name": "date matrix: flag %^S",
+      "stderr": "",
+      "stdout": "03\nrc=0\n"
+    },
+    {
+      "content_hash": "73214385332e3c12",
+      "exit_code": 0,
+      "name": "date matrix: flag %^t",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "e5738b9fe3684c94",
+      "exit_code": 0,
+      "name": "date matrix: flag %^T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "c132772f9a46f479",
+      "exit_code": 0,
+      "name": "date matrix: flag %^u",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "d3d20c920fefbddc",
+      "exit_code": 0,
+      "name": "date matrix: flag %^U",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "b9cab9973568d685",
+      "exit_code": 0,
+      "name": "date matrix: flag %^V",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "05fbc6817c7c1819",
+      "exit_code": 0,
+      "name": "date matrix: flag %^w",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "936b92d72ac9c73f",
+      "exit_code": 0,
+      "name": "date matrix: flag %^W",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "8a4ac30056195257",
+      "exit_code": 0,
+      "name": "date matrix: flag %^x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "d0ba2790c6047a04",
+      "exit_code": 0,
+      "name": "date matrix: flag %^X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "122801a4c0135656",
+      "exit_code": 0,
+      "name": "date matrix: flag %^y",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "e7e19c3e6a66c2b0",
+      "exit_code": 0,
+      "name": "date matrix: flag %^Y",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "d3f4cf7534aecefb",
+      "exit_code": 0,
+      "name": "date matrix: flag %^z",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "2880f4f953a32524",
+      "exit_code": 0,
+      "name": "date matrix: flag %^Z",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "1a878fb99c2ff0cc",
+      "exit_code": 0,
+      "name": "date matrix: flag %#a",
+      "stderr": "",
+      "stdout": "WED\nrc=0\n"
+    },
+    {
+      "content_hash": "557bcabb193e659e",
+      "exit_code": 0,
+      "name": "date matrix: flag %#A",
+      "stderr": "",
+      "stdout": "WEDNESDAY\nrc=0\n"
+    },
+    {
+      "content_hash": "92b550f3cd7f654a",
+      "exit_code": 0,
+      "name": "date matrix: flag %#b",
+      "stderr": "",
+      "stdout": "JAN\nrc=0\n"
+    },
+    {
+      "content_hash": "2e169f1fd60285fb",
+      "exit_code": 0,
+      "name": "date matrix: flag %#B",
+      "stderr": "",
+      "stdout": "JANUARY\nrc=0\n"
+    },
+    {
+      "content_hash": "c5c9b673849db851",
+      "exit_code": 0,
+      "name": "date matrix: flag %#c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "aea8fb3b7d8aca65",
+      "exit_code": 0,
+      "name": "date matrix: flag %#C",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "c3ccc7042dba0db3",
+      "exit_code": 0,
+      "name": "date matrix: flag %#d",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "534914ec351738eb",
+      "exit_code": 0,
+      "name": "date matrix: flag %#D",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "93334662e6c86337",
+      "exit_code": 0,
+      "name": "date matrix: flag %#e",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "b1671f93d8aefbda",
+      "exit_code": 0,
+      "name": "date matrix: flag %#F",
+      "stderr": "",
+      "stdout": "2005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "2d4c7450104d89d0",
+      "exit_code": 0,
+      "name": "date matrix: flag %#g",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "bac8cb661fecb3bc",
+      "exit_code": 0,
+      "name": "date matrix: flag %#G",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "77eb0a176a381839",
+      "exit_code": 0,
+      "name": "date matrix: flag %#h",
+      "stderr": "",
+      "stdout": "JAN\nrc=0\n"
+    },
+    {
+      "content_hash": "2fcc1e1a94df49f5",
+      "exit_code": 0,
+      "name": "date matrix: flag %#H",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "fb9a45d588b1d38c",
+      "exit_code": 0,
+      "name": "date matrix: flag %#I",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "dae93da62a436b1e",
+      "exit_code": 0,
+      "name": "date matrix: flag %#j",
+      "stderr": "",
+      "stdout": "005\nrc=0\n"
+    },
+    {
+      "content_hash": "002d950e25a6f9ad",
+      "exit_code": 0,
+      "name": "date matrix: flag %#k",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "6e6b8f6f3bb979cb",
+      "exit_code": 0,
+      "name": "date matrix: flag %#l",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "3b2fb0ccd786d3ef",
+      "exit_code": 0,
+      "name": "date matrix: flag %#m",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "2a918e84f2e26aae",
+      "exit_code": 0,
+      "name": "date matrix: flag %#M",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "728f10c402800ebf",
+      "exit_code": 0,
+      "name": "date matrix: flag %#n",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "bc7a931949a4c54c",
+      "exit_code": 0,
+      "name": "date matrix: flag %#N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "f9232be618071299",
+      "exit_code": 0,
+      "name": "date matrix: flag %#p",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "c806656a45379dce",
+      "exit_code": 0,
+      "name": "date matrix: flag %#P",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "4ff739f98be88934",
+      "exit_code": 0,
+      "name": "date matrix: flag %#q",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "47fad51461d9953f",
+      "exit_code": 0,
+      "name": "date matrix: flag %#r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "9c31491156548bec",
+      "exit_code": 0,
+      "name": "date matrix: flag %#R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "8d482fb2f7626de7",
+      "exit_code": 0,
+      "name": "date matrix: flag %#s",
+      "stderr": "",
+      "stdout": "1104915903\nrc=0\n"
+    },
+    {
+      "content_hash": "cf6824ebed1e6cff",
+      "exit_code": 0,
+      "name": "date matrix: flag %#S",
+      "stderr": "",
+      "stdout": "03\nrc=0\n"
+    },
+    {
+      "content_hash": "5dc20f56a3542c48",
+      "exit_code": 0,
+      "name": "date matrix: flag %#t",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "1a72ccc4a9c46682",
+      "exit_code": 0,
+      "name": "date matrix: flag %#T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "c490b33ded7cf349",
+      "exit_code": 0,
+      "name": "date matrix: flag %#u",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "c322bb6b2db8cab6",
+      "exit_code": 0,
+      "name": "date matrix: flag %#U",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "44323ef2eb39e02b",
+      "exit_code": 0,
+      "name": "date matrix: flag %#V",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "c771f9b5426fdd97",
+      "exit_code": 0,
+      "name": "date matrix: flag %#w",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "d484cf9f554d8982",
+      "exit_code": 0,
+      "name": "date matrix: flag %#W",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "29723d23c9f43e05",
+      "exit_code": 0,
+      "name": "date matrix: flag %#x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "3e5b8da8047c10ca",
+      "exit_code": 0,
+      "name": "date matrix: flag %#X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "e44f98612018fb5e",
+      "exit_code": 0,
+      "name": "date matrix: flag %#y",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "604ddecf1bf530bc",
+      "exit_code": 0,
+      "name": "date matrix: flag %#Y",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "a36885590aefc7f3",
+      "exit_code": 0,
+      "name": "date matrix: flag %#z",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "077360c2b061b56d",
+      "exit_code": 0,
+      "name": "date matrix: flag %#Z",
+      "stderr": "",
+      "stdout": "utc\nrc=0\n"
+    },
+    {
+      "content_hash": "4f8d74c7f4ec0ff7",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ea",
+      "stderr": "",
+      "stdout": "%Ea\nrc=0\n"
+    },
+    {
+      "content_hash": "c5a4dcb7c2d1bdfb",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EA",
+      "stderr": "",
+      "stdout": "%EA\nrc=0\n"
+    },
+    {
+      "content_hash": "81302a6ffdc42d1e",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Eb",
+      "stderr": "",
+      "stdout": "%Eb\nrc=0\n"
+    },
+    {
+      "content_hash": "175a3dcd1af0bb03",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EB",
+      "stderr": "",
+      "stdout": "%EB\nrc=0\n"
+    },
+    {
+      "content_hash": "299e716895d0959c",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ec",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "23a3825ec17a96c1",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EC",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "fa4c23b3c508b17e",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ed",
+      "stderr": "",
+      "stdout": "%Ed\nrc=0\n"
+    },
+    {
+      "content_hash": "82a24db541c80742",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %ED",
+      "stderr": "",
+      "stdout": "%ED\nrc=0\n"
+    },
+    {
+      "content_hash": "49e6de53dbc570e4",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ee",
+      "stderr": "",
+      "stdout": "%Ee\nrc=0\n"
+    },
+    {
+      "content_hash": "f60e88173d28bc48",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EF",
+      "stderr": "",
+      "stdout": "%EF\nrc=0\n"
+    },
+    {
+      "content_hash": "76c1acf3538a9557",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Eg",
+      "stderr": "",
+      "stdout": "%Eg\nrc=0\n"
+    },
+    {
+      "content_hash": "31abf8f1703ca5ff",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EG",
+      "stderr": "",
+      "stdout": "%EG\nrc=0\n"
+    },
+    {
+      "content_hash": "31b4bc1994cc769a",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Eh",
+      "stderr": "",
+      "stdout": "%Eh\nrc=0\n"
+    },
+    {
+      "content_hash": "28e4e336ba516361",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EH",
+      "stderr": "",
+      "stdout": "%EH\nrc=0\n"
+    },
+    {
+      "content_hash": "6eb0219741e66dad",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EI",
+      "stderr": "",
+      "stdout": "%EI\nrc=0\n"
+    },
+    {
+      "content_hash": "6aba66c2b9e0af83",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ej",
+      "stderr": "",
+      "stdout": "%Ej\nrc=0\n"
+    },
+    {
+      "content_hash": "48b241f732f2b8fc",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ek",
+      "stderr": "",
+      "stdout": "%Ek\nrc=0\n"
+    },
+    {
+      "content_hash": "5cb1bc1b44e74f9b",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %El",
+      "stderr": "",
+      "stdout": "%El\nrc=0\n"
+    },
+    {
+      "content_hash": "30de0f0cbbf23c2a",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Em",
+      "stderr": "",
+      "stdout": "%Em\nrc=0\n"
+    },
+    {
+      "content_hash": "26fe9eb19183d21b",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EM",
+      "stderr": "",
+      "stdout": "%EM\nrc=0\n"
+    },
+    {
+      "content_hash": "92432f541665777c",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %En",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "e1748c8bc52ab8b0",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EN",
+      "stderr": "",
+      "stdout": "%EN\nrc=0\n"
+    },
+    {
+      "content_hash": "fa83f0d99c1bdf35",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ep",
+      "stderr": "",
+      "stdout": "AM\nrc=0\n"
+    },
+    {
+      "content_hash": "ac62f0350f2299ba",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EP",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "a860a6e1808d25ab",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Eq",
+      "stderr": "",
+      "stdout": "1\nrc=0\n"
+    },
+    {
+      "content_hash": "b5a2464de118ee1e",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Er",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "6ecd45cfefb4387b",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %ER",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "2e9412395d13f0dd",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Es",
+      "stderr": "",
+      "stdout": "1104915903\nrc=0\n"
+    },
+    {
+      "content_hash": "fb3d870041f14722",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %ES",
+      "stderr": "",
+      "stdout": "%ES\nrc=0\n"
+    },
+    {
+      "content_hash": "8dcab8de7001b5c6",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Et",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "ba58d0cdff765ab6",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %ET",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "c386d9a19d744123",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Eu",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "e9af76d9929adfa3",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EU",
+      "stderr": "",
+      "stdout": "%EU\nrc=0\n"
+    },
+    {
+      "content_hash": "74a2829e548872dc",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EV",
+      "stderr": "",
+      "stdout": "%EV\nrc=0\n"
+    },
+    {
+      "content_hash": "d55b6299395d5a33",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ew",
+      "stderr": "",
+      "stdout": "%Ew\nrc=0\n"
+    },
+    {
+      "content_hash": "b6891efd30953667",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EW",
+      "stderr": "",
+      "stdout": "%EW\nrc=0\n"
+    },
+    {
+      "content_hash": "a62624309e7efd64",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ex",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "1256a1ffe4c0c633",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EX",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "4bfbb30c9d187d22",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ey",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "028afdbc859f4e97",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EY",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "bb2dc44e2472530e",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ez",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "c32bf4666c5e885b",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %EZ",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "4d16dd13e0eaf625",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Oa",
+      "stderr": "",
+      "stdout": "%Oa\nrc=0\n"
+    },
+    {
+      "content_hash": "b146302a0719dc4a",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OA",
+      "stderr": "",
+      "stdout": "%OA\nrc=0\n"
+    },
+    {
+      "content_hash": "043a8412b8d78cce",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ob",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
+      "content_hash": "b942eb74b8128e5a",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OB",
+      "stderr": "",
+      "stdout": "January\nrc=0\n"
+    },
+    {
+      "content_hash": "bc3c4fea5ef39512",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Oc",
+      "stderr": "",
+      "stdout": "%Oc\nrc=0\n"
+    },
+    {
+      "content_hash": "594ea446d1457795",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OC",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "592a38672bb6c04a",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Od",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "ea44801fae22013e",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OD",
+      "stderr": "",
+      "stdout": "%OD\nrc=0\n"
+    },
+    {
+      "content_hash": "3e7a3011aceae9cb",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Oe",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "3186d6c290757b44",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OF",
+      "stderr": "",
+      "stdout": "%OF\nrc=0\n"
+    },
+    {
+      "content_hash": "cfa6bc7ed4711d4c",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Og",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "df789c6a20a1c1a6",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OG",
+      "stderr": "",
+      "stdout": "2005\nrc=0\n"
+    },
+    {
+      "content_hash": "12e40daf46fb5596",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Oh",
+      "stderr": "",
+      "stdout": "Jan\nrc=0\n"
+    },
+    {
+      "content_hash": "12a18c9bd01102c6",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OH",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "c93e48bfa96d6f67",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OI",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "afbbb5f9e671dd16",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Oj",
+      "stderr": "",
+      "stdout": "005\nrc=0\n"
+    },
+    {
+      "content_hash": "db2dedca7d367c7f",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ok",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "33b768f627560356",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ol",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "07ac09ea3a02ce74",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Om",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "3346162193a097ab",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OM",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "a322ad54a6fdf13c",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %On",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "3d24784ef23e1fd3",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %ON",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "5f6ec320db686d7d",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Op",
+      "stderr": "",
+      "stdout": "AM\nrc=0\n"
+    },
+    {
+      "content_hash": "680670a5b8051ee2",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OP",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "c380e5369754fafe",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Oq",
+      "stderr": "",
+      "stdout": "%Oq\nrc=0\n"
+    },
+    {
+      "content_hash": "3268d5de40b42440",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Or",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "c3fd34a3d67f050c",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OR",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "746d04f2b73512db",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Os",
+      "stderr": "",
+      "stdout": "1104915903\nrc=0\n"
+    },
+    {
+      "content_hash": "82e5a06d378a7c04",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OS",
+      "stderr": "",
+      "stdout": "03\nrc=0\n"
+    },
+    {
+      "content_hash": "5b115c0ad7d7590f",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ot",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "324848793be124cb",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OT",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "f45857ebfd823182",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ou",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "3804a50fc07a198c",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OU",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "16cfc7e7d7b6d964",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OV",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "449616e1ad2d6f63",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ow",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "f2d13cb664269952",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OW",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "9035b97c02d70f0e",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Ox",
+      "stderr": "",
+      "stdout": "%Ox\nrc=0\n"
+    },
+    {
+      "content_hash": "88f8ad861b485185",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OX",
+      "stderr": "",
+      "stdout": "%OX\nrc=0\n"
+    },
+    {
+      "content_hash": "8edaf716e7dd9859",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Oy",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "8ef53bdaa49254c9",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OY",
+      "stderr": "",
+      "stdout": "%OY\nrc=0\n"
+    },
+    {
+      "content_hash": "56eeac2868e9afdb",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %Oz",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "7060068055714b19",
+      "exit_code": 0,
+      "name": "date matrix: locale modifier %OZ",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "a3fc3db7f11b6528",
+      "exit_code": 0,
+      "name": "date matrix: zone %-:z",
+      "stderr": "",
+      "stdout": "+0:00\nrc=0\n"
+    },
+    {
+      "content_hash": "0e219599a6438436",
+      "exit_code": 0,
+      "name": "date matrix: zone %_:z",
+      "stderr": "",
+      "stdout": " +0:00\nrc=0\n"
+    },
+    {
+      "content_hash": "be08864d1997c364",
+      "exit_code": 0,
+      "name": "date matrix: zone %0:z",
+      "stderr": "",
+      "stdout": "+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "6b27735adbb22c3b",
+      "exit_code": 0,
+      "name": "date matrix: zone %3:z",
+      "stderr": "",
+      "stdout": "+0:00\nrc=0\n"
+    },
+    {
+      "content_hash": "5ce3dbdb215786c7",
+      "exit_code": 0,
+      "name": "date matrix: zone %8:z",
+      "stderr": "",
+      "stdout": "+0000:00\nrc=0\n"
+    },
+    {
+      "content_hash": "2fa382f6f0f4e5ae",
+      "exit_code": 0,
+      "name": "date matrix: zone %-::z",
+      "stderr": "",
+      "stdout": "+0:00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "325c2edfd14a0bed",
+      "exit_code": 0,
+      "name": "date matrix: zone %_::z",
+      "stderr": "",
+      "stdout": " +0:00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "07c260c71da0034b",
+      "exit_code": 0,
+      "name": "date matrix: zone %-:::z",
+      "stderr": "",
+      "stdout": "+0\nrc=0\n"
+    },
+    {
+      "content_hash": "ab32088721d39e96",
+      "exit_code": 0,
+      "name": "date matrix: zone %^:z",
+      "stderr": "",
+      "stdout": "+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "16d879078262ca6d",
+      "exit_code": 0,
+      "name": "date matrix: zone %-z",
+      "stderr": "",
+      "stdout": "+0\nrc=0\n"
+    },
+    {
+      "content_hash": "24e3e30259f9c4fd",
+      "exit_code": 0,
+      "name": "date matrix: zone %_z",
+      "stderr": "",
+      "stdout": "   +0\nrc=0\n"
+    },
+    {
+      "content_hash": "792660f864e01fb0",
+      "exit_code": 0,
+      "name": "date matrix: zone %0z",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "5c18bde73424c811",
+      "exit_code": 0,
+      "name": "date matrix: zone %1z",
+      "stderr": "",
+      "stdout": "+0\nrc=0\n"
+    },
+    {
+      "content_hash": "6babeeec90d1d5aa",
+      "exit_code": 0,
+      "name": "date matrix: zone %5z",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "d993696d41af0d5d",
+      "exit_code": 0,
+      "name": "date matrix: zone %8z",
+      "stderr": "",
+      "stdout": "+0000000\nrc=0\n"
+    },
+    {
+      "content_hash": "d3f4cf7534aecefb",
+      "exit_code": 0,
+      "name": "date matrix: zone %^z",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "a36885590aefc7f3",
+      "exit_code": 0,
+      "name": "date matrix: zone %#z",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "cdf1466c0a6cba1a",
+      "exit_code": 0,
+      "name": "date matrix: string width %5a",
+      "stderr": "",
+      "stdout": "  Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "08decb2cff2a59d9",
+      "exit_code": 0,
+      "name": "date matrix: string width %_5a",
+      "stderr": "",
+      "stdout": "  Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "7bedb784ab4b4576",
+      "exit_code": 0,
+      "name": "date matrix: string width %05a",
+      "stderr": "",
+      "stdout": "00Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "b055dc15fd75c2ed",
+      "exit_code": 0,
+      "name": "date matrix: string width %-5a",
+      "stderr": "",
+      "stdout": "Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "6aac967ba6fc3791",
+      "exit_code": 0,
+      "name": "date matrix: string width %^5a",
+      "stderr": "",
+      "stdout": "  WED\nrc=0\n"
+    },
+    {
+      "content_hash": "38eb512ee121b10f",
+      "exit_code": 0,
+      "name": "date matrix: string width %2a",
+      "stderr": "",
+      "stdout": "Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "0427595ac9851b4d",
+      "exit_code": 0,
+      "name": "date matrix: string width %12D",
+      "stderr": "",
+      "stdout": "    01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "5757f5846dcb289d",
+      "exit_code": 0,
+      "name": "date matrix: string width %12T",
+      "stderr": "",
+      "stdout": "    09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "0d4d9bf5f6fede61",
+      "exit_code": 0,
+      "name": "date matrix: string width %_12F",
+      "stderr": "",
+      "stdout": "  2005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "22e78375c37104cd",
+      "exit_code": 0,
+      "name": "date matrix: string width %012F",
+      "stderr": "",
+      "stdout": "002005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "63f7d849da268954",
+      "exit_code": 0,
+      "name": "date matrix: string width %20c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "43ac513f77565329",
+      "exit_code": 0,
+      "name": "date matrix: string width %6p",
+      "stderr": "",
+      "stdout": "    AM\nrc=0\n"
+    },
+    {
+      "content_hash": "2e4c8bc1569f6972",
+      "exit_code": 0,
+      "name": "date matrix: string width %6Z",
+      "stderr": "",
+      "stdout": "   UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "ea30e6f3c446de10",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %-Od",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "5157ed575cd64f61",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %_5Od",
+      "stderr": "",
+      "stdout": "   05\nrc=0\n"
+    },
+    {
+      "content_hash": "17b4093d534da131",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %3Od",
+      "stderr": "",
+      "stdout": " 05\nrc=0\n"
+    },
+    {
+      "content_hash": "c8bd01d5a7b9bb86",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %05Ed",
+      "stderr": "",
+      "stdout": "%05Ed\nrc=0\n"
+    },
+    {
+      "content_hash": "a58bc9fba1e647f6",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %0Ey",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "e49526c4279536f8",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %5EY",
+      "stderr": "",
+      "stdout": " 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "4eeafce1eb58b080",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %-Ey",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "6236caabc709ab75",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %_5Ey",
+      "stderr": "",
+      "stdout": "   05\nrc=0\n"
+    },
+    {
+      "content_hash": "6ca10f36af4afae1",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %-Oe",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "5c89d5c2b66a58d9",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %_OH",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "3dc84339bbf8909c",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %^Ec",
+      "stderr": "",
+      "stdout": "WED JAN  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "74338fb7ec3faf87",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %#Ec",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 2005\nrc=0\n"
+    },
+    {
+      "content_hash": "09cf7a8bda1b1a8d",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %^Ea",
+      "stderr": "",
+      "stdout": "%^EA\nrc=0\n"
+    },
+    {
+      "content_hash": "aaf4049a15c31fcd",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %^Oa",
+      "stderr": "",
+      "stdout": "%^OA\nrc=0\n"
+    },
+    {
+      "content_hash": "25c158802a479f43",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %E",
+      "stderr": "",
+      "stdout": "%E\nrc=0\n"
+    },
+    {
+      "content_hash": "dd6ea147efdc23db",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %O",
+      "stderr": "",
+      "stdout": "%O\nrc=0\n"
+    },
+    {
+      "content_hash": "eb31acc98805233d",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %EJ",
+      "stderr": "",
+      "stdout": "%EJ\nrc=0\n"
+    },
+    {
+      "content_hash": "9a09816881ff1af5",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %OJ",
+      "stderr": "",
+      "stdout": "%OJ\nrc=0\n"
+    },
+    {
+      "content_hash": "904aedd198290e83",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %O%d",
+      "stderr": "",
+      "stdout": "%O05\nrc=0\n"
+    },
+    {
+      "content_hash": "1a1e6f59a63311fe",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %E%d",
+      "stderr": "",
+      "stdout": "%E05\nrc=0\n"
+    },
+    {
+      "content_hash": "07cfb2791f83a5b9",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %EOd",
+      "stderr": "",
+      "stdout": "%EOd\nrc=0\n"
+    },
+    {
+      "content_hash": "7b75ba26b911333d",
+      "exit_code": 0,
+      "name": "date matrix: modifier form %OEd",
+      "stderr": "",
+      "stdout": "%OEd\nrc=0\n"
+    },
+    {
+      "content_hash": "fe0dc4a145e5c0f6",
+      "exit_code": 0,
+      "name": "date matrix: low year %Y",
+      "stderr": "",
+      "stdout": "0005\nrc=0\n"
+    },
+    {
+      "content_hash": "7d287df9df7bec35",
+      "exit_code": 0,
+      "name": "date matrix: low year %-Y",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "7a36b7ba8a413067",
+      "exit_code": 0,
+      "name": "date matrix: low year %_Y",
+      "stderr": "",
+      "stdout": "   5\nrc=0\n"
+    },
+    {
+      "content_hash": "8fa5887a17c4cc97",
+      "exit_code": 0,
+      "name": "date matrix: low year %0Y",
+      "stderr": "",
+      "stdout": "0005\nrc=0\n"
+    },
+    {
+      "content_hash": "458c281a89c022ae",
+      "exit_code": 0,
+      "name": "date matrix: low year %5Y",
+      "stderr": "",
+      "stdout": "00005\nrc=0\n"
+    },
+    {
+      "content_hash": "2add3beecd78041f",
+      "exit_code": 0,
+      "name": "date matrix: low year %G",
+      "stderr": "",
+      "stdout": "0005\nrc=0\n"
+    },
+    {
+      "content_hash": "d5026db82f56dc1f",
+      "exit_code": 0,
+      "name": "date matrix: low year %-G",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "f4ef770ffe3e7da9",
+      "exit_code": 0,
+      "name": "date matrix: low year %C",
+      "stderr": "",
+      "stdout": "00\nrc=0\n"
+    },
+    {
+      "content_hash": "260bb979c9d41260",
+      "exit_code": 0,
+      "name": "date matrix: low year %-C",
+      "stderr": "",
+      "stdout": "0\nrc=0\n"
+    },
+    {
+      "content_hash": "7d5e5b35181ecf6c",
+      "exit_code": 0,
+      "name": "date matrix: low year %y",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "5167af142dd16803",
+      "exit_code": 0,
+      "name": "date matrix: low year %-y",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "7d8ea52883bcd59f",
+      "exit_code": 0,
+      "name": "date matrix: low year %-g",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "eba05f52ff547b4b",
+      "exit_code": 0,
+      "name": "date matrix: compound %-F",
+      "stderr": "",
+      "stdout": "5-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "a7351926ae19e579",
+      "exit_code": 0,
+      "name": "date matrix: compound %-D",
+      "stderr": "",
+      "stdout": "01/05/5\nrc=0\n"
+    },
+    {
+      "content_hash": "05d99cc1d4636010",
+      "exit_code": 0,
+      "name": "date matrix: compound %-T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "4bf6ada66979991b",
+      "exit_code": 0,
+      "name": "date matrix: compound %-R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "5065c620714cac4f",
+      "exit_code": 0,
+      "name": "date matrix: compound %-c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 5\nrc=0\n"
+    },
+    {
+      "content_hash": "b5d4f8bd8adf5d09",
+      "exit_code": 0,
+      "name": "date matrix: compound %-r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "bf02e524b411ce7c",
+      "exit_code": 0,
+      "name": "date matrix: compound %-x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "896cded467fe9dbf",
+      "exit_code": 0,
+      "name": "date matrix: compound %-X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "6877fa0ce66ff72f",
+      "exit_code": 0,
+      "name": "date matrix: compound %_F",
+      "stderr": "",
+      "stdout": "5-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "2e9a56152d85bd31",
+      "exit_code": 0,
+      "name": "date matrix: compound %_D",
+      "stderr": "",
+      "stdout": "01/05/ 5\nrc=0\n"
+    },
+    {
+      "content_hash": "8f808490c6659d94",
+      "exit_code": 0,
+      "name": "date matrix: compound %_T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "27b242fa3e04ad31",
+      "exit_code": 0,
+      "name": "date matrix: compound %_R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "a3d6ad842daf66c6",
+      "exit_code": 0,
+      "name": "date matrix: compound %_c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 5\nrc=0\n"
+    },
+    {
+      "content_hash": "3f795c0821ebaa54",
+      "exit_code": 0,
+      "name": "date matrix: compound %_r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "8eac3d5bcefff596",
+      "exit_code": 0,
+      "name": "date matrix: compound %_x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "1f2964bd747b1d77",
+      "exit_code": 0,
+      "name": "date matrix: compound %_X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "e0b99a84e4e6d7ce",
+      "exit_code": 0,
+      "name": "date matrix: compound %0F",
+      "stderr": "",
+      "stdout": "5-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "f256d89ffcf52411",
+      "exit_code": 0,
+      "name": "date matrix: compound %0D",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "ce64dc3bacea07d1",
+      "exit_code": 0,
+      "name": "date matrix: compound %0T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "e32ee5f4a2793d62",
+      "exit_code": 0,
+      "name": "date matrix: compound %0R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "f4fd9c609ad00ea0",
+      "exit_code": 0,
+      "name": "date matrix: compound %0c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 5\nrc=0\n"
+    },
+    {
+      "content_hash": "7f1d695214d6b21c",
+      "exit_code": 0,
+      "name": "date matrix: compound %0r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "dce863a6901234c0",
+      "exit_code": 0,
+      "name": "date matrix: compound %0x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "1da5303f4103d962",
+      "exit_code": 0,
+      "name": "date matrix: compound %0X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "b9249f053d0bf0cb",
+      "exit_code": 0,
+      "name": "date matrix: compound %^F",
+      "stderr": "",
+      "stdout": "0005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "e65332ca9b84883d",
+      "exit_code": 0,
+      "name": "date matrix: compound %^D",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "abc232a89f2866b7",
+      "exit_code": 0,
+      "name": "date matrix: compound %^T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "355bd2d6b1bbb499",
+      "exit_code": 0,
+      "name": "date matrix: compound %^R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "5576c76a46ba2be7",
+      "exit_code": 0,
+      "name": "date matrix: compound %^c",
+      "stderr": "",
+      "stdout": "WED JAN  5 09:05:03 5\nrc=0\n"
+    },
+    {
+      "content_hash": "1a5932c2ff39e3a4",
+      "exit_code": 0,
+      "name": "date matrix: compound %^r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "21c3648e11f7a593",
+      "exit_code": 0,
+      "name": "date matrix: compound %^x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "621878f9b6b73627",
+      "exit_code": 0,
+      "name": "date matrix: compound %^X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "cce045512c7bf171",
+      "exit_code": 0,
+      "name": "date matrix: compound %#F",
+      "stderr": "",
+      "stdout": "0005-01-05\nrc=0\n"
+    },
+    {
+      "content_hash": "7a30bef3cfddefd3",
+      "exit_code": 0,
+      "name": "date matrix: compound %#D",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "b5554097552abbed",
+      "exit_code": 0,
+      "name": "date matrix: compound %#T",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "90d5d446a5d72920",
+      "exit_code": 0,
+      "name": "date matrix: compound %#R",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "e3d39dbe4802417d",
+      "exit_code": 0,
+      "name": "date matrix: compound %#c",
+      "stderr": "",
+      "stdout": "Wed Jan  5 09:05:03 5\nrc=0\n"
+    },
+    {
+      "content_hash": "684bd469b15869e4",
+      "exit_code": 0,
+      "name": "date matrix: compound %#r",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "6f8a1fe644faec03",
+      "exit_code": 0,
+      "name": "date matrix: compound %#x",
+      "stderr": "",
+      "stdout": "01/05/05\nrc=0\n"
+    },
+    {
+      "content_hash": "89553fba98012b57",
+      "exit_code": 0,
+      "name": "date matrix: compound %#X",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
     },
     {
       "content_hash": "48edbdf07a846391",
@@ -862,6 +3998,76 @@
       "stdout": "%^!\nrc=0\n"
     },
     {
+      "content_hash": "20e42eca498d572c",
+      "exit_code": 0,
+      "name": "date matrix: sequence %^J",
+      "stderr": "",
+      "stdout": "%^J\nrc=0\n"
+    },
+    {
+      "content_hash": "35e41054b53a4000",
+      "exit_code": 0,
+      "name": "date matrix: sequence %#J",
+      "stderr": "",
+      "stdout": "%#J\nrc=0\n"
+    },
+    {
+      "content_hash": "f58218ab0fce7caf",
+      "exit_code": 0,
+      "name": "date matrix: sequence %-J",
+      "stderr": "",
+      "stdout": "%-J\nrc=0\n"
+    },
+    {
+      "content_hash": "738a5e423600f56f",
+      "exit_code": 0,
+      "name": "date matrix: sequence %_J",
+      "stderr": "",
+      "stdout": "%_J\nrc=0\n"
+    },
+    {
+      "content_hash": "c42447317b64381b",
+      "exit_code": 0,
+      "name": "date matrix: sequence %0J",
+      "stderr": "",
+      "stdout": "%0J\nrc=0\n"
+    },
+    {
+      "content_hash": "05e5eec974ed85ac",
+      "exit_code": 0,
+      "name": "date matrix: sequence %_3J",
+      "stderr": "",
+      "stdout": "%_3J\nrc=0\n"
+    },
+    {
+      "content_hash": "f9af83361ccb7191",
+      "exit_code": 0,
+      "name": "date matrix: sequence %0!",
+      "stderr": "",
+      "stdout": "%0!\nrc=0\n"
+    },
+    {
+      "content_hash": "88653b7d296c2e9b",
+      "exit_code": 0,
+      "name": "date matrix: sequence %^!x",
+      "stderr": "",
+      "stdout": "%^!x\nrc=0\n"
+    },
+    {
+      "content_hash": "86a9f6a982a03c51",
+      "exit_code": 0,
+      "name": "date matrix: sequence %0d%-d",
+      "stderr": "",
+      "stdout": "1515\nrc=0\n"
+    },
+    {
+      "content_hash": "34c05fcb91fe5543",
+      "exit_code": 0,
+      "name": "date matrix: sequence %_H:%-M",
+      "stderr": "",
+      "stdout": "13:30\nrc=0\n"
+    },
+    {
       "content_hash": "b5d066f089dbf4aa",
       "exit_code": 0,
       "name": "date matrix: width %3d",
@@ -988,6 +4194,97 @@
       "stdout": "157\nrc=0\n"
     },
     {
+      "content_hash": "1c8ea06677be68d1",
+      "exit_code": 0,
+      "name": "date matrix: width %1d",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "ceb525deec3fc8e7",
+      "exit_code": 0,
+      "name": "date matrix: width %1e",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "e27e2b9e83b8dfcc",
+      "exit_code": 0,
+      "name": "date matrix: width %1H",
+      "stderr": "",
+      "stdout": "9\nrc=0\n"
+    },
+    {
+      "content_hash": "94346ff6dfbe13e0",
+      "exit_code": 0,
+      "name": "date matrix: width %0d",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "b1a4e04fc989c8a2",
+      "exit_code": 0,
+      "name": "date matrix: width %5e",
+      "stderr": "",
+      "stdout": "    5\nrc=0\n"
+    },
+    {
+      "content_hash": "c94d64af145bad8b",
+      "exit_code": 0,
+      "name": "date matrix: width %5k",
+      "stderr": "",
+      "stdout": "    9\nrc=0\n"
+    },
+    {
+      "content_hash": "6dea9bbd52b5f4a0",
+      "exit_code": 0,
+      "name": "date matrix: width %5l",
+      "stderr": "",
+      "stdout": "    9\nrc=0\n"
+    },
+    {
+      "content_hash": "7f65c020804d2453",
+      "exit_code": 0,
+      "name": "date matrix: width %5Y",
+      "stderr": "",
+      "stdout": "02024\nrc=0\n"
+    },
+    {
+      "content_hash": "9dd1a9f733cbebdf",
+      "exit_code": 0,
+      "name": "date matrix: width %_5Y",
+      "stderr": "",
+      "stdout": " 2024\nrc=0\n"
+    },
+    {
+      "content_hash": "9b5ebc760f292961",
+      "exit_code": 0,
+      "name": "date matrix: width %5s",
+      "stderr": "",
+      "stdout": "1717578303\nrc=0\n"
+    },
+    {
+      "content_hash": "00f2fd6f71f578ed",
+      "exit_code": 0,
+      "name": "date matrix: width %_5j",
+      "stderr": "",
+      "stdout": "  157\nrc=0\n"
+    },
+    {
+      "content_hash": "04c43fd8f8c7bcd9",
+      "exit_code": 0,
+      "name": "date matrix: width %_1j",
+      "stderr": "",
+      "stdout": "157\nrc=0\n"
+    },
+    {
+      "content_hash": "21e0bad557731b05",
+      "exit_code": 0,
+      "name": "date matrix: width %2j",
+      "stderr": "",
+      "stdout": "157\nrc=0\n"
+    },
+    {
       "content_hash": "3eae86bc7a2e37d4",
       "exit_code": 0,
       "name": "date matrix: nanoseconds %N",
@@ -1016,6 +4313,20 @@
       "stdout": "000000000\nrc=0\n"
     },
     {
+      "content_hash": "d58966d545232386",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %#N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "123a38c093d374be",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %1N",
+      "stderr": "",
+      "stdout": "0\nrc=0\n"
+    },
+    {
       "content_hash": "75c7156a1bf629a7",
       "exit_code": 0,
       "name": "date matrix: nanoseconds %3N",
@@ -1028,6 +4339,20 @@
       "name": "date matrix: nanoseconds %6N",
       "stderr": "",
       "stdout": "000000\nrc=0\n"
+    },
+    {
+      "content_hash": "61fb5ef5307d5619",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %9N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "c2015cf4e56d746c",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %12N",
+      "stderr": "",
+      "stdout": "000000000000\nrc=0\n"
     },
     {
       "content_hash": "1e836116dc5c3c11",
@@ -1049,6 +4374,13 @@
       "name": "date matrix: nanoseconds %_6N",
       "stderr": "",
       "stdout": "0     \nrc=0\n"
+    },
+    {
+      "content_hash": "6585315fe69eb54f",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %-12N",
+      "stderr": "",
+      "stdout": "0\nrc=0\n"
     },
     {
       "content_hash": "c6678c35339e5c11",
@@ -1128,6 +4460,13 @@
       "stdout": "rc=1\n"
     },
     {
+      "content_hash": "60d08fb452de1fe3",
+      "exit_code": 0,
+      "name": "date matrix: absent flag -j -f %Y",
+      "stderr": "date: invalid option -- 'j'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
       "content_hash": "af848d1644742c50",
       "exit_code": 0,
       "name": "date matrix: absent flag -jf %Y",
@@ -1175,6 +4514,34 @@
       "name": "date matrix: input @1718458200",
       "stderr": "",
       "stdout": "2024-06-15 13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "9f383ce19a5d671b",
+      "exit_code": 0,
+      "name": "date matrix: input @0",
+      "stderr": "",
+      "stdout": "1970-01-01 00:00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "c28f5f1ba4f6c97a",
+      "exit_code": 0,
+      "name": "date matrix: input @-1",
+      "stderr": "",
+      "stdout": "1969-12-31 23:59:59\nrc=0\n"
+    },
+    {
+      "content_hash": "56111777896aef17",
+      "exit_code": 0,
+      "name": "date matrix: input @99999999999999999999",
+      "stderr": "date: invalid date '@99999999999999999999'\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "5c7c5c6aabee439f",
+      "exit_code": 0,
+      "name": "date matrix: input @-99999999999999999999",
+      "stderr": "date: invalid date '@-99999999999999999999'\n",
+      "stdout": "rc=1\n"
     },
     {
       "content_hash": "7d29779998b12451",
@@ -1251,6 +4618,69 @@
       "exit_code": 0,
       "name": "date matrix: date -d with no argument",
       "stderr": "date: option requires an argument -- 'd'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "96a320fc514e0bc6",
+      "exit_code": 0,
+      "name": "date matrix: long --date with no argument",
+      "stderr": "date: option '--date' requires an argument\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "333fe6220aa6ca0e",
+      "exit_code": 0,
+      "name": "date matrix: long --reference with no argument",
+      "stderr": "date: option '--reference' requires an argument\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f9edbc49cb982e02",
+      "exit_code": 0,
+      "name": "date matrix: reference -r and -d together",
+      "stderr": "date: the options to specify dates for printing are mutually exclusive\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "2f3fe6a526b18fd6",
+      "exit_code": 0,
+      "name": "date matrix: end of options --",
+      "stderr": "",
+      "stdout": "2024-06-15\nrc=0\n"
+    },
+    {
+      "content_hash": "2e38f635541d8c9c",
+      "exit_code": 0,
+      "name": "date matrix: long --date with a separate argument",
+      "stderr": "",
+      "stdout": "2024-06-15\nrc=0\n"
+    },
+    {
+      "content_hash": "32006898d6eb11e0",
+      "exit_code": 0,
+      "name": "date matrix: long --reference with a separate argument",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "3600cd824c22b465",
+      "exit_code": 0,
+      "name": "date matrix: long --iso-8601 with a separate argument",
+      "stderr": "date: the argument 'hours' lacks a leading '+';\nwhen using an option to specify date(s), any non-option\nargument must be a format string beginning with '+'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "924df887302ce0d4",
+      "exit_code": 0,
+      "name": "date matrix: bare - operand",
+      "stderr": "date: extra operand '+%F'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "82d0225adb7b0429",
+      "exit_code": 0,
+      "name": "date matrix: extra operand",
+      "stderr": "date: extra operand '+%F'\nTry 'date --help' for more information.\n",
       "stdout": "rc=1\n"
     },
     {

--- a/test/fixtures/bash_expected/date_matrix.json
+++ b/test/fixtures/bash_expected/date_matrix.json
@@ -1233,6 +1233,27 @@
       "stdout": "2024-06-15 17:30:00\nrc=0\n"
     },
     {
+      "content_hash": "2c43bd0c3657225e",
+      "exit_code": 0,
+      "name": "date matrix: reference -r on a missing file",
+      "stderr": "date: /jb_definitely_missing: No such file or directory\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f1fe3a5838214f60",
+      "exit_code": 0,
+      "name": "date matrix: reference -r with no argument",
+      "stderr": "date: option requires an argument -- 'r'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "1310757f10875d1c",
+      "exit_code": 0,
+      "name": "date matrix: date -d with no argument",
+      "stderr": "date: option requires an argument -- 'd'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
       "content_hash": "078461a27e682c98",
       "exit_code": 0,
       "name": "date matrix: utc flag -u",

--- a/test/fixtures/bash_expected/date_matrix.json
+++ b/test/fixtures/bash_expected/date_matrix.json
@@ -1,0 +1,1258 @@
+{
+  "results": [
+    {
+      "content_hash": "8a512421c503f1f6",
+      "exit_code": 0,
+      "name": "date matrix: directive %a (pm)",
+      "stderr": "",
+      "stdout": "Sat\nrc=0\n"
+    },
+    {
+      "content_hash": "dd87e162c7b9fe45",
+      "exit_code": 0,
+      "name": "date matrix: directive %a (am)",
+      "stderr": "",
+      "stdout": "Wed\nrc=0\n"
+    },
+    {
+      "content_hash": "bd952c3ad83363ea",
+      "exit_code": 0,
+      "name": "date matrix: directive %A (pm)",
+      "stderr": "",
+      "stdout": "Saturday\nrc=0\n"
+    },
+    {
+      "content_hash": "58ac9d25be86ee02",
+      "exit_code": 0,
+      "name": "date matrix: directive %A (am)",
+      "stderr": "",
+      "stdout": "Wednesday\nrc=0\n"
+    },
+    {
+      "content_hash": "3bccf3cb091a0df4",
+      "exit_code": 0,
+      "name": "date matrix: directive %b (pm)",
+      "stderr": "",
+      "stdout": "Jun\nrc=0\n"
+    },
+    {
+      "content_hash": "48c2f1533e4edc90",
+      "exit_code": 0,
+      "name": "date matrix: directive %b (am)",
+      "stderr": "",
+      "stdout": "Jun\nrc=0\n"
+    },
+    {
+      "content_hash": "b42f00344ba38511",
+      "exit_code": 0,
+      "name": "date matrix: directive %B (pm)",
+      "stderr": "",
+      "stdout": "June\nrc=0\n"
+    },
+    {
+      "content_hash": "27ea602ff75dbb76",
+      "exit_code": 0,
+      "name": "date matrix: directive %B (am)",
+      "stderr": "",
+      "stdout": "June\nrc=0\n"
+    },
+    {
+      "content_hash": "e148e5d7269cc6f7",
+      "exit_code": 0,
+      "name": "date matrix: directive %c (pm)",
+      "stderr": "",
+      "stdout": "Sat Jun 15 13:30:00 2024\nrc=0\n"
+    },
+    {
+      "content_hash": "8170cd93b1ee3970",
+      "exit_code": 0,
+      "name": "date matrix: directive %c (am)",
+      "stderr": "",
+      "stdout": "Wed Jun  5 09:05:03 2024\nrc=0\n"
+    },
+    {
+      "content_hash": "609c417d9eb36be8",
+      "exit_code": 0,
+      "name": "date matrix: directive %C (pm)",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "8ed42a3fc85ee04b",
+      "exit_code": 0,
+      "name": "date matrix: directive %C (am)",
+      "stderr": "",
+      "stdout": "20\nrc=0\n"
+    },
+    {
+      "content_hash": "9a0b9535ba5de345",
+      "exit_code": 0,
+      "name": "date matrix: directive %d (pm)",
+      "stderr": "",
+      "stdout": "15\nrc=0\n"
+    },
+    {
+      "content_hash": "3b9fe013a4373c65",
+      "exit_code": 0,
+      "name": "date matrix: directive %d (am)",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "4d092b7823d5509a",
+      "exit_code": 0,
+      "name": "date matrix: directive %D (pm)",
+      "stderr": "",
+      "stdout": "06/15/24\nrc=0\n"
+    },
+    {
+      "content_hash": "572da704437b15c6",
+      "exit_code": 0,
+      "name": "date matrix: directive %D (am)",
+      "stderr": "",
+      "stdout": "06/05/24\nrc=0\n"
+    },
+    {
+      "content_hash": "2e652974ea03e3b6",
+      "exit_code": 0,
+      "name": "date matrix: directive %e (pm)",
+      "stderr": "",
+      "stdout": "15\nrc=0\n"
+    },
+    {
+      "content_hash": "c679b175dfc9da46",
+      "exit_code": 0,
+      "name": "date matrix: directive %e (am)",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "bdc3ff2379f61837",
+      "exit_code": 0,
+      "name": "date matrix: directive %F (pm)",
+      "stderr": "",
+      "stdout": "2024-06-15\nrc=0\n"
+    },
+    {
+      "content_hash": "6fa6074d14e7b962",
+      "exit_code": 0,
+      "name": "date matrix: directive %F (am)",
+      "stderr": "",
+      "stdout": "2024-06-05\nrc=0\n"
+    },
+    {
+      "content_hash": "0eecc350b1f35b97",
+      "exit_code": 0,
+      "name": "date matrix: directive %g (pm)",
+      "stderr": "",
+      "stdout": "24\nrc=0\n"
+    },
+    {
+      "content_hash": "858671d4c811b091",
+      "exit_code": 0,
+      "name": "date matrix: directive %g (am)",
+      "stderr": "",
+      "stdout": "24\nrc=0\n"
+    },
+    {
+      "content_hash": "47ac3d2e0f9d2716",
+      "exit_code": 0,
+      "name": "date matrix: directive %G (pm)",
+      "stderr": "",
+      "stdout": "2024\nrc=0\n"
+    },
+    {
+      "content_hash": "0e188f1f98b57670",
+      "exit_code": 0,
+      "name": "date matrix: directive %G (am)",
+      "stderr": "",
+      "stdout": "2024\nrc=0\n"
+    },
+    {
+      "content_hash": "84f1b7701869bcde",
+      "exit_code": 0,
+      "name": "date matrix: directive %h (pm)",
+      "stderr": "",
+      "stdout": "Jun\nrc=0\n"
+    },
+    {
+      "content_hash": "8bcc542278a94e87",
+      "exit_code": 0,
+      "name": "date matrix: directive %h (am)",
+      "stderr": "",
+      "stdout": "Jun\nrc=0\n"
+    },
+    {
+      "content_hash": "fadeb047a08c49a9",
+      "exit_code": 0,
+      "name": "date matrix: directive %H (pm)",
+      "stderr": "",
+      "stdout": "13\nrc=0\n"
+    },
+    {
+      "content_hash": "c7965c3eb24b29df",
+      "exit_code": 0,
+      "name": "date matrix: directive %H (am)",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "7b48191fb1a5b6e1",
+      "exit_code": 0,
+      "name": "date matrix: directive %I (pm)",
+      "stderr": "",
+      "stdout": "01\nrc=0\n"
+    },
+    {
+      "content_hash": "0356bc1b00d5d7cd",
+      "exit_code": 0,
+      "name": "date matrix: directive %I (am)",
+      "stderr": "",
+      "stdout": "09\nrc=0\n"
+    },
+    {
+      "content_hash": "5f76f4e8a7710411",
+      "exit_code": 0,
+      "name": "date matrix: directive %j (pm)",
+      "stderr": "",
+      "stdout": "167\nrc=0\n"
+    },
+    {
+      "content_hash": "e58beffeef851e1f",
+      "exit_code": 0,
+      "name": "date matrix: directive %j (am)",
+      "stderr": "",
+      "stdout": "157\nrc=0\n"
+    },
+    {
+      "content_hash": "660eaf3387141170",
+      "exit_code": 0,
+      "name": "date matrix: directive %k (pm)",
+      "stderr": "",
+      "stdout": "13\nrc=0\n"
+    },
+    {
+      "content_hash": "632fe732934bf946",
+      "exit_code": 0,
+      "name": "date matrix: directive %k (am)",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "da9e91385bcd9b4b",
+      "exit_code": 0,
+      "name": "date matrix: directive %l (pm)",
+      "stderr": "",
+      "stdout": " 1\nrc=0\n"
+    },
+    {
+      "content_hash": "9d316b249d037cba",
+      "exit_code": 0,
+      "name": "date matrix: directive %l (am)",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "daf96127b6418ff3",
+      "exit_code": 0,
+      "name": "date matrix: directive %m (pm)",
+      "stderr": "",
+      "stdout": "06\nrc=0\n"
+    },
+    {
+      "content_hash": "e2241c81bb5421e5",
+      "exit_code": 0,
+      "name": "date matrix: directive %m (am)",
+      "stderr": "",
+      "stdout": "06\nrc=0\n"
+    },
+    {
+      "content_hash": "c3ec8615e5a118d0",
+      "exit_code": 0,
+      "name": "date matrix: directive %M (pm)",
+      "stderr": "",
+      "stdout": "30\nrc=0\n"
+    },
+    {
+      "content_hash": "0767e07ab78c1866",
+      "exit_code": 0,
+      "name": "date matrix: directive %M (am)",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "719c85d03b940f5e",
+      "exit_code": 0,
+      "name": "date matrix: directive %n (pm)",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "dff7a0b251ec631b",
+      "exit_code": 0,
+      "name": "date matrix: directive %n (am)",
+      "stderr": "",
+      "stdout": "\n\nrc=0\n"
+    },
+    {
+      "content_hash": "a3a907a330f4067e",
+      "exit_code": 0,
+      "name": "date matrix: directive %N (pm)",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "3eae86bc7a2e37d4",
+      "exit_code": 0,
+      "name": "date matrix: directive %N (am)",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "79424f8605970eb7",
+      "exit_code": 0,
+      "name": "date matrix: directive %p (pm)",
+      "stderr": "",
+      "stdout": "PM\nrc=0\n"
+    },
+    {
+      "content_hash": "c9463befa11f6f38",
+      "exit_code": 0,
+      "name": "date matrix: directive %p (am)",
+      "stderr": "",
+      "stdout": "AM\nrc=0\n"
+    },
+    {
+      "content_hash": "71ad8effb369c9c1",
+      "exit_code": 0,
+      "name": "date matrix: directive %P (pm)",
+      "stderr": "",
+      "stdout": "pm\nrc=0\n"
+    },
+    {
+      "content_hash": "6b6b3a6c5184cdb3",
+      "exit_code": 0,
+      "name": "date matrix: directive %P (am)",
+      "stderr": "",
+      "stdout": "am\nrc=0\n"
+    },
+    {
+      "content_hash": "791f14466df2dfba",
+      "exit_code": 0,
+      "name": "date matrix: directive %q (pm)",
+      "stderr": "",
+      "stdout": "2\nrc=0\n"
+    },
+    {
+      "content_hash": "07898ee3cfe3a06b",
+      "exit_code": 0,
+      "name": "date matrix: directive %q (am)",
+      "stderr": "",
+      "stdout": "2\nrc=0\n"
+    },
+    {
+      "content_hash": "e6ef1b48a0f443a7",
+      "exit_code": 0,
+      "name": "date matrix: directive %r (pm)",
+      "stderr": "",
+      "stdout": "01:30:00 PM\nrc=0\n"
+    },
+    {
+      "content_hash": "9ba578beaeb9caaa",
+      "exit_code": 0,
+      "name": "date matrix: directive %r (am)",
+      "stderr": "",
+      "stdout": "09:05:03 AM\nrc=0\n"
+    },
+    {
+      "content_hash": "cc32452e4893127c",
+      "exit_code": 0,
+      "name": "date matrix: directive %R (pm)",
+      "stderr": "",
+      "stdout": "13:30\nrc=0\n"
+    },
+    {
+      "content_hash": "5ac22ccbc33a7714",
+      "exit_code": 0,
+      "name": "date matrix: directive %R (am)",
+      "stderr": "",
+      "stdout": "09:05\nrc=0\n"
+    },
+    {
+      "content_hash": "271379063d131a1b",
+      "exit_code": 0,
+      "name": "date matrix: directive %s (pm)",
+      "stderr": "",
+      "stdout": "1718458200\nrc=0\n"
+    },
+    {
+      "content_hash": "e219273c7021b090",
+      "exit_code": 0,
+      "name": "date matrix: directive %s (am)",
+      "stderr": "",
+      "stdout": "1717578303\nrc=0\n"
+    },
+    {
+      "content_hash": "e1da279f3096227e",
+      "exit_code": 0,
+      "name": "date matrix: directive %S (pm)",
+      "stderr": "",
+      "stdout": "00\nrc=0\n"
+    },
+    {
+      "content_hash": "ad0169d4ceaa89e7",
+      "exit_code": 0,
+      "name": "date matrix: directive %S (am)",
+      "stderr": "",
+      "stdout": "03\nrc=0\n"
+    },
+    {
+      "content_hash": "fc362ca8a86a8cb2",
+      "exit_code": 0,
+      "name": "date matrix: directive %t (pm)",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "5a2df75753a2fbcd",
+      "exit_code": 0,
+      "name": "date matrix: directive %t (am)",
+      "stderr": "",
+      "stdout": "\t\nrc=0\n"
+    },
+    {
+      "content_hash": "b56ecdd6fca6eed8",
+      "exit_code": 0,
+      "name": "date matrix: directive %T (pm)",
+      "stderr": "",
+      "stdout": "13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "0bd0bfc60fe97ab3",
+      "exit_code": 0,
+      "name": "date matrix: directive %T (am)",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "3675bace1c8ec962",
+      "exit_code": 0,
+      "name": "date matrix: directive %u (pm)",
+      "stderr": "",
+      "stdout": "6\nrc=0\n"
+    },
+    {
+      "content_hash": "1b1e5222a3b78309",
+      "exit_code": 0,
+      "name": "date matrix: directive %u (am)",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "e58e8b6022b29444",
+      "exit_code": 0,
+      "name": "date matrix: directive %U (pm)",
+      "stderr": "",
+      "stdout": "23\nrc=0\n"
+    },
+    {
+      "content_hash": "9951f88ca197b753",
+      "exit_code": 0,
+      "name": "date matrix: directive %U (am)",
+      "stderr": "",
+      "stdout": "22\nrc=0\n"
+    },
+    {
+      "content_hash": "826a2a38c18df58d",
+      "exit_code": 0,
+      "name": "date matrix: directive %V (pm)",
+      "stderr": "",
+      "stdout": "24\nrc=0\n"
+    },
+    {
+      "content_hash": "7b98ed3a2a17a83a",
+      "exit_code": 0,
+      "name": "date matrix: directive %V (am)",
+      "stderr": "",
+      "stdout": "23\nrc=0\n"
+    },
+    {
+      "content_hash": "2ca3916a701a047a",
+      "exit_code": 0,
+      "name": "date matrix: directive %w (pm)",
+      "stderr": "",
+      "stdout": "6\nrc=0\n"
+    },
+    {
+      "content_hash": "d4c53a88b8e7a6ba",
+      "exit_code": 0,
+      "name": "date matrix: directive %w (am)",
+      "stderr": "",
+      "stdout": "3\nrc=0\n"
+    },
+    {
+      "content_hash": "75a718845d827205",
+      "exit_code": 0,
+      "name": "date matrix: directive %W (pm)",
+      "stderr": "",
+      "stdout": "24\nrc=0\n"
+    },
+    {
+      "content_hash": "a878077f0a57eb7d",
+      "exit_code": 0,
+      "name": "date matrix: directive %W (am)",
+      "stderr": "",
+      "stdout": "23\nrc=0\n"
+    },
+    {
+      "content_hash": "5954a7be901a6c4c",
+      "exit_code": 0,
+      "name": "date matrix: directive %x (pm)",
+      "stderr": "",
+      "stdout": "06/15/24\nrc=0\n"
+    },
+    {
+      "content_hash": "8f9b16c5f1080215",
+      "exit_code": 0,
+      "name": "date matrix: directive %x (am)",
+      "stderr": "",
+      "stdout": "06/05/24\nrc=0\n"
+    },
+    {
+      "content_hash": "152b36fbeb49a36f",
+      "exit_code": 0,
+      "name": "date matrix: directive %X (pm)",
+      "stderr": "",
+      "stdout": "13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "f43c67c955e7269a",
+      "exit_code": 0,
+      "name": "date matrix: directive %X (am)",
+      "stderr": "",
+      "stdout": "09:05:03\nrc=0\n"
+    },
+    {
+      "content_hash": "08afc71636bf9f82",
+      "exit_code": 0,
+      "name": "date matrix: directive %y (pm)",
+      "stderr": "",
+      "stdout": "24\nrc=0\n"
+    },
+    {
+      "content_hash": "8e3fe28f48e3d777",
+      "exit_code": 0,
+      "name": "date matrix: directive %y (am)",
+      "stderr": "",
+      "stdout": "24\nrc=0\n"
+    },
+    {
+      "content_hash": "229b0f4f8cc45377",
+      "exit_code": 0,
+      "name": "date matrix: directive %Y (pm)",
+      "stderr": "",
+      "stdout": "2024\nrc=0\n"
+    },
+    {
+      "content_hash": "5f3de776c7224721",
+      "exit_code": 0,
+      "name": "date matrix: directive %Y (am)",
+      "stderr": "",
+      "stdout": "2024\nrc=0\n"
+    },
+    {
+      "content_hash": "5afc4f2c3e44ff0e",
+      "exit_code": 0,
+      "name": "date matrix: directive %z (pm)",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "3d5e0f401a55e41e",
+      "exit_code": 0,
+      "name": "date matrix: directive %z (am)",
+      "stderr": "",
+      "stdout": "+0000\nrc=0\n"
+    },
+    {
+      "content_hash": "9dd7a235eb4e5d94",
+      "exit_code": 0,
+      "name": "date matrix: directive %Z (pm)",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "dace2b94dc0a864c",
+      "exit_code": 0,
+      "name": "date matrix: directive %Z (am)",
+      "stderr": "",
+      "stdout": "UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "f3240fae37076edc",
+      "exit_code": 0,
+      "name": "date matrix: modifier %:z (pm)",
+      "stderr": "",
+      "stdout": "+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "6933c63c2d5f4a12",
+      "exit_code": 0,
+      "name": "date matrix: modifier %:z (am)",
+      "stderr": "",
+      "stdout": "+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "ed6b7ad13ec47e70",
+      "exit_code": 0,
+      "name": "date matrix: modifier %::z (pm)",
+      "stderr": "",
+      "stdout": "+00:00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "b2b0f809d217affc",
+      "exit_code": 0,
+      "name": "date matrix: modifier %::z (am)",
+      "stderr": "",
+      "stdout": "+00:00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "075e142ce0fa9942",
+      "exit_code": 0,
+      "name": "date matrix: modifier %:::z (pm)",
+      "stderr": "",
+      "stdout": "+00\nrc=0\n"
+    },
+    {
+      "content_hash": "5849420cd1bf91a7",
+      "exit_code": 0,
+      "name": "date matrix: modifier %:::z (am)",
+      "stderr": "",
+      "stdout": "+00\nrc=0\n"
+    },
+    {
+      "content_hash": "7cd1652285503484",
+      "exit_code": 0,
+      "name": "date matrix: modifier %-d (pm)",
+      "stderr": "",
+      "stdout": "15\nrc=0\n"
+    },
+    {
+      "content_hash": "91179ae7c00a3af6",
+      "exit_code": 0,
+      "name": "date matrix: modifier %-d (am)",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "f89ee1d2976a8689",
+      "exit_code": 0,
+      "name": "date matrix: modifier %_d (pm)",
+      "stderr": "",
+      "stdout": "15\nrc=0\n"
+    },
+    {
+      "content_hash": "0fb029c7e0add102",
+      "exit_code": 0,
+      "name": "date matrix: modifier %_d (am)",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "c4dda1e428c67866",
+      "exit_code": 0,
+      "name": "date matrix: modifier %0d (pm)",
+      "stderr": "",
+      "stdout": "15\nrc=0\n"
+    },
+    {
+      "content_hash": "94346ff6dfbe13e0",
+      "exit_code": 0,
+      "name": "date matrix: modifier %0d (am)",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "5a6fe0fcac6631f1",
+      "exit_code": 0,
+      "name": "date matrix: modifier %^a (pm)",
+      "stderr": "",
+      "stdout": "SAT\nrc=0\n"
+    },
+    {
+      "content_hash": "56690bb18e265c4a",
+      "exit_code": 0,
+      "name": "date matrix: modifier %^a (am)",
+      "stderr": "",
+      "stdout": "WED\nrc=0\n"
+    },
+    {
+      "content_hash": "e693440e54e2530e",
+      "exit_code": 0,
+      "name": "date matrix: modifier %#a (pm)",
+      "stderr": "",
+      "stdout": "SAT\nrc=0\n"
+    },
+    {
+      "content_hash": "c4829e5b13f00357",
+      "exit_code": 0,
+      "name": "date matrix: modifier %#a (am)",
+      "stderr": "",
+      "stdout": "WED\nrc=0\n"
+    },
+    {
+      "content_hash": "48edbdf07a846391",
+      "exit_code": 0,
+      "name": "date matrix: sequence %%F",
+      "stderr": "",
+      "stdout": "%F\nrc=0\n"
+    },
+    {
+      "content_hash": "c9013071fb71b575",
+      "exit_code": 0,
+      "name": "date matrix: sequence %%%F",
+      "stderr": "",
+      "stdout": "%2024-06-15\nrc=0\n"
+    },
+    {
+      "content_hash": "c69bcf0d89af124a",
+      "exit_code": 0,
+      "name": "date matrix: sequence %F%T",
+      "stderr": "",
+      "stdout": "2024-06-1513:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "4ddbd4f98603f2ab",
+      "exit_code": 0,
+      "name": "date matrix: sequence %Y%m%d",
+      "stderr": "",
+      "stdout": "20240615\nrc=0\n"
+    },
+    {
+      "content_hash": "abdf09331b00ebe6",
+      "exit_code": 0,
+      "name": "date matrix: sequence %%",
+      "stderr": "",
+      "stdout": "%\nrc=0\n"
+    },
+    {
+      "content_hash": "fd5a9115d88d4190",
+      "exit_code": 0,
+      "name": "date matrix: sequence %%%%",
+      "stderr": "",
+      "stdout": "%%\nrc=0\n"
+    },
+    {
+      "content_hash": "42cffd71070ce1e1",
+      "exit_code": 0,
+      "name": "date matrix: sequence %",
+      "stderr": "",
+      "stdout": "%\nrc=0\n"
+    },
+    {
+      "content_hash": "002f9b3c53113712",
+      "exit_code": 0,
+      "name": "date matrix: sequence %F%",
+      "stderr": "",
+      "stdout": "2024-06-15%\nrc=0\n"
+    },
+    {
+      "content_hash": "397f45f11970880b",
+      "exit_code": 0,
+      "name": "date matrix: sequence %J",
+      "stderr": "",
+      "stdout": "%J\nrc=0\n"
+    },
+    {
+      "content_hash": "a543f6a69bf87053",
+      "exit_code": 0,
+      "name": "date matrix: sequence %%J",
+      "stderr": "",
+      "stdout": "%J\nrc=0\n"
+    },
+    {
+      "content_hash": "f77f349300cbffd1",
+      "exit_code": 0,
+      "name": "date matrix: sequence %F%J%T",
+      "stderr": "",
+      "stdout": "2024-06-15%J13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "4c65d6e69f93fba9",
+      "exit_code": 0,
+      "name": "date matrix: sequence %#%!",
+      "stderr": "",
+      "stdout": "%#%!\nrc=0\n"
+    },
+    {
+      "content_hash": "15c5ec781c0d815b",
+      "exit_code": 0,
+      "name": "date matrix: sequence %-%d",
+      "stderr": "",
+      "stdout": "%-15\nrc=0\n"
+    },
+    {
+      "content_hash": "cbf3a17d2580c73b",
+      "exit_code": 0,
+      "name": "date matrix: sequence %#%%",
+      "stderr": "",
+      "stdout": "%#%\nrc=0\n"
+    },
+    {
+      "content_hash": "0e29e7b180781137",
+      "exit_code": 0,
+      "name": "date matrix: sequence %--d",
+      "stderr": "",
+      "stdout": "15\nrc=0\n"
+    },
+    {
+      "content_hash": "942bd10ef2ec1c13",
+      "exit_code": 0,
+      "name": "date matrix: sequence %0-d",
+      "stderr": "",
+      "stdout": "15\nrc=0\n"
+    },
+    {
+      "content_hash": "9e580938236787c7",
+      "exit_code": 0,
+      "name": "date matrix: sequence %^%a",
+      "stderr": "",
+      "stdout": "%^Sat\nrc=0\n"
+    },
+    {
+      "content_hash": "c34887335e1a489e",
+      "exit_code": 0,
+      "name": "date matrix: sequence %#",
+      "stderr": "",
+      "stdout": "%#\nrc=0\n"
+    },
+    {
+      "content_hash": "7cae49cca129dabc",
+      "exit_code": 0,
+      "name": "date matrix: sequence %-",
+      "stderr": "",
+      "stdout": "%-\nrc=0\n"
+    },
+    {
+      "content_hash": "07448cba5cb51935",
+      "exit_code": 0,
+      "name": "date matrix: sequence %_",
+      "stderr": "",
+      "stdout": "%_\nrc=0\n"
+    },
+    {
+      "content_hash": "fb74626e515523a9",
+      "exit_code": 0,
+      "name": "date matrix: sequence %0",
+      "stderr": "",
+      "stdout": "%0\nrc=0\n"
+    },
+    {
+      "content_hash": "46c200f56a5d2098",
+      "exit_code": 0,
+      "name": "date matrix: sequence %^",
+      "stderr": "",
+      "stdout": "%^\nrc=0\n"
+    },
+    {
+      "content_hash": "ccff5030b14bab86",
+      "exit_code": 0,
+      "name": "date matrix: sequence %^!",
+      "stderr": "",
+      "stdout": "%^!\nrc=0\n"
+    },
+    {
+      "content_hash": "b5d066f089dbf4aa",
+      "exit_code": 0,
+      "name": "date matrix: width %3d",
+      "stderr": "",
+      "stdout": "005\nrc=0\n"
+    },
+    {
+      "content_hash": "4b3428a2d17eab55",
+      "exit_code": 0,
+      "name": "date matrix: width %03d",
+      "stderr": "",
+      "stdout": "005\nrc=0\n"
+    },
+    {
+      "content_hash": "796c4afea8a20282",
+      "exit_code": 0,
+      "name": "date matrix: width %_3d",
+      "stderr": "",
+      "stdout": "  5\nrc=0\n"
+    },
+    {
+      "content_hash": "4f1e4eff6077d5cb",
+      "exit_code": 0,
+      "name": "date matrix: width %-3d",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "18a98b4727e1de45",
+      "exit_code": 0,
+      "name": "date matrix: width %_10d",
+      "stderr": "",
+      "stdout": "         5\nrc=0\n"
+    },
+    {
+      "content_hash": "992f6e762d513467",
+      "exit_code": 0,
+      "name": "date matrix: width %^3a",
+      "stderr": "",
+      "stdout": "WED\nrc=0\n"
+    },
+    {
+      "content_hash": "0aea9aaafcf3c704",
+      "exit_code": 0,
+      "name": "date matrix: width %-0d",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "2ba86bfc2bec7580",
+      "exit_code": 0,
+      "name": "date matrix: width %0_d",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "01d474ef0f50a4b6",
+      "exit_code": 0,
+      "name": "date matrix: width %_2H",
+      "stderr": "",
+      "stdout": " 9\nrc=0\n"
+    },
+    {
+      "content_hash": "0e4b24f19f3e863d",
+      "exit_code": 0,
+      "name": "date matrix: width %_3H",
+      "stderr": "",
+      "stdout": "  9\nrc=0\n"
+    },
+    {
+      "content_hash": "91179ae7c00a3af6",
+      "exit_code": 0,
+      "name": "date matrix: width %-d",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "a738e8a06de22838",
+      "exit_code": 0,
+      "name": "date matrix: width %-H",
+      "stderr": "",
+      "stdout": "9\nrc=0\n"
+    },
+    {
+      "content_hash": "c63003a9b4ecfa83",
+      "exit_code": 0,
+      "name": "date matrix: width %-M",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "d48bfaf8b016c0a9",
+      "exit_code": 0,
+      "name": "date matrix: width %-e",
+      "stderr": "",
+      "stdout": "5\nrc=0\n"
+    },
+    {
+      "content_hash": "c3062753465650c5",
+      "exit_code": 0,
+      "name": "date matrix: width %_e",
+      "stderr": "",
+      "stdout": " 5\nrc=0\n"
+    },
+    {
+      "content_hash": "44ea476b5fb31d31",
+      "exit_code": 0,
+      "name": "date matrix: width %0e",
+      "stderr": "",
+      "stdout": "05\nrc=0\n"
+    },
+    {
+      "content_hash": "4d0391419efaee45",
+      "exit_code": 0,
+      "name": "date matrix: width %-I",
+      "stderr": "",
+      "stdout": "9\nrc=0\n"
+    },
+    {
+      "content_hash": "ba54a2f29b2c6048",
+      "exit_code": 0,
+      "name": "date matrix: width %-j",
+      "stderr": "",
+      "stdout": "157\nrc=0\n"
+    },
+    {
+      "content_hash": "3eae86bc7a2e37d4",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "4ed5c032daf57339",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %-N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "ddd7406e16565600",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %0N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "c571c2da89e6886e",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %^N",
+      "stderr": "",
+      "stdout": "000000000\nrc=0\n"
+    },
+    {
+      "content_hash": "75c7156a1bf629a7",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %3N",
+      "stderr": "",
+      "stdout": "000\nrc=0\n"
+    },
+    {
+      "content_hash": "513512382567a1d8",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %6N",
+      "stderr": "",
+      "stdout": "000000\nrc=0\n"
+    },
+    {
+      "content_hash": "1e836116dc5c3c11",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %_N",
+      "stderr": "",
+      "stdout": "0        \nrc=0\n"
+    },
+    {
+      "content_hash": "0514b760a2820297",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %-3N",
+      "stderr": "",
+      "stdout": "0\nrc=0\n"
+    },
+    {
+      "content_hash": "fc387fb480e5d687",
+      "exit_code": 0,
+      "name": "date matrix: nanoseconds %_6N",
+      "stderr": "",
+      "stdout": "0     \nrc=0\n"
+    },
+    {
+      "content_hash": "c6678c35339e5c11",
+      "exit_code": 0,
+      "name": "date matrix: iso -I",
+      "stderr": "",
+      "stdout": "2024-06-15\nrc=0\n"
+    },
+    {
+      "content_hash": "7a7f5d0b21ac6a77",
+      "exit_code": 0,
+      "name": "date matrix: iso -Idate",
+      "stderr": "",
+      "stdout": "2024-06-15\nrc=0\n"
+    },
+    {
+      "content_hash": "635ff93ef2156c55",
+      "exit_code": 0,
+      "name": "date matrix: iso -Ihours",
+      "stderr": "",
+      "stdout": "2024-06-15T13+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "459b35fb1d9b8b0c",
+      "exit_code": 0,
+      "name": "date matrix: iso -Iminutes",
+      "stderr": "",
+      "stdout": "2024-06-15T13:30+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "7c0227ca707c26b2",
+      "exit_code": 0,
+      "name": "date matrix: iso -Iseconds",
+      "stderr": "",
+      "stdout": "2024-06-15T13:30:00+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "840b099ca0fabb34",
+      "exit_code": 0,
+      "name": "date matrix: iso -Ins",
+      "stderr": "",
+      "stdout": "2024-06-15T13:30:00,000000000+00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "4f11cc12be3bc172",
+      "exit_code": 0,
+      "name": "date matrix: iso --iso-8601=date",
+      "stderr": "",
+      "stdout": "2024-06-15\nrc=0\n"
+    },
+    {
+      "content_hash": "c84169ea50e52d6a",
+      "exit_code": 0,
+      "name": "date matrix: absent flag -v+6m",
+      "stderr": "date: invalid option -- 'v'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "abb8f913c622f810",
+      "exit_code": 0,
+      "name": "date matrix: absent flag -v +6m",
+      "stderr": "date: invalid option -- 'v'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "664b17e37dd38307",
+      "exit_code": 0,
+      "name": "date matrix: absent flag -v-1d",
+      "stderr": "date: invalid option -- 'v'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "3424b4761e50bb0b",
+      "exit_code": 0,
+      "name": "date matrix: absent flag -j",
+      "stderr": "date: invalid option -- 'j'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "af848d1644742c50",
+      "exit_code": 0,
+      "name": "date matrix: absent flag -jf %Y",
+      "stderr": "date: invalid option -- 'j'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "71fe849c4622447d",
+      "exit_code": 0,
+      "name": "date matrix: absent flag --not-a-flag",
+      "stderr": "date: unrecognized option '--not-a-flag'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "3b45b455bd05a440",
+      "exit_code": 0,
+      "name": "date matrix: absent flag -Z",
+      "stderr": "date: invalid option -- 'Z'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6d4acdf0797b483c",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15",
+      "stderr": "",
+      "stdout": "2024-06-15 00:00:00\nrc=0\n"
+    },
+    {
+      "content_hash": "5f093291eb930c27",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00",
+      "stderr": "",
+      "stdout": "2024-06-15 13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "4756938c087e2646",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15T13:30:00",
+      "stderr": "",
+      "stdout": "2024-06-15 13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "7678424c6ef68df8",
+      "exit_code": 0,
+      "name": "date matrix: input @1718458200",
+      "stderr": "",
+      "stdout": "2024-06-15 13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "7d29779998b12451",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00 +1 day",
+      "stderr": "",
+      "stdout": "2024-06-16 12:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "ea28149f995dc2e0",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00 1 day ago",
+      "stderr": "",
+      "stdout": "2024-06-14 13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "5f8d8bfedf84679e",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00 +6 months",
+      "stderr": "",
+      "stdout": "2024-07-15 07:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "cedb8e27b704590a",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00 6 months ago",
+      "stderr": "",
+      "stdout": "2023-12-15 13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "d63f27de2f944ae9",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00 next tuesday",
+      "stderr": "",
+      "stdout": "2024-06-15 13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "e2d87faf59d17708",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00 last monday",
+      "stderr": "",
+      "stdout": "2024-06-15 13:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "56e4575071228587",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00 +2 weeks",
+      "stderr": "",
+      "stdout": "2024-06-22 11:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "d2003f3c147e0007",
+      "exit_code": 0,
+      "name": "date matrix: input 2024-06-15 13:30:00 -3 hours",
+      "stderr": "",
+      "stdout": "2024-06-15 17:30:00\nrc=0\n"
+    },
+    {
+      "content_hash": "078461a27e682c98",
+      "exit_code": 0,
+      "name": "date matrix: utc flag -u",
+      "stderr": "",
+      "stdout": "2024-06-15 13:30:00 UTC\nrc=0\n"
+    },
+    {
+      "content_hash": "c2adae4be1a7309e",
+      "exit_code": 0,
+      "name": "date matrix: rfc flag -R",
+      "stderr": "",
+      "stdout": "Sat, 15 Jun 2024 13:30:00 +0000\nrc=0\n"
+    },
+    {
+      "content_hash": "0cae21027fa38e87",
+      "exit_code": 0,
+      "name": "date matrix: reads -f from a file",
+      "stderr": "",
+      "stdout": "2024-06-15\nrc=0\n"
+    }
+  ],
+  "suite": "date_matrix"
+}

--- a/test/fixtures/bash_expected/head_tail.json
+++ b/test/fixtures/bash_expected/head_tail.json
@@ -36,84 +36,84 @@
       "stdout": "3\n4\n5\n"
     },
     {
-      "content_hash": "a5922d6daf8dda41",
+      "content_hash": "91499b571209b0d1",
       "exit_code": 0,
       "name": "head -c byte mode: first 5 bytes",
       "stderr": "",
       "stdout": "Hello"
     },
     {
-      "content_hash": "f2cc07f2b479ff77",
+      "content_hash": "864eae7f738f5a1a",
       "exit_code": 0,
       "name": "head -c byte mode: from stdin pipe",
       "stderr": "",
       "stdout": "abc"
     },
     {
-      "content_hash": "74f4ff0916d80285",
+      "content_hash": "b64a0ce933b5357d",
       "exit_code": 0,
       "name": "head -c byte mode: N larger than input",
       "stderr": "",
       "stdout": "short"
     },
     {
-      "content_hash": "c239fa665b670645",
+      "content_hash": "74a2f8e4e4bf61bf",
       "exit_code": 0,
       "name": "head -c byte mode: zero bytes",
       "stderr": "",
       "stdout": ""
     },
     {
-      "content_hash": "a9cfeb0cd1dbaa26",
+      "content_hash": "55ed0f84f48dbb88",
       "exit_code": 0,
       "name": "head -c byte mode: empty input",
       "stderr": "",
       "stdout": ""
     },
     {
-      "content_hash": "c6d52634160a6c13",
+      "content_hash": "c0d83bd31ca4eb0f",
       "exit_code": 0,
       "name": "head -c byte mode: includes newlines",
       "stderr": "",
       "stdout": "line1\nli"
     },
     {
-      "content_hash": "ac6c29f2e051b845",
+      "content_hash": "8a706bb6d3f01cdd",
       "exit_code": 0,
       "name": "tail -c byte mode: last 7 bytes",
       "stderr": "",
       "stdout": "World!"
     },
     {
-      "content_hash": "cd8e1303f084b24b",
+      "content_hash": "4640623236d21a01",
       "exit_code": 0,
       "name": "tail -c byte mode: from stdin pipe",
       "stderr": "",
       "stdout": "ghij"
     },
     {
-      "content_hash": "5b4394666e2e4a52",
+      "content_hash": "8d99f00253524e93",
       "exit_code": 0,
       "name": "tail -c byte mode: N larger than input",
       "stderr": "",
       "stdout": "short"
     },
     {
-      "content_hash": "19681666c21ef715",
+      "content_hash": "686e4902cab2250d",
       "exit_code": 0,
       "name": "tail -c byte mode: zero bytes",
       "stderr": "",
       "stdout": ""
     },
     {
-      "content_hash": "575c18be3c2725b7",
+      "content_hash": "cab1715d6c17e313",
       "exit_code": 0,
       "name": "tail -c byte mode: empty input",
       "stderr": "",
       "stdout": ""
     },
     {
-      "content_hash": "d0ef8df077e5a212",
+      "content_hash": "5a6082eb5e3b82ac",
       "exit_code": 0,
       "name": "tail -c byte mode: includes newlines",
       "stderr": "",

--- a/test/fixtures/bash_expected/mv.json
+++ b/test/fixtures/bash_expected/mv.json
@@ -50,14 +50,14 @@
       "stdout": "rc=1\nC\n"
     },
     {
-      "content_hash": "62b26859204b5de7",
+      "content_hash": "561d53b939dce772",
       "exit_code": 0,
       "name": "mv comparison: refuses to move into a symlink pointing at itself",
       "stderr": "mv: cannot move 'a' to a subdirectory of itself, 'l/a'\n",
       "stdout": "rc=1\nF\n"
     },
     {
-      "content_hash": "849325d826f72e28",
+      "content_hash": "8d1741056805202f",
       "exit_code": 0,
       "name": "mv comparison: refuses to move beneath a symlink pointing at itself",
       "stderr": "mv: cannot move 'a' to a subdirectory of itself, 'l/x'\n",

--- a/test/fixtures/bash_expected/real_world.json
+++ b/test/fixtures/bash_expected/real_world.json
@@ -1,203 +1,203 @@
 {
   "results": [
     {
-      "content_hash": "eaacb08dc037c211",
+      "content_hash": "74c95df538c61f82",
       "exit_code": 0,
       "name": "one-liner: head -c to extract prefix",
       "stderr": "",
       "stdout": "abcdefgh"
     },
     {
-      "content_hash": "083347a2abd71572",
+      "content_hash": "b76e1721be41059e",
       "exit_code": 0,
       "name": "one-liner: wc -l on pipeline",
       "stderr": "",
       "stdout": "4\n"
     },
     {
-      "content_hash": "9d86b75c746af369",
+      "content_hash": "34b82bad77c9c42c",
       "exit_code": 0,
       "name": "one-liner: sort | uniq -c pattern",
       "stderr": "",
       "stdout": "      3 apple\n      2 banana\n      1 cherry\n"
     },
     {
-      "content_hash": "3b79f7af0f85c70c",
+      "content_hash": "020d5d322c0af014",
       "exit_code": 0,
       "name": "one-liner: grep -c count matches",
       "stderr": "",
       "stdout": "3\n"
     },
     {
-      "content_hash": "6eeff81a3301a492",
+      "content_hash": "f756a39f8eb28890",
       "exit_code": 0,
       "name": "one-liner: awk field extraction",
       "stderr": "",
       "stdout": "alice\nbob\ncharlie\n"
     },
     {
-      "content_hash": "c5ba448c28900215",
+      "content_hash": "a81b22adba9e637f",
       "exit_code": 0,
       "name": "one-liner: tr squeeze whitespace",
       "stderr": "",
       "stdout": "hello world foo\n"
     },
     {
-      "content_hash": "2970dfa9a50ddb14",
+      "content_hash": "3ad319a4311151ec",
       "exit_code": 0,
       "name": "one-liner: cut -d and paste -d",
       "stderr": "",
       "stdout": "1\n2\n3\n"
     },
     {
-      "content_hash": "349023f7ed641054",
+      "content_hash": "c7e52bee6d3dbb72",
       "exit_code": 0,
       "name": "one-liner: xargs -I replacement",
       "stderr": "",
       "stdout": "item: one\nitem: two\nitem: three\n"
     },
     {
-      "content_hash": "c628dcdbe4252c5f",
+      "content_hash": "05cc878852343c79",
       "exit_code": 0,
       "name": "one-liner: subshell variable isolation",
       "stderr": "",
       "stdout": "inner\nouter\n"
     },
     {
-      "content_hash": "d14924a4f4853e17",
+      "content_hash": "e6c7ee4dc4861f7a",
       "exit_code": 0,
       "name": "one-liner: while read loop with IFS",
       "stderr": "",
       "stdout": "a=1\nb=2\nc=3\n"
     },
     {
-      "content_hash": "cddacda6f0b7191b",
+      "content_hash": "d11d335828ec5695",
       "exit_code": 0,
       "name": "one-liner: printf format string",
       "stderr": "",
       "stdout": "alice         30\nbob           25\ncharlie       35\n"
     },
     {
-      "content_hash": "07110906f0b5c126",
+      "content_hash": "f76e1c4f3128ece7",
       "exit_code": 127,
       "name": "one-liner: seq into arithmetic",
       "stderr": "bash: line 1: bc: command not found\n",
       "stdout": ""
     },
     {
-      "content_hash": "6f0a7fdaffe87eeb",
+      "content_hash": "7044737c2b2abf72",
       "exit_code": 0,
       "name": "one-liner: nested pipelines",
       "stderr": "",
       "stdout": "8\n"
     },
     {
-      "content_hash": "47e28e1f2ab57443",
+      "content_hash": "770504a919dba521",
       "exit_code": 0,
       "name": "one-liner: sed and grep pipeline",
       "stderr": "",
       "stdout": "disk full\ntimeout\n"
     },
     {
-      "content_hash": "99756c361f26f918",
+      "content_hash": "fd6bbe23e5a96aaf",
       "exit_code": 0,
       "name": "one-liner: awk sum column",
       "stderr": "",
       "stdout": "100\n"
     },
     {
-      "content_hash": "00e6d02eceb4529d",
+      "content_hash": "0ff17388743835b3",
       "exit_code": 0,
       "name": "one-liner: head and tail to extract middle",
       "stderr": "",
       "stdout": "5\n6\n7\n"
     },
     {
-      "content_hash": "1f5fd4c459e3af9a",
+      "content_hash": "269f1d6add4855cb",
       "exit_code": 0,
       "name": "one-liner: cat - for stdin in pipeline",
       "stderr": "",
       "stdout": "hello\n"
     },
     {
-      "content_hash": "9cbf6b06d4af11ae",
+      "content_hash": "8264f067ed2932a1",
       "exit_code": 0,
       "name": "one-liner: rev and cut for last field",
       "stderr": "",
       "stdout": "file.txt\n"
     },
     {
-      "content_hash": "803f68986f94d7ee",
+      "content_hash": "f08df403cb4ddb04",
       "exit_code": 0,
       "name": "one-liner: tr delete characters",
       "stderr": "",
       "stdout": "Hello World \n"
     },
     {
-      "content_hash": "1d1e66fd89e6a570",
+      "content_hash": "b24b8385f42442a7",
       "exit_code": 0,
       "name": "one-liner: sort -t -k field sort",
       "stderr": "",
       "stdout": "a:1\nb:2\nc:3\n"
     },
     {
-      "content_hash": "df28220700b4bc69",
+      "content_hash": "04f7363563dc3773",
       "exit_code": 0,
       "name": "one-liner: command substitution in echo",
       "stderr": "",
       "stdout": "there are 3 lines\n"
     },
     {
-      "content_hash": "a4602a1af2bbb56d",
+      "content_hash": "194005786bf4019d",
       "exit_code": 0,
       "name": "one-liner: tail -c byte mode",
       "stderr": "",
       "stdout": "fghij"
     },
     {
-      "content_hash": "4a9f5f03127723c0",
+      "content_hash": "bbb282486f87cb03",
       "exit_code": 0,
       "name": "one-liner: multiple pipes with wc -lw",
       "stderr": "",
       "stdout": "      2       5\n"
     },
     {
-      "content_hash": "3419f4248a3df601",
+      "content_hash": "edc40e3dbaf083d5",
       "exit_code": 0,
       "name": "one-liner: for loop with seq",
       "stderr": "",
       "stdout": "num:1\nnum:2\nnum:3\nnum:4\nnum:5\n"
     },
     {
-      "content_hash": "0fdc8b2425e0deb0",
+      "content_hash": "da8c5d5aaa389136",
       "exit_code": 0,
       "name": "one-liner: grep -v | sort -u dedup",
       "stderr": "",
       "stdout": "apple\nbanana\ncherry\n"
     },
     {
-      "content_hash": "efebc32e5cab5fe2",
+      "content_hash": "e868b1f67ac6c8c0",
       "exit_code": 0,
       "name": "one-liner: awk NR line numbers",
       "stderr": "",
       "stdout": "1: first\n2: second\n3: third\n"
     },
     {
-      "content_hash": "8dd4f831fccb49a1",
+      "content_hash": "c0abb65b0624a388",
       "exit_code": 0,
       "name": "one-liner: tr character translation",
       "stderr": "",
       "stdout": "HELLO WORLD\n"
     },
     {
-      "content_hash": "5baf2740972bb77c",
+      "content_hash": "116f4177d21289bd",
       "exit_code": 0,
       "name": "one-liner: head -c with wc -c to verify",
       "stderr": "",
       "stdout": "5\n"
     },
     {
-      "content_hash": "0a91498ee638b805",
+      "content_hash": "edef90d0772b5c0f",
       "exit_code": 0,
       "name": "one-liner: nested command substitution",
       "stderr": "",

--- a/test/fixtures/bash_expected/special_variables.json
+++ b/test/fixtures/bash_expected/special_variables.json
@@ -302,77 +302,77 @@
       "stdout": "a\n3\n"
     },
     {
-      "content_hash": "4e0be3d964a9dc35",
+      "content_hash": "f9a035703a612267",
       "exit_code": 0,
       "name": "special var trailing text: $# followed by literal",
       "stderr": "",
       "stdout": "0args\n"
     },
     {
-      "content_hash": "f93a4db1b75def55",
+      "content_hash": "195cbbd549607bd6",
       "exit_code": 0,
       "name": "special var trailing text: $? followed by literal",
       "stderr": "",
       "stdout": "0foo\n"
     },
     {
-      "content_hash": "4aa29b0ca8c839cd",
+      "content_hash": "e8696165992d6f4a",
       "exit_code": 0,
       "name": "special var trailing text: bare $ before space",
       "stderr": "",
       "stdout": "$ end\n"
     },
     {
-      "content_hash": "5764212ad8da2dc0",
+      "content_hash": "16d196e1707123d1",
       "exit_code": 0,
       "name": "special var trailing text: bare $ at end of word",
       "stderr": "",
       "stdout": "hello$\n"
     },
     {
-      "content_hash": "88c458d384d8eeb9",
+      "content_hash": "96145d8724412328",
       "exit_code": 0,
       "name": "special var trailing text: $# in double quotes with trailing",
       "stderr": "",
       "stdout": "0items\n"
     },
     {
-      "content_hash": "154514f76d1fabfb",
+      "content_hash": "934702a9133a94fe",
       "exit_code": 0,
       "name": "special var trailing text: $? in double quotes with trailing",
       "stderr": "",
       "stdout": "1code\n"
     },
     {
-      "content_hash": "0b5535321931d845",
+      "content_hash": "655c8da00a65c3a5",
       "exit_code": 0,
       "name": "special var trailing text: $# no args with text in function",
       "stderr": "",
       "stdout": "0done\n"
     },
     {
-      "content_hash": "c8adc8afdbeef2dc",
+      "content_hash": "722a5a2f6ebe8047",
       "exit_code": 0,
       "name": "special var trailing text: $# with args text in function",
       "stderr": "",
       "stdout": "3done\n"
     },
     {
-      "content_hash": "cbabebb75f046268",
+      "content_hash": "f66dc575dbdc263f",
       "exit_code": 0,
       "name": "special var trailing text: regular var consumes full identifier",
       "stderr": "",
       "stdout": "\n"
     },
     {
-      "content_hash": "65d19613148cb12e",
+      "content_hash": "9e706a143cd1c56f",
       "exit_code": 0,
       "name": "special var trailing text: regular var stopped by non-ident char",
       "stderr": "",
       "stdout": "hello/path\n"
     },
     {
-      "content_hash": "2a41edd942666616",
+      "content_hash": "07ca1720edf65304",
       "exit_code": 0,
       "name": "special var trailing text: $@ in function with trailing text",
       "stderr": "",

--- a/test/fixtures/bash_expected/wc.json
+++ b/test/fixtures/bash_expected/wc.json
@@ -148,28 +148,28 @@
       "stdout": "3\n"
     },
     {
-      "content_hash": "364ea40429bd538e",
+      "content_hash": "20074798e3e17a48",
       "exit_code": 0,
       "name": "wc combined flags: -lw lines and words",
       "stderr": "",
       "stdout": "      2       5\n"
     },
     {
-      "content_hash": "44438c7f2ced5b1b",
+      "content_hash": "b4d38a44930be149",
       "exit_code": 0,
       "name": "wc combined flags: -lc lines and bytes",
       "stderr": "",
       "stdout": "      1       6\n"
     },
     {
-      "content_hash": "7981339a5ac59b1e",
+      "content_hash": "4ca6748c61836f69",
       "exit_code": 0,
       "name": "wc combined flags: -lwc all three",
       "stderr": "",
       "stdout": "      2       3      14\n"
     },
     {
-      "content_hash": "e53de18540523d34",
+      "content_hash": "3782a58db4103e82",
       "exit_code": 0,
       "name": "wc combined flags: -wc words and bytes",
       "stderr": "",

--- a/test/just_bash/fixtures_test.exs
+++ b/test/just_bash/fixtures_test.exs
@@ -1,0 +1,218 @@
+defmodule JustBash.FixturesTest do
+  @moduledoc """
+  Locks down the fixture corpus content-addressing.
+
+  The digest is a compatibility surface, not an implementation detail: changing it
+  orphans all 968 recorded expectations at once. The first describe block pins the
+  recipe against values taken from the committed corpus, so an accidental change
+  to canonicalization fails here rather than as a wall of unexplained fixture
+  failures.
+  """
+
+  use ExUnit.Case, async: true
+
+  doctest JustBash.Fixtures
+
+  alias JustBash.Fixtures
+
+  describe "content_hash/2 recipe" do
+    test "reproduces hashes committed in the corpus" do
+      # Taken verbatim from test/fixtures/bash_cases/. If these change, every
+      # recorded expectation must be re-recorded — see Fixtures @hash_version.
+      assert Fixtures.content_hash("echo 'hello world' | wc") == "d34a7800e7f5b693"
+      assert Fixtures.content_hash("echo 'hello' | wc") == "722ef365ed6f83e7"
+    end
+
+    test "an absent files map hashes the same as an empty one" do
+      assert Fixtures.content_hash("echo hi") == Fixtures.content_hash("echo hi", %{})
+    end
+
+    test "distinct scripts hash differently" do
+      refute Fixtures.content_hash("echo a") == Fixtures.content_hash("echo b")
+    end
+
+    test "seeded files participate in the hash" do
+      refute Fixtures.content_hash("cat f", %{"f" => "a"}) ==
+               Fixtures.content_hash("cat f", %{"f" => "b"})
+    end
+
+    test "files key order does not affect the hash" do
+      # Map literals with the same pairs are equal, so build the two orders as
+      # lists to prove the encoder sorts rather than relying on iteration order.
+      forward = Enum.into([{"a", "1"}, {"b", "2"}], %{})
+      reverse = Enum.into([{"b", "2"}, {"a", "1"}], %{})
+
+      assert Fixtures.content_hash("cat", forward) == Fixtures.content_hash("cat", reverse)
+    end
+
+    test "non-ASCII is canonicalized as raw UTF-8, not escaped" do
+      # The corpus contains one non-ASCII case, and it pins this choice: an
+      # encoder that emitted \\uXXXX escapes would produce a different digest.
+      assert Fixtures.canonical("echo é", %{}) =~ "é"
+      refute Fixtures.canonical("echo é", %{}) =~ "u00e9"
+    end
+
+    test "is 16 lowercase hex characters" do
+      hash = Fixtures.content_hash("echo hi")
+
+      assert String.length(hash) == 16
+      assert hash =~ ~r/^[0-9a-f]{16}$/
+    end
+  end
+
+  describe "canonical/2" do
+    test "emits files before script, compactly" do
+      assert Fixtures.canonical("echo hi", %{}) == ~s({"files":{},"script":"echo hi"})
+    end
+
+    test "emits sorted, compact file entries" do
+      assert Fixtures.canonical("cat", %{"b" => "2", "a" => "1"}) ==
+               ~s({"files":{"a":"1","b":"2"},"script":"cat"})
+    end
+  end
+
+  describe "hash_case/1" do
+    test "tolerates an absent files key" do
+      assert Fixtures.hash_case(%{"script" => "echo hi"}) == Fixtures.content_hash("echo hi")
+    end
+
+    test "tolerates a null files value" do
+      assert Fixtures.hash_case(%{"script" => "echo hi", "files" => nil}) ==
+               Fixtures.content_hash("echo hi")
+    end
+
+    test "ignores fields that are not recording inputs" do
+      # Renaming a case, or widening what it tolerates, must not orphan a
+      # recording that is still byte-for-byte correct.
+      bare = %{"script" => "echo hi"}
+      decorated = Map.merge(bare, %{"name" => "renamed", "opts" => %{"ignore_stderr" => true}})
+
+      assert Fixtures.hash_case(bare) == Fixtures.hash_case(decorated)
+    end
+  end
+
+  describe "validate/2" do
+    setup do
+      test_case = %{"name" => "a case", "script" => "echo hi"}
+      %{case: Map.put(test_case, "content_hash", Fixtures.hash_case(test_case))}
+    end
+
+    test "a sound suite has no problems", %{case: test_case} do
+      recording = %{"content_hash" => test_case["content_hash"], "stdout" => "hi\n"}
+
+      assert Fixtures.validate([test_case], [recording]) == []
+    end
+
+    test "detects a hash left behind by an edited script", %{case: test_case} do
+      edited = %{test_case | "script" => "echo changed"}
+      recording = %{"content_hash" => test_case["content_hash"]}
+
+      problems = Fixtures.validate([edited], [recording])
+
+      assert [{:stale_hash, "a case", stored, computed}] =
+               Enum.filter(problems, &match?({:stale_hash, _, _, _}, &1))
+
+      assert stored == test_case["content_hash"]
+      assert computed == Fixtures.hash_case(edited)
+
+      # The recording the stale hash pointed at is now unclaimed. Both facts are
+      # reported: the edit is the cause, the orphan is the evidence.
+      assert {:orphan_recording, stored} in problems
+    end
+
+    test "detects an absent hash as stale", %{case: test_case} do
+      bare = Map.delete(test_case, "content_hash")
+
+      assert [{:stale_hash, "a case", nil, _computed}] = Fixtures.validate([bare], [])
+    end
+
+    test "detects a case with no recording", %{case: test_case} do
+      assert [{:missing_recording, "a case", hash}] = Fixtures.validate([test_case], [])
+      assert hash == test_case["content_hash"]
+    end
+
+    test "detects a recording no live case claims", %{case: test_case} do
+      recording = %{"content_hash" => test_case["content_hash"]}
+      orphan = %{"content_hash" => "0000000000000000"}
+
+      assert [{:orphan_recording, "0000000000000000"}] =
+               Fixtures.validate([test_case], [recording, orphan])
+    end
+
+    test "accepts two cases sharing a hash when their inputs are identical", %{case: test_case} do
+      # The corpus contains such a pair, differing only in name.
+      twin = %{test_case | "name" => "same script, different name"}
+      recording = %{"content_hash" => test_case["content_hash"]}
+
+      assert Fixtures.validate([test_case, twin], [recording]) == []
+    end
+
+    test "reports every problem rather than stopping at the first" do
+      stale = %{"name" => "stale", "script" => "echo a", "content_hash" => "dead000000000000"}
+      missing = %{"name" => "missing", "script" => "echo b"}
+      missing = Map.put(missing, "content_hash", Fixtures.hash_case(missing))
+
+      problems = Fixtures.validate([stale, missing], [])
+
+      assert length(problems) == 2
+      assert Enum.any?(problems, &match?({:stale_hash, "stale", _, _}, &1))
+      assert Enum.any?(problems, &match?({:missing_recording, "missing", _}, &1))
+    end
+  end
+
+  describe "describe/1" do
+    test "a stale hash explains the consequence, not just the mismatch" do
+      message = Fixtures.describe({:stale_hash, "a case", "aaa", "bbb"})
+
+      assert message =~ "a case"
+      assert message =~ "aaa"
+      assert message =~ "bbb"
+      assert message =~ "different script"
+    end
+
+    test "an absent stored hash reads as none rather than empty" do
+      assert Fixtures.describe({:stale_hash, "a case", nil, "bbb"}) =~ "(none)"
+    end
+
+    test "names every case involved in a collision" do
+      message = Fixtures.describe({:hash_collision, "abc", ["first", "second"]})
+
+      assert message =~ "abc"
+      assert message =~ "first"
+      assert message =~ "second"
+    end
+  end
+
+  describe "the committed corpus" do
+    @cases_dir Path.expand("../fixtures/bash_cases", __DIR__)
+    @expected_dir Path.expand("../fixtures/bash_expected", __DIR__)
+
+    test "every suite is sound" do
+      # JustBash.FixtureTest raises at compile time on the two fatal problems.
+      # This asserts the weaker ones too, so an orphaned recording is visible as
+      # a normal test failure rather than accumulating unnoticed.
+      problems =
+        @cases_dir
+        |> Path.join("*.json")
+        |> Path.wildcard()
+        |> Enum.sort()
+        |> Enum.flat_map(fn case_file ->
+          suite = Path.basename(case_file, ".json")
+          expected_file = Path.join(@expected_dir, "#{suite}.json")
+
+          cases = case_file |> File.read!() |> Jason.decode!() |> Map.fetch!("cases")
+
+          results =
+            case File.read(expected_file) do
+              {:ok, body} -> body |> Jason.decode!() |> Map.get("results", [])
+              {:error, :enoent} -> []
+            end
+
+          Enum.map(Fixtures.validate(cases, results), &"#{suite}: #{Fixtures.describe(&1)}")
+        end)
+
+      assert problems == [],
+             "fixture corpus integrity problems:\n" <> Enum.join(problems, "\n")
+    end
+  end
+end


### PR DESCRIPTION
Groundwork for a differential testing story that finds bugs before a production agent does, plus the first enumerated matrix and the bugs it found.

## Why

The recent fix wave (#56, #57, #60, #63) was found reactively: an agent driving the sandbox returned a wrong answer, a human noticed, an issue got filed. There is no proactive enumeration. The obvious remedy is "run real bash in a container and compare" — but that already exists and works. `mix bash_fixtures` records real bash in Docker and `fixture_test.exs` byte-compares stdout/stderr/exit across 33 suites.

The gap is what the corpus *contains*. One measurement settles it:

> `test/fixtures/bash_cases/date.json` has 30 hand-written cases and covers none of `%F`, `%D`, `%T`, `%R`, `-I` or `-v` — the exact directives #63 had to fix.

The existing, unmodified oracle would have caught that bug with ~25 lines of JSON. It shipped because nobody wrote down strftime's alphabet. The corpus grew by example — one case per bug already found — so a directive nobody had thought about had no case, and an absent case is indistinguishable from a passing one.

A command's conversion and flag sets are *finite*. They are not a space to sample with a fuzzer; they are a list to enumerate.

## What's here

**1. The corpus verifies its own content-addressing** (`2bffbbd`)

Cases and recordings are joined by `content_hash`, and nothing in the repo computed it — it was only ever read, as an opaque join key. Two consequences: a case couldn't be added programmatically (the only way in was to hand-compute a 16-hex value by an unknown recipe), and a stored hash that is never re-derived can't detect its own staleness.

62 of 968 hashes had drifted. Re-recording them produced **no behavioral change** — the expectations were right for the current scripts, so the hazard was latent rather than realised. It no longer is: `JustBash.Fixtures` owns the digest, `fixture_test.exs` recomputes rather than trusts it, and a stale hash or collision now fails compilation instead of silently mispairing.

- `mix bash_fixtures.verify` — the same checks offline. Because the hash comes from the inputs, "edited a script but never re-recorded" is detectable with **no Docker at all**, which is what lets CI stay hermetic.
- `mix bash_fixtures.rehash` — adopts edited scripts. Deliberately leaves expectations unclaimed so `verify` says so and the re-record diff shows what the cases should have been asserting.
- The recorder piped Docker's stderr into `Jason.decode!`. Any byte Docker writes there — image platform mismatches, pull progress — corrupted the payload silently, since a truncated parse fails far from its cause. It now writes to a mounted file.
- Only recording *inputs* are hashed. Renaming a case, or widening what it tolerates, must not orphan a recording that is still byte-for-byte correct — the property `fixture_test.exs:27` already claimed in a comment but nothing enforced.
- Drops the unused `locked:true` mechanism: a recording that silently contradicts real bash is the artifact that hides drift.

**2. `mix bash_fixtures.gen` + the date matrix** (`e3336f6`, `e50c105`)

182 enumerated cases against real GNU date. In a command that already had 30 hand-written cases, they found **40 divergences**:

| class | count | examples |
| --- | --- | --- |
| conversion printed verbatim at exit 0 | 21 | `%c %g %G %k %l %q %r %U %V %W %x %X %z`, every field-flag form (`%-d %_d %0d %^a %:z %::z %:::z`) |
| flag silently discarded, returns today at exit 0 | 7 | `-v+6m`, `-v-1d`, `-Z`, `--not-a-flag`, `-j`, `-jf` |
| wrong format | 1 | `-R` emitted the default format, not RFC 5322 |
| `-d` input rejected | 2 | `@SECONDS`, offset-less ISO |
| flag rejected that GNU implements | 1 | `-r FILE` |

The first class is the same bug #63 fixed for `%F`. **That fix closed instances, not the class** — 21 more conversions were still printing themselves at exit 0. The second is #64 exactly, and it is the failure that had an agent file a goal six months in the past and report success.

All fixed. `date -r` now reports a file's mtime from the VFS, with errors through `FS.strerror/1` so descending through a regular file reports ENOTDIR rather than the hardcoded "No such file or directory" that 33 command modules still use for every error kind.

## Two things the oracle corrected mid-fix

Both worth keeping, because both are cases where reading the docs would have left the bug in:

- The existing composition property in `property_test.exs` caught the first attempt treating `%#%!` as a modified `%%`. Real date refuses `%` as a conversion for a flag run: it emits the flags literally and starts a fresh directive at the `%`, so `%-%d` is `%-15`. The property was right.
- Folding flags one at a time renders `%-0d` as `5`. Real date renders `05` — the last padding flag wins outright, so padding is now decided once from the whole run.

## Enumeration lessons, encoded

**One base instant hides half the bugs.** At day 15 and hour 13, `%-d`, `%_d` and `%0d` all render "15" and every padding bug hides. Every conversion is recorded at two instants, one with a single-digit day and a morning hour — which is what surfaced `%_3d`.

**Gaps are recorded, never omitted.** 13 divergences remain, each with the reason it stands: GNU's `-d` relative grammar (`"6 months ago"`, `"next tuesday"`) is unimplemented, `-j`/`-f` are documented BSD spellings GNU rejects, and `%N` pads with trailing spaces under `_` and `-` unlike every other conversion. A `known_gap` opt marks them; it rides in `opts`, which the digest excludes, so marking or closing a gap never invalidates a recording. A recorded gap is countable and has a reason attached; an absent case looks like a passing one, which is how this class survived #63.

## Verification

All five gates from CLAUDE.md: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --strict` (only the intentional test-fixture finding), `mix dialyzer`, `mix test` — **4219 tests, 0 failures, 14 skipped**. `mix bash_fixtures.verify`: 34 suites sound. Corpus is now 1150 recorded differential cases.

Closes #64.

Follow-up work is tracked in #70 (the remaining matrices, oracle hardening, oracle-free invariants, the Oils subset and CI topology), with the two prerequisites split out as #68 (unknown flags absorbed as operands) and #69 (builtin raises escape `exec/2`; `Limit` has no wall-clock bound).