### PR TITLE
fix: a CLI flag rejects unknown spec keys and accepts extra long spellings

### DIFF
--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -41,16 +41,26 @@ defmodule JustBash.CLI do
 
   Flag specs use the exact shape of `JustBash.Commands.ArgParser`: a keyword list of
   `name: [type: ..., ...]`. Supported keys: `:type` (`:boolean`, `:string`, `:integer`,
-  `:float`, `:accumulator`), `:short`, `:long` (defaults to `--name`), `:default`,
-  `:required`, `:values` (enum), `:transform`, and `:doc` (used in help output).
+  `:float`, `:accumulator`), `:short`, `:long` (defaults to `--name`), `:aliases`,
+  `:default`, `:required`, `:values` (enum), `:transform`, and `:doc` (used in help output).
 
   Flag specs are validated at build time (`command/2` raises `ArgumentError`):
 
+    * an unrecognized spec key is rejected — a typo'd or imagined key would otherwise be
+      silently ignored and indistinguishable from a working one.
     * `--help`/`-h` are **reserved** — see "Reserved flags" below.
     * `:required` and `:default` are mutually exclusive (a required flag errors when omitted,
       so the default could never apply).
     * a `:default` must be a member of `:values` when both are given (the enum check only
       runs on flags the user actually provides, so an out-of-range default would slip past it).
+    * an alias must start with `--` and may not collide with another flag's long form or alias.
+
+  ## Flag aliases
+
+  `:aliases` gives one flag extra long spellings, for renaming a flag without breaking
+  callers: `target_on: [type: :string, aliases: ["--target-date"]]` accepts both
+  `--target-on` and `--target-date`. `:long` stays canonical and is the only form shown in
+  usage lines, help, and `describe/1` — aliases are accepted, not advertised.
 
   `:values` is compared against the **coerced** value, so list members must match the flag's
   `:type` — e.g. `type: :integer, values: [1, 2]` (integers, not `~w(1 2)`). The raw
@@ -129,6 +139,20 @@ defmodule JustBash.CLI do
   # Exit code used for all usage errors (unknown command, bad flags, missing args),
   # matching the convention of git/most CLIs.
   @usage_exit 2
+
+  # Every key a flag spec may carry — the `JustBash.Commands.ArgParser` shape plus `:doc`.
+  # Anything else is rejected at build time (see `validate_flag_spec!/3`).
+  @flag_spec_keys [
+    :type,
+    :short,
+    :long,
+    :aliases,
+    :default,
+    :required,
+    :values,
+    :transform,
+    :doc
+  ]
 
   @enforce_keys [:name]
   defstruct name: nil, doc: nil, commands: [], aliases: [], on_missing_subcommand: :error
@@ -873,16 +897,20 @@ defmodule JustBash.CLI do
             "command #{inspect(name)} :flags must be a keyword list of flag specs, got: #{inspect(flags)}"
     end
 
-    Enum.map(flags, fn {flag_name, spec} ->
-      unless Keyword.keyword?(spec) do
-        raise ArgumentError,
-              "command #{inspect(name)} flag #{inspect(flag_name)} spec must be a keyword list, got: #{inspect(spec)}"
-      end
+    flags =
+      Enum.map(flags, fn {flag_name, spec} ->
+        unless Keyword.keyword?(spec) do
+          raise ArgumentError,
+                "command #{inspect(name)} flag #{inspect(flag_name)} spec must be a keyword list, got: #{inspect(spec)}"
+        end
 
-      spec = Keyword.put_new(spec, :long, default_long(flag_name))
-      validate_flag_spec!(name, flag_name, spec)
-      {flag_name, spec}
-    end)
+        spec = Keyword.put_new(spec, :long, default_long(flag_name))
+        validate_flag_spec!(name, flag_name, spec)
+        {flag_name, spec}
+      end)
+
+    validate_alias_collisions!(name, flags)
+    flags
   end
 
   defp normalize_flags!(name, flags) do
@@ -891,6 +919,8 @@ defmodule JustBash.CLI do
   end
 
   # Build-time guards that can't drift into runtime surprises:
+  #   * an unrecognized key is never read by the parser, so a typo (or an imagined feature)
+  #     would behave exactly like a spec that works — until the flag is exercised.
   #   * `--help`/`-h` are intercepted by the router before any leaf parses, so a flag that
   #     claims them could never receive its value (see the "reserved flags" note in the
   #     moduledoc).
@@ -899,6 +929,9 @@ defmodule JustBash.CLI do
   #   * a `:default` outside `:values` would silently bypass the enum check, which only
   #     runs on provided flags.
   defp validate_flag_spec!(name, flag_name, spec) do
+    validate_flag_keys!(name, flag_name, spec)
+    validate_flag_aliases!(name, flag_name, spec[:aliases])
+
     cond do
       spec[:long] == "--help" or spec[:short] == "-h" ->
         reserved = if spec[:long] == "--help", do: "--help", else: "-h"
@@ -913,6 +946,75 @@ defmodule JustBash.CLI do
       true ->
         validate_default_in_values!(name, flag_name, spec)
     end
+  end
+
+  defp validate_flag_keys!(name, flag_name, spec) do
+    case Keyword.keys(spec) -- @flag_spec_keys do
+      [] ->
+        :ok
+
+      [unknown | _rest] ->
+        raise ArgumentError,
+              "command #{inspect(name)} flag #{inspect(flag_name)}: unknown flag option " <>
+                "#{inspect(unknown)}; valid options are #{inspect(@flag_spec_keys)}"
+    end
+  end
+
+  defp validate_flag_aliases!(_name, _flag_name, nil), do: :ok
+
+  defp validate_flag_aliases!(name, flag_name, aliases) when is_list(aliases) do
+    Enum.each(aliases, &validate_flag_alias!(name, flag_name, &1))
+  end
+
+  defp validate_flag_aliases!(name, flag_name, other) do
+    raise ArgumentError,
+          "command #{inspect(name)} flag #{inspect(flag_name)}: :aliases must be a list of " <>
+            "strings, got: #{inspect(other)}"
+  end
+
+  defp validate_flag_alias!(name, flag_name, form) when is_binary(form) do
+    cond do
+      form == "--help" ->
+        raise ArgumentError,
+              "command #{inspect(name)} flag #{inspect(flag_name)}: alias \"--help\" is reserved " <>
+                "for help and cannot be used as a flag"
+
+      not String.starts_with?(form, "--") or form == "--" ->
+        raise ArgumentError,
+              "command #{inspect(name)} flag #{inspect(flag_name)}: alias #{inspect(form)} must " <>
+                "be a long flag form starting with \"--\""
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_flag_alias!(name, flag_name, other) do
+    raise ArgumentError,
+          "command #{inspect(name)} flag #{inspect(flag_name)}: :aliases must be a list of " <>
+            "strings, got: #{inspect(other)}"
+  end
+
+  # Two flags claiming the same long form would resolve to whichever the parser indexed last,
+  # silently binding the wrong flag. Aliases make that easy to do by accident, so every alias
+  # must be distinct from every long form and every other alias on the command.
+  defp validate_alias_collisions!(name, flags) do
+    longs = for {_flag_name, spec} <- flags, spec[:long], do: spec[:long]
+    aliased = for {flag_name, spec} <- flags, form <- spec[:aliases] || [], do: {flag_name, form}
+
+    do_validate_alias_collisions!(name, aliased, longs)
+  end
+
+  defp do_validate_alias_collisions!(_name, [], _taken), do: :ok
+
+  defp do_validate_alias_collisions!(name, [{flag_name, form} | rest], taken) do
+    if form in taken do
+      raise ArgumentError,
+            "command #{inspect(name)} flag #{inspect(flag_name)}: alias #{inspect(form)} " <>
+              "collides with an existing flag long form or alias"
+    end
+
+    do_validate_alias_collisions!(name, rest, [form | taken])
   end
 
   defp validate_default_in_values!(name, flag_name, spec) do

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -56,6 +56,8 @@ defmodule JustBash.CLI do
     * an alias must start with `--`, and no two flags may share a long form, an alias, or a
       short form — the parser indexes them into one map, so a collision would silently bind
       the wrong flag.
+    * a long form or alias may not contain `=` — the parser splits `--flag=value` on the first
+      `=` before matching, so such a spelling could never be reached.
 
   ## Flag aliases
 
@@ -932,6 +934,7 @@ defmodule JustBash.CLI do
   #     runs on provided flags.
   defp validate_flag_spec!(name, flag_name, spec) do
     validate_flag_keys!(name, flag_name, spec)
+    validate_flag_long!(name, flag_name, spec[:long])
     validate_flag_aliases!(name, flag_name, spec[:aliases])
 
     cond do
@@ -962,6 +965,24 @@ defmodule JustBash.CLI do
     end
   end
 
+  defp validate_flag_long!(name, flag_name, long) when is_binary(long),
+    do: reject_equals!(name, flag_name, "long form", long)
+
+  defp validate_flag_long!(_name, _flag_name, _long), do: :ok
+
+  # `ArgParser.parse_loop/5` splits a long token on its first `=` (the `--flag=value` form)
+  # before consulting the long-form map, so a spelling containing `=` is registered but can
+  # never be matched: it builds clean and does nothing.
+  defp reject_equals!(name, flag_name, kind, form) do
+    if String.contains?(form, "=") do
+      raise ArgumentError,
+            "command #{inspect(name)} flag #{inspect(flag_name)}: #{kind} #{inspect(form)} " <>
+              "cannot contain \"=\" — the parser splits a long flag on \"=\" before matching it"
+    end
+
+    :ok
+  end
+
   defp validate_flag_aliases!(_name, _flag_name, nil), do: :ok
 
   defp validate_flag_aliases!(name, flag_name, aliases) when is_list(aliases) do
@@ -987,7 +1008,7 @@ defmodule JustBash.CLI do
                 "be a long flag form starting with \"--\""
 
       true ->
-        :ok
+        reject_equals!(name, flag_name, "alias", form)
     end
   end
 

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -53,7 +53,9 @@ defmodule JustBash.CLI do
       so the default could never apply).
     * a `:default` must be a member of `:values` when both are given (the enum check only
       runs on flags the user actually provides, so an out-of-range default would slip past it).
-    * an alias must start with `--` and may not collide with another flag's long form or alias.
+    * an alias must start with `--`, and no two flags may share a long form, an alias, or a
+      short form — the parser indexes them into one map, so a collision would silently bind
+      the wrong flag.
 
   ## Flag aliases
 
@@ -909,7 +911,7 @@ defmodule JustBash.CLI do
         {flag_name, spec}
       end)
 
-    validate_alias_collisions!(name, flags)
+    validate_flag_collisions!(name, flags)
     flags
   end
 
@@ -995,27 +997,42 @@ defmodule JustBash.CLI do
             "strings, got: #{inspect(other)}"
   end
 
-  # Two flags claiming the same long form would resolve to whichever the parser indexed last,
-  # silently binding the wrong flag. Aliases make that easy to do by accident, so every alias
-  # must be distinct from every long form and every other alias on the command.
-  defp validate_alias_collisions!(name, flags) do
-    longs = for {_flag_name, spec} <- flags, spec[:long], do: spec[:long]
-    aliased = for {flag_name, spec} <- flags, form <- spec[:aliases] || [], do: {flag_name, form}
+  # Two flags claiming the same spelling would resolve to whichever the parser indexed last
+  # (`build_flag_maps/1` is a last-write-wins reduce), silently binding the wrong flag. Every
+  # long form and alias on a command must therefore be distinct from each other, and every
+  # short form distinct from every other short form. Longs go first so a collision between a
+  # long form and an alias is reported against the alias, which is the form that moved.
+  defp validate_flag_collisions!(name, flags) do
+    longs = for {flag_name, spec} <- flags, spec[:long], do: {flag_name, :long, spec[:long]}
+    shorts = for {flag_name, spec} <- flags, spec[:short], do: {flag_name, :short, spec[:short]}
 
-    do_validate_alias_collisions!(name, aliased, longs)
+    aliased =
+      for {flag_name, spec} <- flags, form <- spec[:aliases] || [], do: {flag_name, :alias, form}
+
+    do_validate_flag_collisions!(name, longs ++ aliased, [])
+    do_validate_flag_collisions!(name, shorts, [])
   end
 
-  defp do_validate_alias_collisions!(_name, [], _taken), do: :ok
+  defp do_validate_flag_collisions!(_name, [], _taken), do: :ok
 
-  defp do_validate_alias_collisions!(name, [{flag_name, form} | rest], taken) do
+  defp do_validate_flag_collisions!(name, [{flag_name, kind, form} | rest], taken) do
     if form in taken do
       raise ArgumentError,
-            "command #{inspect(name)} flag #{inspect(flag_name)}: alias #{inspect(form)} " <>
-              "collides with an existing flag long form or alias"
+            "command #{inspect(name)} flag #{inspect(flag_name)}: " <>
+              collision_message(kind, form)
     end
 
-    do_validate_alias_collisions!(name, rest, [form | taken])
+    do_validate_flag_collisions!(name, rest, [form | taken])
   end
+
+  defp collision_message(:long, form),
+    do: "long form #{inspect(form)} collides with an existing flag long form or alias"
+
+  defp collision_message(:alias, form),
+    do: "alias #{inspect(form)} collides with an existing flag long form or alias"
+
+  defp collision_message(:short, form),
+    do: "short form #{inspect(form)} collides with an existing flag short form"
 
   defp validate_default_in_values!(name, flag_name, spec) do
     with {:ok, default} <- Keyword.fetch(spec, :default),

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -158,6 +158,27 @@ defmodule JustBash.CLI do
     :doc
   ]
 
+  # Every option `command/2` reads. Anything else would be dropped unread — including
+  # `visible:` for `:visible?`, which discards an authorization predicate.
+  @command_opt_keys [
+    :doc,
+    :commands,
+    :run,
+    :flags,
+    :args,
+    :examples,
+    :validate,
+    :allow_unknown_flags,
+    :visible?,
+    :on_missing_subcommand
+  ]
+
+  # Every option `new/2` reads.
+  @cli_opt_keys [:doc, :commands, :aliases, :on_missing_subcommand]
+
+  # Every key a positional argument spec may carry (see `t:JustBash.CLI.Command.arg_spec/0`).
+  @arg_spec_keys [:name, :doc, :required, :variadic]
+
   @enforce_keys [:name]
   defstruct name: nil, doc: nil, commands: [], aliases: [], on_missing_subcommand: :error
 
@@ -279,11 +300,14 @@ defmodule JustBash.CLI do
     * `:on_missing_subcommand` — `:error` (default) or `:help`; what the root does when
       invoked with no subcommand (see `command/2`)
 
-  Raises `ArgumentError` if names are invalid or top-level command names collide.
+  Raises `ArgumentError` if names are invalid, top-level command names collide, or an
+  option is unrecognized or repeated — an option this function does not read would be
+  dropped unread, indistinguishable from one that works.
   """
   @spec new(String.t(), keyword()) :: t()
   def new(name, opts \\ []) when is_binary(name) do
     validate_name!(name, "CLI")
+    validate_spec_keys!("CLI #{inspect(name)}", "option", Keyword.keys(opts), @cli_opt_keys)
 
     commands = Keyword.get(opts, :commands, [])
     validate_commands!(commands)
@@ -332,11 +356,22 @@ defmodule JustBash.CLI do
     * `:on_missing_subcommand` — `:error` (default) or `:help` (groups only); `:help` prints
       the command listing at exit 0 instead of a usage error when the group is invoked bare
 
-  Raises `ArgumentError` on invalid shape (e.g. both or neither of `:commands`/`:run`).
+  Raises `ArgumentError` on invalid shape (e.g. both or neither of `:commands`/`:run`), and
+  on an unrecognized or repeated option — including inside an `:args` entry. A key this
+  builder does not read would be dropped unread and behave exactly like one that works;
+  `visible:` for `:visible?` would silently discard an authorization predicate, and
+  `requird:` on a positional would silently make a required argument optional.
   """
   @spec command(String.t(), keyword()) :: Command.t()
   def command(name, opts \\ []) when is_binary(name) do
     validate_name!(name, "command")
+
+    validate_spec_keys!(
+      "command #{inspect(name)}",
+      "option",
+      Keyword.keys(opts),
+      @command_opt_keys
+    )
 
     commands = Keyword.get(opts, :commands, [])
     run = Keyword.get(opts, :run)
@@ -1125,7 +1160,14 @@ defmodule JustBash.CLI do
     raise ArgumentError, "command #{inspect(name)} :args must be a list, got: #{inspect(other)}"
   end
 
-  defp normalize_arg!(_name, %{name: arg_name} = spec) when is_atom(arg_name) do
+  defp normalize_arg!(name, %{name: arg_name} = spec) when is_atom(arg_name) do
+    validate_spec_keys!(
+      "command #{inspect(name)}",
+      "positional argument option",
+      Map.keys(spec),
+      @arg_spec_keys
+    )
+
     %{
       name: arg_name,
       doc: Map.get(spec, :doc),

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -954,14 +954,35 @@ defmodule JustBash.CLI do
   end
 
   defp validate_flag_keys!(name, flag_name, spec) do
-    case Keyword.keys(spec) -- @flag_spec_keys do
-      [] ->
+    validate_spec_keys!(
+      "command #{inspect(name)} flag #{inspect(flag_name)}",
+      "flag option",
+      Keyword.keys(spec),
+      @flag_spec_keys
+    )
+  end
+
+  # The unknown/duplicate key guard shared by every spec the builder accepts. Both failures
+  # are the same silent drop: an unrecognized key is never read, so a typo (or an imagined
+  # feature) behaves exactly like a key that works, and a duplicated key is dropped by
+  # `Keyword` access, which returns only the first value. `Enum.uniq/1` before the subtraction
+  # matters because list subtraction removes one occurrence per element — without it a legally
+  # duplicated *valid* key survives and gets reported as unknown, in a message that lists it
+  # as valid in the same sentence.
+  defp validate_spec_keys!(context, label, keys, allowed) do
+    unique = Enum.uniq(keys)
+
+    case {unique -- allowed, keys -- unique} do
+      {[], []} ->
         :ok
 
-      [unknown | _rest] ->
+      {[unknown | _rest], _duplicates} ->
         raise ArgumentError,
-              "command #{inspect(name)} flag #{inspect(flag_name)}: unknown flag option " <>
-                "#{inspect(unknown)}; valid options are #{inspect(@flag_spec_keys)}"
+              "#{context}: unknown #{label} #{inspect(unknown)}; " <>
+                "valid options are #{inspect(allowed)}"
+
+      {[], [duplicate | _rest]} ->
+        raise ArgumentError, "#{context}: duplicate #{label} #{inspect(duplicate)}"
     end
   end
 

--- a/lib/just_bash/commands/arg_parser.ex
+++ b/lib/just_bash/commands/arg_parser.ex
@@ -34,6 +34,8 @@ defmodule JustBash.Commands.ArgParser do
 
   - `:short` - Short flag form (e.g., "-s")
   - `:long` - Long flag form (e.g., "--silent")
+  - `:aliases` - Additional long forms accepted for the same flag (e.g., `["--quiet"]`).
+    `:long` stays the canonical spelling used in help and error messages
   - `:type` - Value type (`:boolean`, `:string`, `:integer`, `:float`, `:accumulator`)
   - `:default` - Default value if flag not provided
   - `:required` - When `true`, parsing fails if the flag is not provided
@@ -49,6 +51,7 @@ defmodule JustBash.Commands.ArgParser do
   @type flag_spec :: [
           short: String.t(),
           long: String.t(),
+          aliases: [String.t()],
           type: flag_type(),
           default: any(),
           required: boolean(),
@@ -107,10 +110,16 @@ defmodule JustBash.Commands.ArgParser do
     end
   end
 
+  # `:aliases` share the long map with `:long`, so an alias parses exactly like the canonical
+  # form. Only `:long` is ever read back out for display (see `flag_display_name/1`).
   defp build_flag_maps(flags) do
     Enum.reduce(flags, {%{}, %{}}, fn {name, spec}, {shorts, longs} ->
       shorts = if spec[:short], do: Map.put(shorts, spec[:short], {name, spec}), else: shorts
       longs = if spec[:long], do: Map.put(longs, spec[:long], {name, spec}), else: longs
+
+      longs =
+        Enum.reduce(spec[:aliases] || [], longs, &Map.put(&2, &1, {name, spec}))
+
       {shorts, longs}
     end)
   end

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -141,6 +141,120 @@ defmodule JustBash.CLI.BuilderTest do
       end
     end
 
+    test "raises on an unrecognized flag-spec key" do
+      assert_raise ArgumentError,
+                   ~r/unknown flag option :totally_bogus_key.*valid options are/s,
+                   fn ->
+                     CLI.command("x",
+                       flags: [
+                         other: [type: :string, long: "--other-name", totally_bogus_key: 123]
+                       ],
+                       run: fn i -> {ok(), i.bash} end
+                     )
+                   end
+    end
+
+    test "raises on a misspelled flag-spec key" do
+      assert_raise ArgumentError, ~r/unknown flag option :requird/, fn ->
+        CLI.command("x",
+          flags: [n: [type: :integer, requird: true]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "accepts a flag :aliases list and keeps :long canonical" do
+      cmd =
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: ["--target-date", "--date"]]],
+          run: fn i -> {ok(), i.bash} end
+        )
+
+      assert cmd.flags[:target_on][:long] == "--target-on"
+      assert cmd.flags[:target_on][:aliases] == ["--target-date", "--date"]
+    end
+
+    test "raises when :aliases is not a list of strings" do
+      assert_raise ArgumentError, ~r/:aliases must be a list of strings/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: "--target-date"]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+
+      assert_raise ArgumentError, ~r/:aliases must be a list of strings/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: [:"--target-date"]]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when an alias is not a long flag form" do
+      assert_raise ArgumentError, ~r/alias "target-date" must be a long flag form/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: ["target-date"]]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+
+      assert_raise ArgumentError, ~r/alias "-t" must be a long flag form/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: ["-t"]]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+
+      assert_raise ArgumentError, ~r/alias "--" must be a long flag form/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: ["--"]]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when an alias claims the reserved --help form" do
+      assert_raise ArgumentError, ~r/--help.* is reserved/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: ["--help"]]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when an alias collides with another flag's long form" do
+      assert_raise ArgumentError, ~r/alias "--format" collides/, fn ->
+        CLI.command("x",
+          flags: [
+            format: [type: :string],
+            target_on: [type: :string, aliases: ["--format"]]
+          ],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when an alias collides with another flag's alias" do
+      assert_raise ArgumentError, ~r/alias "--date" collides/, fn ->
+        CLI.command("x",
+          flags: [
+            recorded_on: [type: :string, aliases: ["--date"]],
+            target_on: [type: :string, aliases: ["--date"]]
+          ],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when an alias collides with its own flag's long form" do
+      assert_raise ArgumentError, ~r/alias "--target-on" collides/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: ["--target-on"]]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
     test "raises on flags that are not a keyword list" do
       assert_raise ArgumentError, ~r/:flags must be a keyword list/, fn ->
         CLI.command("x", flags: %{not: :keyword}, run: fn i -> {ok(), i.bash} end)

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -255,6 +255,33 @@ defmodule JustBash.CLI.BuilderTest do
       end
     end
 
+    test "raises when two flags claim the same long form" do
+      assert_raise ArgumentError, ~r/long form "--dup" collides/, fn ->
+        CLI.command("x",
+          flags: [a: [type: :string, long: "--dup"], b: [type: :string, long: "--dup"]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when two flag names derive the same long form" do
+      assert_raise ArgumentError, ~r/long form "--dry-run" collides/, fn ->
+        CLI.command("x",
+          flags: [dry_run: [type: :boolean], "dry-run": [type: :boolean]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when two flags claim the same short form" do
+      assert_raise ArgumentError, ~r/short form "-x" collides/, fn ->
+        CLI.command("x",
+          flags: [a: [type: :boolean, short: "-x"], b: [type: :boolean, short: "-x"]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
     test "raises on flags that are not a keyword list" do
       assert_raise ArgumentError, ~r/:flags must be a keyword list/, fn ->
         CLI.command("x", flags: %{not: :keyword}, run: fn i -> {ok(), i.bash} end)

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -339,6 +339,55 @@ defmodule JustBash.CLI.BuilderTest do
         CLI.command("pr", commands: [child], args: [%{name: :id}])
       end
     end
+
+    test "raises on an unrecognized command option" do
+      assert_raise ArgumentError, ~r/command "admin": unknown option :totally_bogus/, fn ->
+        CLI.command("admin",
+          totally_bogus: 123,
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    # Dropping the `?` discards the authorization predicate: the node stays routable for every
+    # caller, which is a silent security downgrade rather than a cosmetic typo.
+    test "raises on :visible written without its question mark" do
+      assert_raise ArgumentError, ~r/unknown option :visible;/, fn ->
+        CLI.command("admin",
+          visible: fn _bash -> false end,
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises on a misspelled :flags option" do
+      assert_raise ArgumentError, ~r/unknown option :flgs/, fn ->
+        CLI.command("go",
+          flgs: [target_on: [type: :string]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises on a duplicated command option" do
+      err =
+        assert_raise ArgumentError, fn ->
+          CLI.command("go", doc: "one", doc: "two", run: fn i -> {ok(), i.bash} end)
+        end
+
+      assert Exception.message(err) =~ "duplicate option :doc"
+    end
+
+    test "raises on an unrecognized positional argument key" do
+      assert_raise ArgumentError,
+                   ~r/unknown positional argument option :requird/,
+                   fn ->
+                     CLI.command("go",
+                       args: [%{name: :path, requird: true, doc: "path"}],
+                       run: fn i -> {ok(), i.bash} end
+                     )
+                   end
+    end
   end
 
   describe "new/2" do
@@ -364,6 +413,18 @@ defmodule JustBash.CLI.BuilderTest do
       assert_raise ArgumentError, ~r/duplicate subcommand name/, fn ->
         CLI.new("acme", commands: [a, b])
       end
+    end
+
+    test "raises on an unrecognized CLI option" do
+      assert_raise ArgumentError, ~r/CLI "acme": unknown option :comands/, fn ->
+        CLI.new("acme", comands: [])
+      end
+    end
+
+    test "raises on a duplicated CLI option" do
+      err = assert_raise ArgumentError, fn -> CLI.new("acme", doc: "one", doc: "two") end
+
+      assert Exception.message(err) =~ "duplicate option :doc"
     end
   end
 

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -163,6 +163,21 @@ defmodule JustBash.CLI.BuilderTest do
       end
     end
 
+    test "raises naming a duplicated flag-spec key as a duplicate, not as unknown" do
+      err =
+        assert_raise ArgumentError, fn ->
+          CLI.command("x",
+            flags: [n: [type: :integer, type: :string]],
+            run: fn i -> {ok(), i.bash} end
+          )
+        end
+
+      message = Exception.message(err)
+
+      assert message =~ "duplicate flag option :type"
+      refute message =~ "unknown flag option"
+    end
+
     test "accepts a flag :aliases list and keeps :long canonical" do
       cmd =
         CLI.command("x",

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -428,5 +428,155 @@ defmodule JustBash.CLI.BuilderTest do
     end
   end
 
+  # The builder's key allowlists are load-bearing in the *strict* direction: any key missing
+  # from one turns a spec that works today into a build-time raise, and nothing else in the
+  # suite would notice — dropping `:transform` from the flag list left the whole suite green
+  # while breaking every downstream CLI that uses it. These tests enumerate each list rather
+  # than sampling it: every key is exercised positively, and the builder's own "valid options
+  # are" list is pinned to the enumeration, so a key added or dropped on either side goes red.
+  describe "spec key allowlists" do
+    @flag_spec_keys [
+      :type,
+      :short,
+      :long,
+      :aliases,
+      :default,
+      :required,
+      :values,
+      :transform,
+      :doc
+    ]
+
+    @command_opt_keys [
+      :doc,
+      :commands,
+      :run,
+      :flags,
+      :args,
+      :examples,
+      :validate,
+      :allow_unknown_flags,
+      :visible?,
+      :on_missing_subcommand
+    ]
+
+    @cli_opt_keys [:doc, :commands, :aliases, :on_missing_subcommand]
+
+    @arg_spec_keys [:name, :doc, :required, :variadic]
+
+    test "every flag-spec key is accepted on its own" do
+      for key <- @flag_spec_keys do
+        spec = Keyword.put([type: :string], key, flag_spec_value(key))
+
+        assert %Command{} =
+                 CLI.command("x", flags: [n: spec], run: fn i -> {ok(), i.bash} end),
+               "flag-spec key #{inspect(key)} was rejected by the builder"
+      end
+    end
+
+    test "a flag spec carrying every key at once is accepted" do
+      # :required and :default are mutually exclusive by design, so each variant drops the
+      # other; between them the two specs cover the whole allowlist.
+      for dropped <- [:default, :required] do
+        spec = for key <- @flag_spec_keys -- [dropped], do: {key, flag_spec_value(key)}
+
+        assert %Command{} = CLI.command("x", flags: [n: spec], run: fn i -> {ok(), i.bash} end)
+      end
+    end
+
+    test "the builder reports exactly the enumerated flag-spec keys as valid" do
+      err =
+        assert_raise ArgumentError, fn ->
+          CLI.command("x", flags: [n: [nope: 1]], run: fn i -> {ok(), i.bash} end)
+        end
+
+      assert Exception.message(err) =~ "valid options are #{inspect(@flag_spec_keys)}"
+    end
+
+    test "every command option is accepted, on a leaf or on a group" do
+      leaf_opts = [
+        doc: "leaf doc",
+        run: fn i -> {ok(), i.bash} end,
+        flags: [verbose: [type: :boolean]],
+        args: [%{name: :path}],
+        examples: ["x go /tmp"],
+        validate: fn _inv -> :ok end,
+        allow_unknown_flags: true,
+        visible?: fn _bash -> true end
+      ]
+
+      group_opts = [
+        doc: "group doc",
+        commands: [CLI.command("child", run: fn i -> {ok(), i.bash} end)],
+        visible?: fn _bash -> true end,
+        on_missing_subcommand: :help
+      ]
+
+      assert Enum.sort(Enum.uniq(Keyword.keys(leaf_opts) ++ Keyword.keys(group_opts))) ==
+               Enum.sort(@command_opt_keys)
+
+      assert %Command{} = CLI.command("go", leaf_opts)
+      assert %Command{} = CLI.command("pr", group_opts)
+    end
+
+    test "the builder reports exactly the enumerated command options as valid" do
+      err =
+        assert_raise ArgumentError, fn ->
+          CLI.command("go", nope: 1, run: fn i -> {ok(), i.bash} end)
+        end
+
+      assert Exception.message(err) =~ "valid options are #{inspect(@command_opt_keys)}"
+    end
+
+    test "every CLI option is accepted at once" do
+      opts = [
+        doc: "Acme toolkit",
+        commands: [CLI.command("go", run: fn i -> {ok(), i.bash} end)],
+        aliases: ["ac"],
+        on_missing_subcommand: :help
+      ]
+
+      assert Enum.sort(Keyword.keys(opts)) == Enum.sort(@cli_opt_keys)
+      assert %CLI{name: "acme"} = CLI.new("acme", opts)
+    end
+
+    test "the builder reports exactly the enumerated CLI options as valid" do
+      err = assert_raise ArgumentError, fn -> CLI.new("acme", nope: 1) end
+
+      assert Exception.message(err) =~ "valid options are #{inspect(@cli_opt_keys)}"
+    end
+
+    test "every positional argument key is accepted at once" do
+      spec = %{name: :path, doc: "a path", required: true, variadic: true}
+
+      assert Enum.sort(Map.keys(spec)) == Enum.sort(@arg_spec_keys)
+
+      cmd = CLI.command("go", args: [spec], run: fn i -> {ok(), i.bash} end)
+
+      assert [%{name: :path, doc: "a path", required: true, variadic: true}] = cmd.args
+    end
+
+    test "the builder reports exactly the enumerated positional argument keys as valid" do
+      err =
+        assert_raise ArgumentError, fn ->
+          CLI.command("go", args: [%{name: :path, nope: 1}], run: fn i -> {ok(), i.bash} end)
+        end
+
+      assert Exception.message(err) =~ "valid options are #{inspect(@arg_spec_keys)}"
+    end
+  end
+
+  # A representative value for each flag-spec key. Kept as a function rather than a module
+  # attribute because `:transform` holds a function capture, which cannot be escaped into one.
+  defp flag_spec_value(:type), do: :integer
+  defp flag_spec_value(:short), do: "-n"
+  defp flag_spec_value(:long), do: "--enum"
+  defp flag_spec_value(:aliases), do: ["--alias-form"]
+  defp flag_spec_value(:default), do: "a"
+  defp flag_spec_value(:required), do: true
+  defp flag_spec_value(:values), do: ["a", "b"]
+  defp flag_spec_value(:transform), do: &String.upcase/1
+  defp flag_spec_value(:doc), do: "a doc string"
+
   defp ok, do: %{stdout: "", stderr: "", exit_code: 0}
 end

--- a/test/cli/builder_test.exs
+++ b/test/cli/builder_test.exs
@@ -255,6 +255,27 @@ defmodule JustBash.CLI.BuilderTest do
       end
     end
 
+    # `ArgParser` splits a long token on its first `=` before consulting the long-form map, so
+    # a spelling containing `=` is registered but unreachable — it would build clean and never
+    # match, the exact silent-drop failure the key allowlist exists to prevent.
+    test "raises when an alias contains =" do
+      assert_raise ArgumentError, ~r/alias "--target=date" cannot contain "="/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, aliases: ["--target=date"]]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
+    test "raises when a :long form contains =" do
+      assert_raise ArgumentError, ~r/long form "--target=date" cannot contain "="/, fn ->
+        CLI.command("x",
+          flags: [target_on: [type: :string, long: "--target=date"]],
+          run: fn i -> {ok(), i.bash} end
+        )
+      end
+    end
+
     test "raises when two flags claim the same long form" do
       assert_raise ArgumentError, ~r/long form "--dup" collides/, fn ->
         CLI.command("x",

--- a/test/cli/routing_test.exs
+++ b/test/cli/routing_test.exs
@@ -215,6 +215,77 @@ defmodule JustBash.CLI.RoutingTest do
     end
   end
 
+  describe "flag aliases" do
+    defp alias_cli do
+      CLI.new("probe",
+        commands: [
+          CLI.command("go",
+            doc: "Write a date column",
+            flags: [
+              target_on: [type: :string, aliases: ["--target-date"], doc: "date"],
+              verbose: [type: :boolean, short: "-v", aliases: ["--loud"]]
+            ],
+            run: fn inv ->
+              tag = if inv.flags.verbose, do: "VERBOSE ", else: ""
+              {Command.ok("#{tag}target_on=#{inv.flags.target_on}\n"), inv.bash}
+            end
+          )
+        ]
+      )
+    end
+
+    defp run_alias(script) do
+      bash = JustBash.new(commands: %{"probe" => alias_cli()})
+      {result, _bash} = JustBash.exec(bash, script)
+      result
+    end
+
+    test "the canonical long form still parses" do
+      result = run_alias("probe go --target-on 1")
+      assert result.exit_code == 0
+      assert result.stdout == "target_on=1\n"
+    end
+
+    test "an alias parses into the same flag" do
+      result = run_alias("probe go --target-date 1")
+      assert result.exit_code == 0
+      assert result.stdout == "target_on=1\n"
+    end
+
+    test "an alias accepts the --flag=value form" do
+      result = run_alias("probe go --target-date=1")
+      assert result.exit_code == 0
+      assert result.stdout == "target_on=1\n"
+    end
+
+    test "an alias works for a boolean flag" do
+      result = run_alias("probe go --target-on 1 --loud")
+      assert result.exit_code == 0
+      assert result.stdout == "VERBOSE target_on=1\n"
+    end
+
+    test "an unrelated unknown flag still errors" do
+      result = run_alias("probe go --target-dat 1")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: --target-dat"
+    end
+
+    test "help shows only the canonical long form" do
+      result = run_alias("probe go --help")
+      assert result.exit_code == 0
+      assert result.stdout =~ "--target-on"
+      refute result.stdout =~ "--target-date"
+      refute result.stdout =~ "--loud"
+    end
+
+    test "the usage line on an error shows only the canonical long form" do
+      result = run_alias("probe go --nope")
+      assert result.exit_code == 2
+      assert result.stderr =~ "[--target-on <string>]"
+      refute result.stderr =~ "--target-date"
+    end
+  end
+
   describe "command-level validation" do
     defp validating_cli do
       CLI.new("acme",

--- a/test/commands/arg_parser_test.exs
+++ b/test/commands/arg_parser_test.exs
@@ -289,6 +289,42 @@ defmodule JustBash.Commands.ArgParserTest do
     end
   end
 
+  describe "aliases option" do
+    @alias_flags [
+      target_on: [long: "--target-on", aliases: ["--target-date"], type: :string, required: true],
+      verbose: [long: "--verbose", aliases: ["--loud"], type: :boolean]
+    ]
+
+    test "parses the canonical long form" do
+      {:ok, opts, _} = ArgParser.parse(["--target-on", "2027-02-03"], @alias_flags)
+      assert opts.target_on == "2027-02-03"
+    end
+
+    test "parses an alias into the same flag" do
+      {:ok, opts, _} = ArgParser.parse(["--target-date", "2027-02-03"], @alias_flags)
+      assert opts.target_on == "2027-02-03"
+    end
+
+    test "parses an alias in --flag=value form" do
+      {:ok, opts, _} = ArgParser.parse(["--target-date=2027-02-03"], @alias_flags)
+      assert opts.target_on == "2027-02-03"
+    end
+
+    test "an alias satisfies a required flag" do
+      assert {:ok, _opts, _} = ArgParser.parse(["--target-date", "x"], @alias_flags)
+    end
+
+    test "an alias sets a boolean flag" do
+      {:ok, opts, _} = ArgParser.parse(["--target-on", "x", "--loud"], @alias_flags)
+      assert opts.verbose == true
+    end
+
+    test "errors still name the canonical long form, not the alias used" do
+      assert {:error, message} = ArgParser.parse([], @alias_flags)
+      assert message =~ "missing required flag: --target-on"
+    end
+  end
+
   describe "values (enum) option" do
     @enum_flags [
       format: [long: "--format", type: :string, values: ["text", "json"], default: "text"]


### PR DESCRIPTION
Closes #65

Two related gaps in `JustBash.CLI` flag specs: an unrecognised spec key was silently accepted and never read, and a flag could only ever have one long form.

## What was broken

`normalize_flags!/2` filled in `:long` and handed the spec to `validate_flag_spec!/3`, which checked only `:long`/`:short`, `:required` + `:default`, and `:default` ∈ `:values`. Every other key passed straight through, unread. `:aliases` is an especially easy key to reach for because it already exists one level up on `CLI.new/2` — and the library agreed with you right up until runtime.

Against `82ee9e5`, the issue's `AliasProbe` repro:

```
$ probe go --target-on 1
   exit=0
$ probe go --target-date 1
   exit=2 stderr="probe go: unknown option: --target-date"
```

`aliases:` did nothing, `totally_bogus_key: 123` did nothing, and neither produced a peep at build time.

## What the fix does

**(a) Unknown flag-spec keys raise at build time.** `validate_flag_spec!/3` now checks the spec's keys against the full set — `:type`, `:short`, `:long`, `:aliases`, `:default`, `:required`, `:values`, `:transform`, `:doc` — and raises naming the offender and listing the valid options. This joins the guards already there (`--help`/`-h` reserved, `:required` + `:default`, `:default` outside `:values`), whose comment already says these are guards that "can't drift into runtime surprises".

```
raised: command "go" flag :other: unknown flag option :totally_bogus_key; valid options are
[:type, :short, :long, :aliases, :default, :required, :values, :transform, :doc]
```

**(b) `:aliases` on a flag now works.** A list of extra long spellings accepted by the parser, for symmetry with `CLI.new/2`'s tool-level `:aliases`. `JustBash.Commands.ArgParser.build_flag_maps/1` registers each alias in the same long-form map as `:long`, so an alias parses identically — including the `--flag=value` form, booleans, and satisfying `required: true`. `:long` stays canonical: it is the only spelling shown in usage lines, `--help`, error messages, and `describe/1`. Aliases are accepted, not advertised.

Alias validation mirrors `:long`: the list must be a list of strings, each must be a long flag form starting with `--` (so `"-t"`, `"target-date"`, and a bare `"--"` all raise), `--help` is reserved, and no alias may collide with another flag's long form or alias (nor with its own flag's `:long`) — a collision would otherwise resolve to whichever flag the parser indexed last and silently bind the wrong one.

After the fix, the issue's repro:

```
$ probe go --target-on 1
   exit=0 stdout="target_on=1\n"
$ probe go --target-date 1
   exit=0 stdout="target_on=1\n"
```

The moduledoc's flag-key list, build-time-guard list, and a new "Flag aliases" section document the behaviour.

## New tests

Written first, watched fail (11 failures against the unfixed tree), then fixed.

`test/cli/builder_test.exs` — build-time guards:
* raises on an unrecognised flag-spec key (`totally_bogus_key`) and on a misspelling (`requird`)
* accepts an `:aliases` list and keeps `:long` canonical
* raises when `:aliases` is not a list of strings (bare string; atom entry)
* raises when an alias is not a long flag form (`"target-date"`, `"-t"`, `"--"`)
* raises when an alias claims the reserved `--help`
* raises when an alias collides with another flag's long form, another flag's alias, or its own flag's long form

`test/cli/routing_test.exs` — end-to-end through the shell, the issue's `probe go` CLI:
* the canonical long form still parses; an alias parses into the same flag; `--target-date=1` works; an alias works on a boolean flag
* an unrelated unknown flag (`--target-dat`) still errors at exit 2
* `--help` and the error usage line show only `--target-on`, never `--target-date` or `--loud`

`test/commands/arg_parser_test.exs` — parser level: canonical form, alias, `--flag=value` alias, alias satisfying `required: true`, alias setting a boolean, and the missing-required error still naming the canonical `--target-on` rather than an alias.

## Gates

All five run on the final tree.

```
$ mix compile --warnings-as-errors
Compiling 2 files (.ex)
Generated just_bash app

$ mix format --check-formatted
format ok

$ mix credo --strict
Checking 229 source files (this might take a while) ...

  Refactoring opportunities
┃
┃ [F] ↘ Avoid `apply/2` and `apply/3` when the number of arguments is known.
┃       test/support/banned_fixture_apply.ex:4:16 #(BannedCallTracer.Fixture.Apply.run)

Analysis took 1.5 seconds (0.08s to load, 1.4s running 68 checks on 229 files)
5117 mods/funs, found 1 refactoring opportunity.
```

(the sole credo finding is the pre-existing intentional test fixture, untouched by this branch)

```
$ mix test
Running ExUnit with seed: 373057, max_cases: 20
Excluding tags: [:live]
Finished in 23.8 seconds (23.6s async, 0.2s sync)
2 doctests, 62 properties, 4774 tests, 0 failures (5 excluded)

$ mix dialyzer
Checking PLT...
PLT is up to date!
ignore_warnings: .dialyzer_ignore.exs
Starting Dialyzer
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done in 0m3.02s
done (passed successfully)
```

## Review round 2

Five confirmed review findings addressed on top of the original branch (see the [reply comment](https://github.com/elixir-ai-tools/just_bash/pull/71#issuecomment-5204733896) for the repro-by-repro walkthrough). Two of them change what this PR claims to do:

**The collision guard now covers `:long` and `:short`, not just aliases.** Its comment said "two flags claiming the same long form would resolve to whichever the parser indexed last, silently binding the wrong flag", but the fold seeded `taken` with the long forms and walked only the aliases, so the case the comment named went unchecked. `long: "--dup"` on two flags built clean and bound the wrong one. Both long forms and short forms are now checked.

**Scope extension: `command/2`, `new/2`, and `:args` entries also reject unknown and repeated keys.** The flag-spec allowlist closed the silent drop inside a flag and left the identical drop one level up and one level down. Both are pre-existing rather than introduced here, but they are the same class the issue was filed about — `visible:` for `:visible?` discarded an authorization predicate and left an intended-hidden node routable by every caller, and `requird:` on a positional silently made a required argument optional. All four allowlists share one `validate_spec_keys!/4`.

Also in this round: a `:long` form or alias containing `=` is rejected (the parser splits on `=` before matching, so such a spelling was registered and unreachable); a duplicated *valid* key is now diagnosed as a duplicate instead of being reported as unknown in a message that listed it as valid; and each of the four allowlists gained enumerated positive tests pinned to the builder's own "valid options are" output — deleting `:transform` from the flag list previously left the whole suite green.

The gate output below is from the original branch tip; the round-2 gates (`4796 tests, 0 failures`) are in the reply comment.

## Scope

Both halves the issue describes are delivered. Nothing left out. The issue floated `deprecated_long:` (accepted, hidden, warns on stderr) as an alternative shape; `:aliases` was chosen per the issue's own preference for symmetry with `CLI.new/2`, and no stderr deprecation warning is emitted.

