### PR TITLE
fix: a flag a command does not implement is an error, not a filename

### DIFF
--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -78,7 +78,8 @@ defmodule JustBash.Commands.Cp do
       P: false,
       L: false,
       d: false
-    }
+    },
+    usage: "cp [OPTION]... SOURCE... DEST"
   }
 
   @try_help "Try 'cp --help' for more information.\n"
@@ -91,6 +92,9 @@ defmodule JustBash.Commands.Cp do
     case FlagParser.parse(args, @flag_spec) do
       {:ok, flags, operands} ->
         copy(bash, operands, options(flags))
+
+      :help ->
+        {Command.ok(FlagParser.help("cp", @flag_spec)), bash}
 
       {:error, reason} ->
         {Command.error(FlagParser.format_error("cp", reason, @try_help)), bash}

--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -88,8 +88,13 @@ defmodule JustBash.Commands.Cp do
 
   @impl true
   def execute(bash, args, _stdin) do
-    {flags, operands} = FlagParser.parse(args, @flag_spec)
-    copy(bash, operands, options(flags))
+    case FlagParser.parse(args, @flag_spec) do
+      {:ok, flags, operands} ->
+        copy(bash, operands, options(flags))
+
+      {:error, reason} ->
+        {Command.error(FlagParser.format_error("cp", reason, @try_help)), bash}
+    end
   end
 
   defp options(flags) do

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -53,13 +53,26 @@ defmodule JustBash.Commands.Grep do
     }
   }
 
+  @usage """
+  Usage: grep [OPTION]... PATTERNS [FILE]...
+  Try 'grep --help' for more information.
+  """
+
   @impl true
   def names, do: ["grep"]
 
   @impl true
   def execute(bash, args, stdin) do
-    {flags, rest} = FlagParser.parse(args, @flag_spec)
+    case FlagParser.parse(args, @flag_spec) do
+      {:ok, flags, rest} ->
+        grep(bash, flags, rest, stdin)
 
+      {:error, reason} ->
+        {Command.error(FlagParser.format_error("grep", reason, @usage), 2), bash}
+    end
+  end
+
+  defp grep(bash, flags, rest, stdin) do
     case rest do
       [pattern | files] when files != [] ->
         execute_with_files(bash, pattern, files, flags)

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -50,7 +50,8 @@ defmodule JustBash.Commands.Grep do
       r: false,
       with_filename: false,
       no_filename: false
-    }
+    },
+    usage: "grep [OPTION]... PATTERNS [FILE]..."
   }
 
   @usage """
@@ -66,6 +67,9 @@ defmodule JustBash.Commands.Grep do
     case FlagParser.parse(args, @flag_spec) do
       {:ok, flags, rest} ->
         grep(bash, flags, rest, stdin)
+
+      :help ->
+        {Command.ok(FlagParser.help("grep", @flag_spec)), bash}
 
       {:error, reason} ->
         {Command.error(FlagParser.format_error("grep", reason, @usage), 2), bash}

--- a/lib/just_bash/commands/head.ex
+++ b/lib/just_bash/commands/head.ex
@@ -10,6 +10,7 @@ defmodule JustBash.Commands.Head do
     boolean: [],
     value: [:n, :c],
     integer: [:n, :c],
+    value_labels: %{n: "number of lines", c: "number of bytes"},
     defaults: %{n: 10, c: nil}
   }
 

--- a/lib/just_bash/commands/head.ex
+++ b/lib/just_bash/commands/head.ex
@@ -11,7 +11,8 @@ defmodule JustBash.Commands.Head do
     value: [:n, :c],
     integer: [:n, :c],
     value_labels: %{n: "number of lines", c: "number of bytes"},
-    defaults: %{n: 10, c: nil}
+    defaults: %{n: 10, c: nil},
+    usage: "head [OPTION]... [FILE]..."
   }
 
   @usage "Try 'head --help' for more information.\n"
@@ -23,6 +24,7 @@ defmodule JustBash.Commands.Head do
   def execute(bash, args, stdin) do
     case FlagParser.parse(args, @flag_spec) do
       {:ok, flags, files} -> head(bash, flags, files, stdin)
+      :help -> {Command.ok(FlagParser.help("head", @flag_spec)), bash}
       {:error, reason} -> {Command.error(FlagParser.format_error("head", reason, @usage)), bash}
     end
   end

--- a/lib/just_bash/commands/head.ex
+++ b/lib/just_bash/commands/head.ex
@@ -9,16 +9,24 @@ defmodule JustBash.Commands.Head do
   @flag_spec %{
     boolean: [],
     value: [:n, :c],
+    integer: [:n, :c],
     defaults: %{n: 10, c: nil}
   }
+
+  @usage "Try 'head --help' for more information.\n"
 
   @impl true
   def names, do: ["head"]
 
   @impl true
   def execute(bash, args, stdin) do
-    {flags, files} = FlagParser.parse(args, @flag_spec)
+    case FlagParser.parse(args, @flag_spec) do
+      {:ok, flags, files} -> head(bash, flags, files, stdin)
+      {:error, reason} -> {Command.error(FlagParser.format_error("head", reason, @usage)), bash}
+    end
+  end
 
+  defp head(bash, flags, files, stdin) do
     mode =
       if flags.c do
         {:bytes, flags.c}

--- a/lib/just_bash/commands/ls.ex
+++ b/lib/just_bash/commands/ls.ex
@@ -10,7 +10,8 @@ defmodule JustBash.Commands.Ls do
     boolean: [:a, :l, :h, :r, :R, :S, :t, :one],
     value: [],
     defaults: %{a: false, l: false, h: false, r: false, R: false, S: false, t: false, one: false},
-    aliases: %{"1" => :one}
+    aliases: %{"1" => :one},
+    usage: "ls [OPTION]... [FILE]..."
   }
 
   @usage "Try 'ls --help' for more information.\n"
@@ -22,6 +23,7 @@ defmodule JustBash.Commands.Ls do
   def execute(bash, args, _stdin) do
     case FlagParser.parse(args, @flag_spec) do
       {:ok, flags, paths} -> list(bash, flags, paths)
+      :help -> {Command.ok(FlagParser.help("ls", @flag_spec)), bash}
       {:error, reason} -> {Command.error(FlagParser.format_error("ls", reason, @usage), 2), bash}
     end
   end

--- a/lib/just_bash/commands/ls.ex
+++ b/lib/just_bash/commands/ls.ex
@@ -13,12 +13,20 @@ defmodule JustBash.Commands.Ls do
     aliases: %{"1" => :one}
   }
 
+  @usage "Try 'ls --help' for more information.\n"
+
   @impl true
   def names, do: ["ls"]
 
   @impl true
   def execute(bash, args, _stdin) do
-    {flags, paths} = FlagParser.parse(args, @flag_spec)
+    case FlagParser.parse(args, @flag_spec) do
+      {:ok, flags, paths} -> list(bash, flags, paths)
+      {:error, reason} -> {Command.error(FlagParser.format_error("ls", reason, @usage), 2), bash}
+    end
+  end
+
+  defp list(bash, flags, paths) do
     paths = if paths == [], do: ["."], else: paths
 
     {stdout, stderr, exit_code, fs} =

--- a/lib/just_bash/commands/sort.ex
+++ b/lib/just_bash/commands/sort.ex
@@ -30,7 +30,13 @@ defmodule JustBash.Commands.Sort do
   end
 
   defp sort(bash, flags, files, stdin) do
-    {content, fs} = get_content(bash, files, stdin)
+    case get_content(bash, files, stdin) do
+      {:ok, content, fs} -> sorted(bash, flags, content, fs)
+      {:error, message} -> {Command.error(message, 2), bash}
+    end
+  end
+
+  defp sorted(bash, flags, content, fs) do
     # Don't trim - preserve empty lines. Only remove trailing empty if content ends with \n
     lines = String.split(content, "\n", trim: false)
 
@@ -50,14 +56,17 @@ defmodule JustBash.Commands.Sort do
     {Command.ok(output), %{bash | fs: fs}}
   end
 
-  defp get_content(bash, [], stdin), do: {stdin, bash.fs}
+  defp get_content(bash, [], stdin), do: {:ok, stdin, bash.fs}
+  defp get_content(bash, ["-" | _], stdin), do: {:ok, stdin, bash.fs}
 
+  # A file sort cannot read is reported, not read as empty: swallowing the
+  # error is how `sort -- -Q` answered with nothing at exit 0.
   defp get_content(bash, [file | _], _stdin) do
     resolved = FS.resolve_path(bash.cwd, file)
 
     case FS.read_file(bash.fs, resolved) do
-      {:ok, c, fs} -> {c, fs}
-      {:error, _} -> {"", bash.fs}
+      {:ok, content, fs} -> {:ok, content, fs}
+      {:error, _} -> {:error, "sort: cannot read: #{file}: No such file or directory\n"}
     end
   end
 
@@ -107,8 +116,6 @@ defmodule JustBash.Commands.Sort do
         key_a < key_b
     end
   end
-
-  defp parse_key_spec(spec) when is_integer(spec), do: {spec, nil}
 
   defp parse_key_spec(spec) when is_binary(spec) do
     # Parse key spec like "2" or "2,2" or "2,2nr" or "1,1rn"

--- a/lib/just_bash/commands/sort.ex
+++ b/lib/just_bash/commands/sort.ex
@@ -10,7 +10,8 @@ defmodule JustBash.Commands.Sort do
     boolean: [:r, :u, :n, :f],
     value: [:t],
     multi_value: [:k],
-    defaults: %{r: false, u: false, n: false, f: false, k: [], t: nil}
+    defaults: %{r: false, u: false, n: false, f: false, k: [], t: nil},
+    usage: "sort [OPTION]... [FILE]..."
   }
 
   @usage "Try 'sort --help' for more information.\n"
@@ -23,6 +24,9 @@ defmodule JustBash.Commands.Sort do
     case FlagParser.parse(args, @flag_spec) do
       {:ok, flags, files} ->
         sort(bash, flags, files, stdin)
+
+      :help ->
+        {Command.ok(FlagParser.help("sort", @flag_spec)), bash}
 
       {:error, reason} ->
         {Command.error(FlagParser.format_error("sort", reason, @usage), 2), bash}

--- a/lib/just_bash/commands/sort.ex
+++ b/lib/just_bash/commands/sort.ex
@@ -70,9 +70,19 @@ defmodule JustBash.Commands.Sort do
 
     case FS.read_file(bash.fs, resolved) do
       {:ok, content, fs} -> {:ok, content, fs}
-      {:error, _} -> {:error, "sort: cannot read: #{file}: No such file or directory\n"}
+      {:error, error} -> {:error, read_error(file, error)}
     end
   end
+
+  # GNU sort has two templates, and which one it uses says where the failure
+  # happened. A directory opens, so it is the read that fails and coreutils
+  # says `read failed:`; everything else fails at open and says `cannot read:`.
+  # The reason always comes from strerror - naming a directory that exists
+  # "No such file or directory" is a false statement about the filesystem.
+  defp read_error(file, %VFS.Error{kind: :eisdir} = error),
+    do: "sort: read failed: #{file}: #{FS.strerror(error)}\n"
+
+  defp read_error(file, error), do: "sort: cannot read: #{file}: #{FS.strerror(error)}\n"
 
   defp sort_lines(lines, %{k: key_specs} = flags) when key_specs != [] do
     delimiter = flags[:t] || " "

--- a/lib/just_bash/commands/sort.ex
+++ b/lib/just_bash/commands/sort.ex
@@ -13,12 +13,23 @@ defmodule JustBash.Commands.Sort do
     defaults: %{r: false, u: false, n: false, f: false, k: [], t: nil}
   }
 
+  @usage "Try 'sort --help' for more information.\n"
+
   @impl true
   def names, do: ["sort"]
 
   @impl true
   def execute(bash, args, stdin) do
-    {flags, files} = FlagParser.parse(args, @flag_spec)
+    case FlagParser.parse(args, @flag_spec) do
+      {:ok, flags, files} ->
+        sort(bash, flags, files, stdin)
+
+      {:error, reason} ->
+        {Command.error(FlagParser.format_error("sort", reason, @usage), 2), bash}
+    end
+  end
+
+  defp sort(bash, flags, files, stdin) do
     {content, fs} = get_content(bash, files, stdin)
     # Don't trim - preserve empty lines. Only remove trailing empty if content ends with \n
     lines = String.split(content, "\n", trim: false)

--- a/lib/just_bash/commands/tail.ex
+++ b/lib/just_bash/commands/tail.ex
@@ -10,6 +10,7 @@ defmodule JustBash.Commands.Tail do
     boolean: [],
     value: [:n, :c],
     integer: [:n, :c],
+    value_labels: %{n: "number of lines", c: "number of bytes"},
     defaults: %{n: 10, c: nil}
   }
 

--- a/lib/just_bash/commands/tail.ex
+++ b/lib/just_bash/commands/tail.ex
@@ -11,7 +11,8 @@ defmodule JustBash.Commands.Tail do
     value: [:n, :c],
     integer: [:n, :c],
     value_labels: %{n: "number of lines", c: "number of bytes"},
-    defaults: %{n: 10, c: nil}
+    defaults: %{n: 10, c: nil},
+    usage: "tail [OPTION]... [FILE]..."
   }
 
   @usage "Try 'tail --help' for more information.\n"
@@ -23,6 +24,7 @@ defmodule JustBash.Commands.Tail do
   def execute(bash, args, stdin) do
     case FlagParser.parse(args, @flag_spec) do
       {:ok, flags, files} -> tail(bash, flags, files, stdin)
+      :help -> {Command.ok(FlagParser.help("tail", @flag_spec)), bash}
       {:error, reason} -> {Command.error(FlagParser.format_error("tail", reason, @usage)), bash}
     end
   end

--- a/lib/just_bash/commands/tail.ex
+++ b/lib/just_bash/commands/tail.ex
@@ -9,16 +9,24 @@ defmodule JustBash.Commands.Tail do
   @flag_spec %{
     boolean: [],
     value: [:n, :c],
+    integer: [:n, :c],
     defaults: %{n: 10, c: nil}
   }
+
+  @usage "Try 'tail --help' for more information.\n"
 
   @impl true
   def names, do: ["tail"]
 
   @impl true
   def execute(bash, args, stdin) do
-    {flags, files} = FlagParser.parse(args, @flag_spec)
+    case FlagParser.parse(args, @flag_spec) do
+      {:ok, flags, files} -> tail(bash, flags, files, stdin)
+      {:error, reason} -> {Command.error(FlagParser.format_error("tail", reason, @usage)), bash}
+    end
+  end
 
+  defp tail(bash, flags, files, stdin) do
     mode =
       if flags.c do
         {:bytes, flags.c}

--- a/lib/just_bash/commands/tr.ex
+++ b/lib/just_bash/commands/tr.ex
@@ -27,7 +27,16 @@ defmodule JustBash.Commands.Tr do
   end
 
   defp parse_args([], %{sets: []} = _opts) do
-    {:error, "tr: missing operand\n"}
+    {:error, "tr: missing operand\n" <> @try_help}
+  end
+
+  # One set is enough to delete or squeeze, but translating needs somewhere to
+  # translate to. Falling through to `run/2`'s catch-all answered with empty
+  # output at exit 0 - the failure this command's flag handling exists to stop.
+  defp parse_args([], %{delete: false, squeeze: false, sets: [set]}) do
+    {:error,
+     "tr: missing operand after '#{set}'\n" <>
+       "Two strings must be given when translating.\n" <> @try_help}
   end
 
   defp parse_args([], opts) do

--- a/lib/just_bash/commands/tr.ex
+++ b/lib/just_bash/commands/tr.ex
@@ -3,6 +3,9 @@ defmodule JustBash.Commands.Tr do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.FlagParser
+
+  @try_help "Try 'tr --help' for more information.\n"
 
   @impl true
   def names, do: ["tr"]
@@ -31,30 +34,45 @@ defmodule JustBash.Commands.Tr do
     {:ok, %{opts | sets: Enum.reverse(opts.sets)}}
   end
 
-  defp parse_args(["-d" | rest], opts), do: parse_args(rest, %{opts | delete: true})
-  defp parse_args(["-s" | rest], opts), do: parse_args(rest, %{opts | squeeze: true})
-  defp parse_args(["-c" | rest], opts), do: parse_args(rest, %{opts | complement: true})
-  defp parse_args(["-C" | rest], opts), do: parse_args(rest, %{opts | complement: true})
+  # Everything after `--` is a character set, even when it is dash-shaped.
+  defp parse_args(["--" | rest], opts) do
+    parse_args([], %{opts | sets: Enum.reverse(rest) ++ opts.sets})
+  end
 
-  # Combined flags like -ds, -cs, -cd, etc.
-  defp parse_args(["-" <> flags | rest], opts) when byte_size(flags) > 1 do
-    opts =
-      flags
-      |> String.graphemes()
-      |> Enum.reduce(opts, fn
-        "d", acc -> %{acc | delete: true}
-        "s", acc -> %{acc | squeeze: true}
-        "c", acc -> %{acc | complement: true}
-        "C", acc -> %{acc | complement: true}
-        _, acc -> acc
-      end)
-
-    parse_args(rest, opts)
+  # Combined flags like -ds, -cs, -cd, and single flags like -d. A character
+  # the reducer does not know is an error: dropping it silently made
+  # `tr -dX b` delete `b` and report success, and a lone unknown flag such as
+  # `-x` used to fall through to the clause below and become a character set.
+  defp parse_args(["-" <> flags | rest], opts) when flags != "" do
+    case reduce_flags(flags, opts) do
+      {:ok, opts} -> parse_args(rest, opts)
+      {:error, _reason} = error -> error
+    end
   end
 
   defp parse_args([set | rest], opts) do
     parse_args(rest, %{opts | sets: [set | opts.sets]})
   end
+
+  defp reduce_flags("-" <> _ = long_flag, _opts) do
+    {:error, unknown_flag("-" <> long_flag)}
+  end
+
+  defp reduce_flags(flags, opts) do
+    flags
+    |> String.graphemes()
+    |> Enum.reduce_while({:ok, opts}, fn char, {:ok, acc} -> apply_flag(char, acc) end)
+  end
+
+  defp apply_flag("d", opts), do: {:cont, {:ok, %{opts | delete: true}}}
+  defp apply_flag("s", opts), do: {:cont, {:ok, %{opts | squeeze: true}}}
+
+  defp apply_flag(char, opts) when char in ["c", "C"],
+    do: {:cont, {:ok, %{opts | complement: true}}}
+
+  defp apply_flag(char, _opts), do: {:halt, {:error, unknown_flag(char)}}
+
+  defp unknown_flag(flag), do: FlagParser.format_error("tr", {:unknown_flag, flag}, @try_help)
 
   defp run(input, %{delete: true, squeeze: false, sets: [set1]}) do
     chars = expand_set(set1) |> MapSet.new(&<<&1::utf8>>)

--- a/lib/just_bash/commands/tr.ex
+++ b/lib/just_bash/commands/tr.ex
@@ -7,6 +7,16 @@ defmodule JustBash.Commands.Tr do
 
   @try_help "Try 'tr --help' for more information.\n"
 
+  # `tr` keeps its own reducer because a set may look like a flag, but the flags
+  # it accepts are still declared once, so `tr --help` answers from them.
+  @flag_spec %{
+    boolean: [:c, :d, :s],
+    value: [],
+    aliases: %{"C" => :c},
+    defaults: %{c: false, d: false, s: false},
+    usage: "tr [OPTION]... SET1 [SET2]"
+  }
+
   @impl true
   def names, do: ["tr"]
 
@@ -16,6 +26,9 @@ defmodule JustBash.Commands.Tr do
       {:ok, opts} ->
         output = run(stdin, opts)
         {Command.ok(output), bash}
+
+      :help ->
+        {Command.ok(FlagParser.help("tr", @flag_spec)), bash}
 
       {:error, msg} ->
         {Command.error(msg), bash}
@@ -42,6 +55,8 @@ defmodule JustBash.Commands.Tr do
   defp parse_args([], opts) do
     {:ok, %{opts | sets: Enum.reverse(opts.sets)}}
   end
+
+  defp parse_args(["--help" | _rest], _opts), do: :help
 
   # Everything after `--` is a character set, even when it is dash-shaped.
   defp parse_args(["--" | rest], opts) do

--- a/lib/just_bash/commands/uniq.ex
+++ b/lib/just_bash/commands/uniq.ex
@@ -12,13 +12,20 @@ defmodule JustBash.Commands.Uniq do
     defaults: %{c: false, d: false, u: false}
   }
 
+  @usage "Try 'uniq --help' for more information.\n"
+
   @impl true
   def names, do: ["uniq"]
 
   @impl true
   def execute(bash, args, stdin) do
-    {flags, files} = FlagParser.parse(args, @flag_spec)
+    case FlagParser.parse(args, @flag_spec) do
+      {:ok, flags, files} -> uniq(bash, flags, files, stdin)
+      {:error, reason} -> {Command.error(FlagParser.format_error("uniq", reason, @usage)), bash}
+    end
+  end
 
+  defp uniq(bash, flags, files, stdin) do
     {content, fs} =
       case files do
         [] ->

--- a/lib/just_bash/commands/uniq.ex
+++ b/lib/just_bash/commands/uniq.ex
@@ -9,7 +9,8 @@ defmodule JustBash.Commands.Uniq do
   @flag_spec %{
     boolean: [:c, :d, :u],
     value: [],
-    defaults: %{c: false, d: false, u: false}
+    defaults: %{c: false, d: false, u: false},
+    usage: "uniq [OPTION]... [INPUT [OUTPUT]]"
   }
 
   @usage "Try 'uniq --help' for more information.\n"
@@ -21,6 +22,7 @@ defmodule JustBash.Commands.Uniq do
   def execute(bash, args, stdin) do
     case FlagParser.parse(args, @flag_spec) do
       {:ok, flags, files} -> uniq(bash, flags, files, stdin)
+      :help -> {Command.ok(FlagParser.help("uniq", @flag_spec)), bash}
       {:error, reason} -> {Command.error(FlagParser.format_error("uniq", reason, @usage)), bash}
     end
   end

--- a/lib/just_bash/flag_parser.ex
+++ b/lib/just_bash/flag_parser.ex
@@ -8,6 +8,7 @@ defmodule JustBash.FlagParser do
   - Value flags: `-n 10`, `-d ","` (flag that takes next argument)
   - Getopt clusters ending in a value flag: `-nk2` is `-n -k 2`
   - Stop parsing at `--`
+  - `--help`, answered from the spec itself
 
   A flag the spec does not describe is an error, never an operand. Demoting it
   turned `sort -Q file` into a read of a file named `-Q`, which sort reports as
@@ -28,6 +29,7 @@ defmodule JustBash.FlagParser do
       # Parse arguments
       case FlagParser.parse(args, spec) do
         {:ok, flags, rest} -> ...
+        :help -> FlagParser.help("ls", spec)
         {:error, reason} -> FlagParser.format_error("ls", reason, @usage)
       end
 
@@ -43,6 +45,8 @@ defmodule JustBash.FlagParser do
     everything else stays a string, so `sort -t 1` is the delimiter `"1"`
   - `:value_labels` - What an `:integer` flag counts, as GNU names it in
     `invalid number of lines: 'abc'`. Required for every `:integer` flag
+  - `:usage` - The synopsis line `help/2` prints, defaulting to
+    `"<command> [OPTION]..."`
   """
 
   @type flag_spec :: %{
@@ -52,7 +56,8 @@ defmodule JustBash.FlagParser do
           optional(:aliases) => map(),
           optional(:multi_value) => [atom()],
           optional(:integer) => [atom()],
-          optional(:value_labels) => %{atom() => String.t()}
+          optional(:value_labels) => %{atom() => String.t()},
+          optional(:usage) => String.t()
         }
 
   @type error ::
@@ -60,7 +65,7 @@ defmodule JustBash.FlagParser do
           | {:missing_value, String.t()}
           | {:invalid_value, String.t(), String.t()}
 
-  @type parse_result :: {:ok, map(), [String.t()]} | {:error, error()}
+  @type parse_result :: {:ok, map(), [String.t()]} | :help | {:error, error()}
 
   @doc """
   Parse command-line arguments according to the given flag specification.
@@ -69,9 +74,9 @@ defmodule JustBash.FlagParser do
   - `flags` is a map containing all flag values
   - `remaining_args` is a list of non-flag arguments
 
-  Returns `{:error, reason}` for the first argument that is flag-shaped but not
-  in the spec, for a value flag with nothing after it, and for a value declared
-  `:integer` that is not a number.
+  Returns `:help` for `--help`, and `{:error, reason}` for the first argument
+  that is flag-shaped but not in the spec, for a value flag with nothing after
+  it, and for a value declared `:integer` that is not a number.
 
   ## Examples
 
@@ -127,6 +132,61 @@ defmodule JustBash.FlagParser do
   def format_error(command, {:invalid_value, label, value}, _usage),
     do: "#{command}: invalid #{label}: '#{value}'\n"
 
+  @doc """
+  The usage `Try '<command> --help' for more information.` promises.
+
+  Rendered from the spec, so it lists exactly the flags the parser accepts and
+  cannot drift from them.
+
+  ## Examples
+
+      iex> spec = %{boolean: [:a], value: [:n], defaults: %{a: false, n: nil}}
+      iex> FlagParser.help("demo", spec)
+      "Usage: demo [OPTION]...\\nOptions this shell implements:\\n  -a\\n  -n VALUE\\n"
+  """
+  @spec help(String.t(), flag_spec()) :: String.t()
+  def help(command, spec) do
+    synopsis = Map.get(spec, :usage, "#{command} [OPTION]...")
+
+    ["Usage: ", synopsis, "\nOptions this shell implements:\n", option_lines(spec)]
+    |> IO.iodata_to_binary()
+  end
+
+  defp option_lines(spec) do
+    values = value_flags(spec)
+
+    spec
+    |> flag_lookup()
+    |> Enum.group_by(fn {_spelling, atom} -> atom end, fn {spelling, _atom} -> "-" <> spelling end)
+    |> Enum.map(fn {atom, spellings} ->
+      {atom, spellings |> typeable(atom) |> Enum.sort_by(&spelling_order(&1, atom))}
+    end)
+    |> Enum.sort_by(fn {_atom, [first | _]} -> {String.downcase(first), first} end)
+    |> Enum.map(fn {atom, spellings} ->
+      argument = if atom in values, do: " VALUE", else: ""
+      ["  ", Enum.join(spellings, ", "), argument, "\n"]
+    end)
+  end
+
+  # `flag_lookup/1` also answers to a multi-character atom's own name, so grep
+  # accepts `-with_filename` as well as `-H`. Printing that would advertise a
+  # spelling nobody means to type, so only real short and long options are
+  # listed — unless the atom's name is all a flag has.
+  defp typeable(spellings, atom) do
+    case Enum.filter(spellings, &short_or_long?/1) do
+      [] -> ["-" <> Atom.to_string(atom)]
+      typeable -> typeable
+    end
+  end
+
+  defp short_or_long?("-" <> name), do: String.length(name) == 1 or String.starts_with?(name, "-")
+
+  # The flag's own name first, then its other short spellings, then the long
+  # ones — the order a reader scans for "which letter do I type".
+  defp spelling_order(spelling, atom) do
+    {String.starts_with?(spelling, "--"), spelling != "-" <> Atom.to_string(atom), spelling}
+  end
+
   defp do_parse([], _spec, flags, rest) do
     {:ok, flags, Enum.reverse(rest)}
   end
@@ -156,6 +216,9 @@ defmodule JustBash.FlagParser do
 
       flag_atom in value_flags(spec) ->
         take_value(flag_atom, flag_str, remaining, spec, flags)
+
+      flag_str == "-help" ->
+        :help
 
       true ->
         parse_unnamed(flag_str, remaining, spec, flags, lookup)

--- a/lib/just_bash/flag_parser.ex
+++ b/lib/just_bash/flag_parser.ex
@@ -21,6 +21,7 @@ defmodule JustBash.FlagParser do
         boolean: [:a, :l, :v, :r],
         value: [:n, :d],
         integer: [:n],
+        value_labels: %{n: "number of lines"},
         defaults: %{a: false, l: false, v: false, r: false, n: 10, d: nil}
       }
 
@@ -40,6 +41,8 @@ defmodule JustBash.FlagParser do
   - `:multi_value` - Value flags that accumulate a list instead of overwriting
   - `:integer` - Value flags whose value is a count. Only these are converted;
     everything else stays a string, so `sort -t 1` is the delimiter `"1"`
+  - `:value_labels` - What an `:integer` flag counts, as GNU names it in
+    `invalid number of lines: 'abc'`. Required for every `:integer` flag
   """
 
   @type flag_spec :: %{
@@ -48,10 +51,14 @@ defmodule JustBash.FlagParser do
           :defaults => map(),
           optional(:aliases) => map(),
           optional(:multi_value) => [atom()],
-          optional(:integer) => [atom()]
+          optional(:integer) => [atom()],
+          optional(:value_labels) => %{atom() => String.t()}
         }
 
-  @type error :: {:unknown_flag, String.t()} | {:missing_value, String.t()}
+  @type error ::
+          {:unknown_flag, String.t()}
+          | {:missing_value, String.t()}
+          | {:invalid_value, String.t(), String.t()}
 
   @type parse_result :: {:ok, map(), [String.t()]} | {:error, error()}
 
@@ -63,11 +70,12 @@ defmodule JustBash.FlagParser do
   - `remaining_args` is a list of non-flag arguments
 
   Returns `{:error, reason}` for the first argument that is flag-shaped but not
-  in the spec, or for a value flag with nothing after it.
+  in the spec, for a value flag with nothing after it, and for a value declared
+  `:integer` that is not a number.
 
   ## Examples
 
-      iex> spec = %{boolean: [:a, :l], value: [:n], integer: [:n], defaults: %{a: false, l: false, n: 10}}
+      iex> spec = %{boolean: [:a, :l], value: [:n], integer: [:n], value_labels: %{n: "number of lines"}, defaults: %{a: false, l: false, n: 10}}
       iex> FlagParser.parse(["-a", "-n", "5", "file.txt"], spec)
       {:ok, %{a: true, l: false, n: 5}, ["file.txt"]}
 
@@ -98,6 +106,9 @@ defmodule JustBash.FlagParser do
 
       iex> FlagParser.format_error("sort", {:unknown_flag, "--nope"}, "")
       "sort: unrecognized option '--nope'\\n"
+
+      iex> FlagParser.format_error("head", {:invalid_value, "number of lines", "abc"}, "")
+      "head: invalid number of lines: 'abc'\\n"
   """
   @spec format_error(String.t(), error(), String.t()) :: String.t()
   def format_error(command, {:unknown_flag, "--" <> _ = flag}, usage),
@@ -111,6 +122,10 @@ defmodule JustBash.FlagParser do
 
   def format_error(command, {:missing_value, flag}, usage),
     do: "#{command}: option requires an argument -- '#{flag}'\n" <> usage
+
+  # GNU prints no `Try --help` line for a bad count, so neither do we.
+  def format_error(command, {:invalid_value, label, value}, _usage),
+    do: "#{command}: invalid #{label}: '#{value}'\n"
 
   defp do_parse([], _spec, flags, rest) do
     {:ok, flags, Enum.reverse(rest)}
@@ -199,11 +214,15 @@ defmodule JustBash.FlagParser do
   end
 
   defp take_cluster_value(flag_atom, _char, attached, remaining, spec, flags) do
-    {:ok, put_flag(flags, flag_atom, parse_value(attached, flag_atom, spec), spec), remaining}
+    with {:ok, value} <- parse_value(attached, flag_atom, spec) do
+      {:ok, put_flag(flags, flag_atom, value, spec), remaining}
+    end
   end
 
   defp take_value(flag_atom, _flag_str, [raw | rest], spec, flags) do
-    {:ok, put_flag(flags, flag_atom, parse_value(raw, flag_atom, spec), spec), rest}
+    with {:ok, value} <- parse_value(raw, flag_atom, spec) do
+      {:ok, put_flag(flags, flag_atom, value, spec), rest}
+    end
   end
 
   defp take_value(_flag_atom, flag_str, [], _spec, _flags) do
@@ -232,13 +251,26 @@ defmodule JustBash.FlagParser do
   end
 
   # Only a flag declared `:integer` is a count. Coercing every value that looks
-  # like one made `sort -t 1` a delimiter of `1` rather than `"1"`.
+  # like one made `sort -t 1` a delimiter of `1` rather than `"1"`; handing back
+  # a count that is not a number made `head -n abc` raise out of `Enum.take/2`.
   defp parse_value(value, flag_atom, spec) do
-    with true <- flag_atom in Map.get(spec, :integer, []),
-         {num, ""} <- Integer.parse(value) do
-      num
+    if flag_atom in Map.get(spec, :integer, []) do
+      parse_count(value, flag_atom, spec)
     else
-      _ -> value
+      {:ok, value}
     end
+  end
+
+  defp parse_count(value, flag_atom, spec) do
+    case Integer.parse(value) do
+      {count, ""} -> {:ok, count}
+      _ -> {:error, {:invalid_value, value_label(flag_atom, spec), value}}
+    end
+  end
+
+  # A spec that declares `:integer` without saying what is being counted cannot
+  # word the error, and that is a bug in the spec, not in the input.
+  defp value_label(flag_atom, spec) do
+    spec |> Map.fetch!(:value_labels) |> Map.fetch!(flag_atom)
   end
 end

--- a/lib/just_bash/flag_parser.ex
+++ b/lib/just_bash/flag_parser.ex
@@ -6,6 +6,7 @@ defmodule JustBash.FlagParser do
   - Boolean flags: `-a`, `-l`, `-v`
   - Combined flags: `-la` (equivalent to `-l -a`)
   - Value flags: `-n 10`, `-d ","` (flag that takes next argument)
+  - Getopt clusters ending in a value flag: `-nk2` is `-n -k 2`
   - Stop parsing at `--`
 
   A flag the spec does not describe is an error, never an operand. Demoting it
@@ -121,11 +122,8 @@ defmodule JustBash.FlagParser do
 
   defp do_parse(["-" <> flag_str | remaining], spec, flags, rest) when flag_str != "" do
     case parse_flag(flag_str, remaining, spec, flags) do
-      {:ok, new_flags, new_remaining} ->
-        do_parse(new_remaining, spec, new_flags, rest)
-
-      {:error, _reason} = error ->
-        error
+      {:ok, new_flags, new_remaining} -> do_parse(new_remaining, spec, new_flags, rest)
+      other -> other
     end
   end
 
@@ -134,92 +132,91 @@ defmodule JustBash.FlagParser do
   end
 
   defp parse_flag(flag_str, remaining, spec, flags) do
-    aliases = Map.get(spec, :aliases, %{})
     lookup = flag_lookup(spec)
-    flag_atom = Map.get(aliases, flag_str) || Map.get(lookup, flag_str)
+    flag_atom = Map.get(lookup, flag_str)
 
     cond do
       flag_atom in spec.boolean ->
         {:ok, Map.put(flags, flag_atom, true), remaining}
 
-      flag_atom in spec.value or flag_atom in Map.get(spec, :multi_value, []) ->
+      flag_atom in value_flags(spec) ->
         take_value(flag_atom, flag_str, remaining, spec, flags)
 
-      String.length(flag_str) > 1 ->
-        combined_lookup = Map.merge(lookup, aliases)
-
-        with :error <- try_attached_value_flag(flag_str, spec, flags, combined_lookup),
-             :error <- parse_combined_flags(flag_str, spec, flags, combined_lookup) do
-          try_numeric_flag(flag_str, remaining, spec, flags)
-        else
-          {:ok, new_flags} -> {:ok, new_flags, remaining}
-        end
-
       true ->
-        try_numeric_flag(flag_str, remaining, spec, flags)
+        parse_unnamed(flag_str, remaining, spec, flags, lookup)
     end
   end
 
-  defp take_value(flag_atom, _flag_str, [value | rest], spec, flags) do
-    {:ok, put_flag(flags, flag_atom, parse_value(value, flag_atom, spec), spec), rest}
+  # A flag the spec does not name outright is a bare count (`head -5`), a
+  # getopt cluster (`sort -nk2`), or an error.
+  defp parse_unnamed("-" <> _ = long_flag_str, _remaining, _spec, _flags, _lookup) do
+    {:error, {:unknown_flag, display_flag(long_flag_str)}}
+  end
+
+  defp parse_unnamed(flag_str, remaining, spec, flags, lookup) do
+    case numeric_shorthand(flag_str, spec) do
+      {:ok, count} ->
+        {:ok, Map.put(flags, :n, count), remaining}
+
+      :error ->
+        parse_cluster(String.graphemes(flag_str), remaining, spec, flags, lookup)
+    end
+  end
+
+  defp numeric_shorthand(flag_str, spec) do
+    with true <- :n in spec.value,
+         {count, ""} <- Integer.parse(flag_str) do
+      {:ok, count}
+    else
+      _ -> :error
+    end
+  end
+
+  # getopt walks a cluster one character at a time: booleans accumulate, and a
+  # value flag takes the rest of the cluster as its argument — or the next
+  # argument when it is the last character. It stops on the first character the
+  # spec does not describe at all, so the diagnostic can never name a flag the
+  # command implements.
+  defp parse_cluster([], remaining, _spec, flags, _lookup), do: {:ok, flags, remaining}
+
+  defp parse_cluster([char | rest], remaining, spec, flags, lookup) do
+    flag_atom = Map.get(lookup, char)
+
+    cond do
+      flag_atom in spec.boolean ->
+        parse_cluster(rest, remaining, spec, Map.put(flags, flag_atom, true), lookup)
+
+      flag_atom in value_flags(spec) ->
+        take_cluster_value(flag_atom, char, Enum.join(rest), remaining, spec, flags)
+
+      true ->
+        {:error, {:unknown_flag, char}}
+    end
+  end
+
+  defp take_cluster_value(flag_atom, char, "", remaining, spec, flags) do
+    take_value(flag_atom, char, remaining, spec, flags)
+  end
+
+  defp take_cluster_value(flag_atom, _char, attached, remaining, spec, flags) do
+    {:ok, put_flag(flags, flag_atom, parse_value(attached, flag_atom, spec), spec), remaining}
+  end
+
+  defp take_value(flag_atom, _flag_str, [raw | rest], spec, flags) do
+    {:ok, put_flag(flags, flag_atom, parse_value(raw, flag_atom, spec), spec), rest}
   end
 
   defp take_value(_flag_atom, flag_str, [], _spec, _flags) do
     {:error, {:missing_value, display_flag(flag_str)}}
   end
 
-  defp try_attached_value_flag(flag_str, spec, flags, lookup) do
-    <<first_char::binary-size(1), rest::binary>> = flag_str
-    flag_atom = Map.get(lookup, first_char)
-    multi_value = Map.get(spec, :multi_value, [])
-
-    if flag_atom != nil and (flag_atom in spec.value or flag_atom in multi_value) and rest != "" do
-      {:ok, put_flag(flags, flag_atom, parse_value(rest, flag_atom, spec), spec)}
-    else
-      :error
-    end
-  end
-
-  defp parse_combined_flags(flag_str, spec, flags, lookup) do
-    atoms = Enum.map(String.graphemes(flag_str), &Map.get(lookup, &1))
-
-    if Enum.all?(atoms, &(&1 in spec.boolean)) do
-      {:ok, Enum.reduce(atoms, flags, fn atom, acc -> Map.put(acc, atom, true) end)}
-    else
-      :error
-    end
-  end
-
   defp flag_lookup(spec) do
-    (spec.boolean ++ spec.value ++ Map.get(spec, :multi_value, []))
+    (spec.boolean ++ value_flags(spec))
     |> Map.new(fn atom -> {Atom.to_string(atom), atom} end)
+    |> Map.merge(Map.get(spec, :aliases, %{}))
   end
 
-  defp try_numeric_flag(flag_str, remaining, spec, flags) do
-    with true <- :n in spec.value,
-         {num, ""} <- Integer.parse(flag_str) do
-      {:ok, Map.put(flags, :n, num), remaining}
-    else
-      _ -> unknown_flag(flag_str, spec)
-    end
-  end
-
-  defp unknown_flag("-" <> _ = long_flag_str, _spec) do
-    {:error, {:unknown_flag, display_flag(long_flag_str)}}
-  end
-
-  # Out of a cluster, getopt stops on the first character the spec does not
-  # describe as a boolean flag, so that is what is named — not the cluster.
-  defp unknown_flag(flag_str, spec) do
-    lookup = Map.merge(flag_lookup(spec), Map.get(spec, :aliases, %{}))
-
-    offender =
-      flag_str
-      |> String.graphemes()
-      |> Enum.find(flag_str, fn char -> Map.get(lookup, char) not in spec.boolean end)
-
-    {:error, {:unknown_flag, offender}}
-  end
+  defp value_flags(spec), do: spec.value ++ Map.get(spec, :multi_value, [])
 
   # `parse/2` sees one leading `-` already stripped, so a long option arrives
   # here still carrying the second one.
@@ -227,11 +224,8 @@ defmodule JustBash.FlagParser do
   defp display_flag(short_flag_str), do: short_flag_str
 
   defp put_flag(flags, flag_atom, value, spec) do
-    multi_value = Map.get(spec, :multi_value, [])
-
-    if flag_atom in multi_value do
-      existing = Map.get(flags, flag_atom, [])
-      Map.put(flags, flag_atom, existing ++ [value])
+    if flag_atom in Map.get(spec, :multi_value, []) do
+      Map.put(flags, flag_atom, Map.get(flags, flag_atom, []) ++ [value])
     else
       Map.put(flags, flag_atom, value)
     end

--- a/lib/just_bash/flag_parser.ex
+++ b/lib/just_bash/flag_parser.ex
@@ -8,23 +8,37 @@ defmodule JustBash.FlagParser do
   - Value flags: `-n 10`, `-d ","` (flag that takes next argument)
   - Stop parsing at `--`
 
+  A flag the spec does not describe is an error, never an operand. Demoting it
+  turned `sort -Q file` into a read of a file named `-Q`, which sort reports as
+  nothing at all: empty stdout, empty stderr, exit 0. Callers get
+  `{:error, {:unknown_flag, flag}}` and report it with `format_error/3`.
+
   ## Usage
 
       # Define your flag spec
       spec = %{
         boolean: [:a, :l, :v, :r],
         value: [:n, :d],
+        integer: [:n],
         defaults: %{a: false, l: false, v: false, r: false, n: 10, d: nil}
       }
 
       # Parse arguments
-      {flags, rest} = FlagParser.parse(args, spec)
+      case FlagParser.parse(args, spec) do
+        {:ok, flags, rest} -> ...
+        {:error, reason} -> FlagParser.format_error("ls", reason, @usage)
+      end
 
   ## Flag Specification
 
   - `:boolean` - List of single-character atoms for boolean flags
   - `:value` - List of single-character atoms for flags that take a value
   - `:defaults` - Map of default values for all flags
+  - `:aliases` - Map of flag string to atom, for spellings that are not the
+    atom itself (`"R" => :r`, `"-recursive" => :r`)
+  - `:multi_value` - Value flags that accumulate a list instead of overwriting
+  - `:integer` - Value flags whose value is a count. Only these are converted;
+    everything else stays a string, so `sort -t 1` is the delimiter `"1"`
   """
 
   @type flag_spec :: %{
@@ -32,39 +46,77 @@ defmodule JustBash.FlagParser do
           :value => [atom()],
           :defaults => map(),
           optional(:aliases) => map(),
-          optional(:multi_value) => [atom()]
+          optional(:multi_value) => [atom()],
+          optional(:integer) => [atom()]
         }
 
-  @type parse_result :: {map(), [String.t()]}
+  @type error :: {:unknown_flag, String.t()} | {:missing_value, String.t()}
+
+  @type parse_result :: {:ok, map(), [String.t()]} | {:error, error()}
 
   @doc """
   Parse command-line arguments according to the given flag specification.
 
-  Returns a tuple of `{flags, remaining_args}` where:
+  Returns `{:ok, flags, remaining_args}` where:
   - `flags` is a map containing all flag values
   - `remaining_args` is a list of non-flag arguments
 
+  Returns `{:error, reason}` for the first argument that is flag-shaped but not
+  in the spec, or for a value flag with nothing after it.
+
   ## Examples
 
-      iex> spec = %{boolean: [:a, :l], value: [:n], defaults: %{a: false, l: false, n: 10}}
+      iex> spec = %{boolean: [:a, :l], value: [:n], integer: [:n], defaults: %{a: false, l: false, n: 10}}
       iex> FlagParser.parse(["-a", "-n", "5", "file.txt"], spec)
-      {%{a: true, l: false, n: 5}, ["file.txt"]}
+      {:ok, %{a: true, l: false, n: 5}, ["file.txt"]}
 
       iex> spec = %{boolean: [:a, :l], value: [], defaults: %{a: false, l: false}}
       iex> FlagParser.parse(["-al", "dir"], spec)
-      {%{a: true, l: true}, ["dir"]}
+      {:ok, %{a: true, l: true}, ["dir"]}
+
+      iex> spec = %{boolean: [:a, :l], value: [], defaults: %{a: false, l: false}}
+      iex> FlagParser.parse(["-Q", "dir"], spec)
+      {:error, {:unknown_flag, "Q"}}
   """
   @spec parse([String.t()], flag_spec()) :: parse_result()
   def parse(args, spec) do
     do_parse(args, spec, spec.defaults, [])
   end
 
+  @doc """
+  Render a `parse/2` error the way GNU coreutils words it, followed by `usage`.
+
+  A short option is named by its character and a long option in full, because
+  that is the unit that was rejected — `-laQ` is a bad `Q`, and
+  `invalid option -- '-'` for `--nope` identifies nothing.
+
+  ## Examples
+
+      iex> FlagParser.format_error("sort", {:unknown_flag, "Q"}, "")
+      "sort: invalid option -- 'Q'\\n"
+
+      iex> FlagParser.format_error("sort", {:unknown_flag, "--nope"}, "")
+      "sort: unrecognized option '--nope'\\n"
+  """
+  @spec format_error(String.t(), error(), String.t()) :: String.t()
+  def format_error(command, {:unknown_flag, "--" <> _ = flag}, usage),
+    do: "#{command}: unrecognized option '#{flag}'\n" <> usage
+
+  def format_error(command, {:unknown_flag, flag}, usage),
+    do: "#{command}: invalid option -- '#{flag}'\n" <> usage
+
+  def format_error(command, {:missing_value, "--" <> _ = flag}, usage),
+    do: "#{command}: option '#{flag}' requires an argument\n" <> usage
+
+  def format_error(command, {:missing_value, flag}, usage),
+    do: "#{command}: option requires an argument -- '#{flag}'\n" <> usage
+
   defp do_parse([], _spec, flags, rest) do
-    {flags, Enum.reverse(rest)}
+    {:ok, flags, Enum.reverse(rest)}
   end
 
   defp do_parse(["--" | remaining], _spec, flags, rest) do
-    {flags, Enum.reverse(rest) ++ remaining}
+    {:ok, flags, Enum.reverse(rest) ++ remaining}
   end
 
   defp do_parse(["-" <> flag_str | remaining], spec, flags, rest) when flag_str != "" do
@@ -72,8 +124,8 @@ defmodule JustBash.FlagParser do
       {:ok, new_flags, new_remaining} ->
         do_parse(new_remaining, spec, new_flags, rest)
 
-      :not_a_flag ->
-        do_parse(remaining, spec, flags, ["-" <> flag_str | rest])
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -90,43 +142,30 @@ defmodule JustBash.FlagParser do
       flag_atom in spec.boolean ->
         {:ok, Map.put(flags, flag_atom, true), remaining}
 
-      flag_atom in spec.value ->
-        case remaining do
-          [value | rest] ->
-            parsed_value = parse_value(value)
-            {:ok, put_flag(flags, flag_atom, parsed_value, spec), rest}
-
-          [] ->
-            :not_a_flag
-        end
-
-      flag_atom in Map.get(spec, :multi_value, []) ->
-        case remaining do
-          [value | rest] ->
-            parsed_value = parse_value(value)
-            {:ok, put_flag(flags, flag_atom, parsed_value, spec), rest}
-
-          [] ->
-            :not_a_flag
-        end
+      flag_atom in spec.value or flag_atom in Map.get(spec, :multi_value, []) ->
+        take_value(flag_atom, flag_str, remaining, spec, flags)
 
       String.length(flag_str) > 1 ->
         combined_lookup = Map.merge(lookup, aliases)
 
-        case try_attached_value_flag(flag_str, spec, flags, combined_lookup) do
-          {:ok, new_flags} ->
-            {:ok, new_flags, remaining}
-
-          :error ->
-            case parse_combined_flags(flag_str, spec, flags, combined_lookup) do
-              {:ok, new_flags} -> {:ok, new_flags, remaining}
-              :error -> try_numeric_flag(flag_str, remaining, spec, flags)
-            end
+        with :error <- try_attached_value_flag(flag_str, spec, flags, combined_lookup),
+             :error <- parse_combined_flags(flag_str, spec, flags, combined_lookup) do
+          try_numeric_flag(flag_str, remaining, spec, flags)
+        else
+          {:ok, new_flags} -> {:ok, new_flags, remaining}
         end
 
       true ->
         try_numeric_flag(flag_str, remaining, spec, flags)
     end
+  end
+
+  defp take_value(flag_atom, _flag_str, [value | rest], spec, flags) do
+    {:ok, put_flag(flags, flag_atom, parse_value(value, flag_atom, spec), spec), rest}
+  end
+
+  defp take_value(_flag_atom, flag_str, [], _spec, _flags) do
+    {:error, {:missing_value, display_flag(flag_str)}}
   end
 
   defp try_attached_value_flag(flag_str, spec, flags, lookup) do
@@ -135,8 +174,7 @@ defmodule JustBash.FlagParser do
     multi_value = Map.get(spec, :multi_value, [])
 
     if flag_atom != nil and (flag_atom in spec.value or flag_atom in multi_value) and rest != "" do
-      parsed_value = parse_value(rest)
-      {:ok, put_flag(flags, flag_atom, parsed_value, spec)}
+      {:ok, put_flag(flags, flag_atom, parse_value(rest, flag_atom, spec), spec)}
     else
       :error
     end
@@ -158,18 +196,35 @@ defmodule JustBash.FlagParser do
   end
 
   defp try_numeric_flag(flag_str, remaining, spec, flags) do
-    if :n in spec.value do
-      case Integer.parse(flag_str) do
-        {num, ""} ->
-          {:ok, Map.put(flags, :n, num), remaining}
-
-        _ ->
-          :not_a_flag
-      end
+    with true <- :n in spec.value,
+         {num, ""} <- Integer.parse(flag_str) do
+      {:ok, Map.put(flags, :n, num), remaining}
     else
-      :not_a_flag
+      _ -> unknown_flag(flag_str, spec)
     end
   end
+
+  defp unknown_flag("-" <> _ = long_flag_str, _spec) do
+    {:error, {:unknown_flag, display_flag(long_flag_str)}}
+  end
+
+  # Out of a cluster, getopt stops on the first character the spec does not
+  # describe as a boolean flag, so that is what is named — not the cluster.
+  defp unknown_flag(flag_str, spec) do
+    lookup = Map.merge(flag_lookup(spec), Map.get(spec, :aliases, %{}))
+
+    offender =
+      flag_str
+      |> String.graphemes()
+      |> Enum.find(flag_str, fn char -> Map.get(lookup, char) not in spec.boolean end)
+
+    {:error, {:unknown_flag, offender}}
+  end
+
+  # `parse/2` sees one leading `-` already stripped, so a long option arrives
+  # here still carrying the second one.
+  defp display_flag("-" <> _ = long_flag_str), do: "-" <> long_flag_str
+  defp display_flag(short_flag_str), do: short_flag_str
 
   defp put_flag(flags, flag_atom, value, spec) do
     multi_value = Map.get(spec, :multi_value, [])
@@ -182,9 +237,13 @@ defmodule JustBash.FlagParser do
     end
   end
 
-  defp parse_value(value) do
-    case Integer.parse(value) do
-      {num, ""} -> num
+  # Only a flag declared `:integer` is a count. Coercing every value that looks
+  # like one made `sort -t 1` a delimiter of `1` rather than `"1"`.
+  defp parse_value(value, flag_atom, spec) do
+    with true <- flag_atom in Map.get(spec, :integer, []),
+         {num, ""} <- Integer.parse(value) do
+      num
+    else
       _ -> value
     end
   end

--- a/test/commands/text_processing_test.exs
+++ b/test/commands/text_processing_test.exs
@@ -1,6 +1,8 @@
 defmodule JustBash.Commands.TextProcessingTest do
   use ExUnit.Case, async: true
 
+  alias JustBash.FS.Memory
+
   describe "cat command" do
     test "cat reads file content" do
       bash = JustBash.new(files: %{"/test.txt" => "hello world"})
@@ -943,17 +945,27 @@ defmodule JustBash.Commands.TextProcessingTest do
     # is `cannot read:`, while a directory - which opens fine and only fails
     # once sort reads it - is `read failed:`. Collapsing both onto the ENOENT
     # wording told the caller a path that exists does not, which is a worse
-    # answer than the exit code alone. Checked against GNU coreutils 9 gsort;
-    # the whole table is asserted at once so a fourth error kind cannot arrive
-    # wearing the wrong template.
+    # answer than the exit code alone. Checked against GNU coreutils 9 gsort.
+    #
+    # "Every way" is asserted, not claimed: the test below this one derives
+    # the set of error kinds from the compiled beams and fails unless each
+    # one is either a row here or listed in @kinds_read_file_cannot_return
+    # with the reason it cannot reach sort. Hand-counting is what let :eloop
+    # go missing from a table whose whole point was to be closed.
     @unreadable_operands [
       {:enoent, "/nope", "sort: cannot read: /nope: No such file or directory\n"},
       {:eisdir, "/d", "sort: read failed: /d: Is a directory\n"},
-      {:enotdir, "/file.txt/sub", "sort: cannot read: /file.txt/sub: Not a directory\n"}
+      {:enotdir, "/file.txt/sub", "sort: cannot read: /file.txt/sub: Not a directory\n"},
+      {:eloop, "/loopa", "sort: cannot read: /loopa: Too many levels of symbolic links\n"}
     ]
+
+    # A two-hop cycle. Resolution bounces /loopa -> /loopb -> /loopa until the
+    # symlink budget is spent, which is the only way an operand reaches :eloop.
+    @symlink_cycle "ln -s /loopb /loopa; ln -s /loopa /loopb"
 
     test "an operand sort cannot read is named with the reason it could not be read" do
       bash = JustBash.new(files: %{"/file.txt" => "b\na\n", "/d/inner" => "x\n"})
+      {_, bash} = JustBash.exec(bash, @symlink_cycle)
 
       observed =
         Map.new(@unreadable_operands, fn {kind, path, _} ->
@@ -964,6 +976,48 @@ defmodule JustBash.Commands.TextProcessingTest do
       expected = Map.new(@unreadable_operands, fn {kind, _, msg} -> {kind, {2, "", msg}} end)
 
       assert observed == expected
+    end
+
+    # The kinds that exist but cannot come back from `FS.read_file/2`, each
+    # with what does produce it. Listed rather than dropped: an absent kind
+    # is indistinguishable from a kind nobody thought about.
+    @kinds_read_file_cannot_return %{
+      eexist: "mkdir/symlink/link refusing a name that is already taken",
+      enotempty: "rmdir on a directory that still has entries",
+      eacces: "Memory.link/3 hard-linking a non-file; no read path consults mode bits",
+      erofs: "a read-only mount, which this FS has no way to declare",
+      enotsup: "the POSIX shim's symlink/link stubs on backends that have neither",
+      einval:
+        "readlink on a non-symlink, and the backend's one computed-kind Error.new/2, " <>
+          "which forwards a VFS.StreamOptions rejection - read_file/2 passes no options",
+      exdev: "a rename that crosses a mount boundary",
+      eio: "strerror names it for completeness; no backend here constructs it"
+    }
+
+    test "the unreadable-operand table accounts for every error kind that exists" do
+      backend = VFS.Mountable.impl_for!(Memory.new(%{}))
+      constructed = Enum.flat_map([Memory, backend], &error_new_kind_arguments/1)
+
+      # Every `Error.new/2` in the backend names its kind literally but one:
+      # `stream_read/3` forwards whatever `VFS.StreamOptions` rejected, which is
+      # the `:einval` @kinds_read_file_cannot_return excuses. A second such call
+      # site would be a kind reading the beam cannot see, so it fails here
+      # rather than quietly shrinking what the rest of this test checks.
+      assert Enum.count(constructed, &(&1 == :computed_at_runtime)) == 1
+
+      universe =
+        MapSet.new(strerror_kinds() ++ Enum.reject(constructed, &(&1 == :computed_at_runtime)))
+
+      tabled = MapSet.new(@unreadable_operands, fn {kind, _, _} -> kind end)
+      accounted = MapSet.new(Map.keys(@kinds_read_file_cannot_return))
+
+      assert MapSet.disjoint?(tabled, accounted),
+             "a kind cannot be both exercised and excused: " <>
+               inspect(MapSet.intersection(tabled, accounted))
+
+      assert MapSet.union(tabled, accounted) == universe,
+             "unaccounted: #{inspect(MapSet.difference(universe, MapSet.union(tabled, accounted)))}, " <>
+               "stale: #{inspect(MapSet.difference(MapSet.union(tabled, accounted), universe))}"
     end
   end
 
@@ -1406,5 +1460,51 @@ defmodule JustBash.Commands.TextProcessingTest do
       assert result.exit_code == 1
       assert result.stderr =~ "invalid tab size"
     end
+  end
+
+  # Two derivations of "the error kinds that exist", both read out of the
+  # compiled beams rather than transcribed, so neither can drift silently:
+  # the kinds `FS.strerror/1` has a message for, and the kinds the memory
+  # backend constructs. Adding a clause to either shows up as a failing
+  # assertion in "the unreadable-operand table accounts for every error kind
+  # that exists" instead of as a row nobody noticed was missing.
+
+  # The literal atoms in `FS.strerror/1`'s clause heads. The `%Error{}` head
+  # and the `is_atom/1` catch-all are not literals and drop out.
+  defp strerror_kinds do
+    for {:function, _anno, :strerror, 1, clauses} <- abstract_code(JustBash.FS),
+        {:clause, _clause_anno, [{:atom, _atom_anno, kind}], _guards, _body} <- clauses,
+        do: kind
+  end
+
+  # Every first argument `module` hands `VFS.Error.new/2`: the atom itself
+  # where the call names its kind literally, `:computed_at_runtime` where it
+  # forwards a value.
+  defp error_new_kind_arguments(module) do
+    module |> abstract_code() |> collect_error_new_kinds()
+  end
+
+  defp collect_error_new_kinds(
+         {:call, _anno, {:remote, _, {:atom, _, VFS.Error}, {:atom, _, :new}}, [kind | rest]}
+       ) do
+    [kind_argument(kind) | collect_error_new_kinds(rest)]
+  end
+
+  defp collect_error_new_kinds(forms) when is_list(forms),
+    do: Enum.flat_map(forms, &collect_error_new_kinds/1)
+
+  defp collect_error_new_kinds(form) when is_tuple(form),
+    do: form |> Tuple.to_list() |> collect_error_new_kinds()
+
+  defp collect_error_new_kinds(_leaf), do: []
+
+  defp kind_argument({:atom, _anno, kind}), do: kind
+  defp kind_argument(_forwarded), do: :computed_at_runtime
+
+  defp abstract_code(module) do
+    {:ok, {_module, [abstract_code: {:raw_abstract_v1, forms}]}} =
+      module |> :code.which() |> :beam_lib.chunks([:abstract_code])
+
+    forms
   end
 end

--- a/test/commands/text_processing_test.exs
+++ b/test/commands/text_processing_test.exs
@@ -937,6 +937,34 @@ defmodule JustBash.Commands.TextProcessingTest do
       {result, _} = JustBash.exec(bash, "sort -k1,1nr -k2,2 /data.txt")
       assert result.stdout == "3 date\n2 apple\n2 cherry\n1 banana\n"
     end
+
+    # Every way an operand can fail to be read, and the diagnostic GNU sort
+    # prints for it. coreutils uses two templates, not one: the open failure
+    # is `cannot read:`, while a directory - which opens fine and only fails
+    # once sort reads it - is `read failed:`. Collapsing both onto the ENOENT
+    # wording told the caller a path that exists does not, which is a worse
+    # answer than the exit code alone. Checked against GNU coreutils 9 gsort;
+    # the whole table is asserted at once so a fourth error kind cannot arrive
+    # wearing the wrong template.
+    @unreadable_operands [
+      {:enoent, "/nope", "sort: cannot read: /nope: No such file or directory\n"},
+      {:eisdir, "/d", "sort: read failed: /d: Is a directory\n"},
+      {:enotdir, "/file.txt/sub", "sort: cannot read: /file.txt/sub: Not a directory\n"}
+    ]
+
+    test "an operand sort cannot read is named with the reason it could not be read" do
+      bash = JustBash.new(files: %{"/file.txt" => "b\na\n", "/d/inner" => "x\n"})
+
+      observed =
+        Map.new(@unreadable_operands, fn {kind, path, _} ->
+          {result, _} = JustBash.exec(bash, "sort #{path}")
+          {kind, {result.exit_code, result.stdout, result.stderr}}
+        end)
+
+      expected = Map.new(@unreadable_operands, fn {kind, _, msg} -> {kind, {2, "", msg}} end)
+
+      assert observed == expected
+    end
   end
 
   describe "uniq command" do

--- a/test/commands/unknown_flags_test.exs
+++ b/test/commands/unknown_flags_test.exs
@@ -102,6 +102,45 @@ defmodule JustBash.Commands.UnknownFlagsTest do
       assert result.stderr =~ "sort: invalid option -- 'Q'\n"
     end
 
+    # getopt lets a cluster of booleans end in a value flag, so `-nk2` is
+    # `-n -k 2`. Rejecting the cluster named `k`, a flag sort implements, and
+    # sent the caller after a problem that was not there.
+    test "a cluster ending in an implemented value flag is not an unknown flag" do
+      bash = JustBash.new(files: %{"/f.txt" => "b 2\na 1\n"})
+      {result, _} = JustBash.exec(bash, "sort -nk2 /f.txt")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert result.stdout == "a 1\nb 2\n"
+    end
+
+    test "a cluster whose value flag carries its own argument sorts by that key" do
+      bash = JustBash.new(files: %{"/f.txt" => "a:2\nb:1\n"})
+      {result, _} = JustBash.exec(bash, "sort -rt: -k2 /f.txt")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert result.stdout == "a:2\nb:1\n"
+    end
+
+    test "a value flag that ends a cluster takes the next argument" do
+      bash = JustBash.new(files: %{"/f.txt" => "a 2\nb 1\n"})
+      {result, _} = JustBash.exec(bash, "sort -rk 2 /f.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == "a 2\nb 1\n"
+    end
+
+    # The character named out of a cluster has to be one the command really
+    # does not have.
+    test "a cluster is reported by a character the command does not implement" do
+      bash = JustBash.new(files: %{"/f.txt" => "b 2\na 1\n"})
+      {result, _} = JustBash.exec(bash, "sort -nQk2 /f.txt")
+
+      assert result.exit_code == 2
+      assert result.stderr =~ "sort: invalid option -- 'Q'\n"
+    end
+
     # A long option is named in full: `invalid option -- '-'` identifies nothing.
     test "an unknown long option is named in full" do
       {result, _} = JustBash.exec(bash(), "sort --jb-not-a-flag /f.txt")

--- a/test/commands/unknown_flags_test.exs
+++ b/test/commands/unknown_flags_test.exs
@@ -232,6 +232,60 @@ defmodule JustBash.Commands.UnknownFlagsTest do
     end
   end
 
+  # `head -n abc` used to reach Enum.take/2 with a binary and raise a
+  # FunctionClauseError straight out of JustBash.exec/2, and `head -c xy`
+  # quietly printed the whole file. A flag declared :integer is a count.
+  describe "a count that is not a number" do
+    test "head rejects a non-numeric line count the way GNU words it" do
+      {result, _} = JustBash.exec(bash(), "head -n abc /f.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "head: invalid number of lines: 'abc'\n"
+    end
+
+    # `-nq` is `-n q`: an unimplemented head flag clustered after a value flag
+    # is that flag's argument, and it is not a number.
+    test "head rejects a cluster whose attached count is not a number" do
+      {result, _} = JustBash.exec(bash(), "head -nq /f.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "head: invalid number of lines: 'q'\n"
+    end
+
+    test "head rejects an empty count" do
+      {result, _} = JustBash.exec(bash(), "head -n '' /f.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "head: invalid number of lines: ''\n"
+    end
+
+    test "head rejects a non-numeric byte count instead of printing everything" do
+      {result, _} = JustBash.exec(bash(), "head -c xy /f.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "head: invalid number of bytes: 'xy'\n"
+    end
+
+    test "tail rejects a non-numeric line count" do
+      {result, _} = JustBash.exec(bash(), "tail -n abc /f.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "tail: invalid number of lines: 'abc'\n"
+    end
+
+    test "a count that is a number is still a count" do
+      {result, _} = JustBash.exec(bash(), "head -n 2 /f.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == "a\nb\n"
+    end
+  end
+
   describe "flag values are not coerced" do
     # `parse_value/1` used to turn every integer-looking value into an integer,
     # so `sort -t 1` handed String.split/2 the number 1 and crashed the shell.

--- a/test/commands/unknown_flags_test.exs
+++ b/test/commands/unknown_flags_test.exs
@@ -230,6 +230,37 @@ defmodule JustBash.Commands.UnknownFlagsTest do
       assert result.exit_code == 0
       assert result.stdout == "a_b\n"
     end
+
+    # Translating needs two sets. One set and no -d/-s used to fall past every
+    # `run/2` head into the catch-all that answers "", so `tr -- -d` reported
+    # success with the input silently dropped - the failure this file exists
+    # to keep out.
+    test "one set with nothing to translate to is a missing operand" do
+      {result, _} = JustBash.exec(bash(), "echo abc | tr -- -d")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+
+      assert result.stderr ==
+               "tr: missing operand after '-d'\n" <>
+                 "Two strings must be given when translating.\n" <>
+                 "Try 'tr --help' for more information.\n"
+    end
+
+    test "one ordinary set with nothing to translate to is a missing operand" do
+      {result, _} = JustBash.exec(bash(), "echo abc | tr x")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr =~ "tr: missing operand after 'x'\n"
+    end
+
+    test "one set is enough when it is being deleted" do
+      {result, _} = JustBash.exec(bash(), "echo abc | tr -d b")
+
+      assert result.exit_code == 0
+      assert result.stdout == "ac\n"
+    end
   end
 
   # `head -n abc` used to reach Enum.take/2 with a binary and raise a

--- a/test/commands/unknown_flags_test.exs
+++ b/test/commands/unknown_flags_test.exs
@@ -406,19 +406,29 @@ defmodule JustBash.Commands.UnknownFlagsTest do
     # whole, so a new command cannot join the registry without being classified
     # and a command cannot change category unnoticed.
     #
-    #   :strict   - non-zero exit with a diagnostic on stderr. What every
-    #               option-parsing command should do.
-    #   :quiet    - non-zero exit with no diagnostic. These three parse no
-    #               options at all; bash is equally silent.
-    #   :operand  - exit 0 is correct: bash also treats the argument as data.
-    #               `echo -Z` prints `-Z`, `test -Z` is a non-empty string.
-    #   :absorbed - STILL WRONG. Exits 0 with the flag ignored, exactly the way
-    #               `sort -Q` did. These are the hand-rolled `parse_args`
-    #               commands that issue #68 explicitly defers migrating onto
-    #               FlagParser (migrating first would have spread the bug, not
-    #               fixed it). Listed by name so the list can only shrink.
+    #   :strict    - non-zero exit, nothing on stdout, and a diagnostic that
+    #                names the *option*. What every option-parsing command
+    #                should do, and the only category that certifies the fix:
+    #                a non-zero exit alone does not, because `ls -Z`, `head -Z`,
+    #                `tail -Z` and `cp -Z` all exited non-zero before this
+    #                change too - by demoting the flag and then failing to open
+    #                the file it named.
+    #   :misblamed - STILL WRONG. Non-zero exit, but the diagnostic is about a
+    #                file the flag was turned into rather than about the flag.
+    #                `cat -Z /f.txt` says `cat: -Z: No such file or directory`
+    #                and prints the file anyway; GNU says
+    #                `cat: invalid option -- 'Z'` and prints nothing.
+    #   :quiet     - non-zero exit with no diagnostic. These three parse no
+    #                options at all; bash is equally silent.
+    #   :operand   - exit 0 is correct: bash also treats the argument as data.
+    #                `echo -Z` prints `-Z`, `test -Z` is a non-empty string.
+    #   :absorbed  - STILL WRONG. Exits 0 with the flag ignored, exactly the way
+    #                `sort -Q` did. These are the hand-rolled `parse_args`
+    #                commands that issue #68 explicitly defers migrating onto
+    #                FlagParser (migrating first would have spread the bug, not
+    #                fixed it). Listed by name so the list can only shrink.
     @classification %{
-      "." => :strict,
+      "." => :misblamed,
       ":" => :operand,
       "[" => :absorbed,
       "arch" => :absorbed,
@@ -426,15 +436,15 @@ defmodule JustBash.Commands.UnknownFlagsTest do
       "base64" => :strict,
       "basename" => :absorbed,
       "break" => :absorbed,
-      "cat" => :strict,
-      "cd" => :strict,
-      "chmod" => :strict,
-      "chown" => :strict,
+      "cat" => :misblamed,
+      "cd" => :misblamed,
+      "chmod" => :misblamed,
+      "chown" => :misblamed,
       "comm" => :strict,
-      "command" => :strict,
+      "command" => :misblamed,
       "continue" => :absorbed,
       "cp" => :strict,
-      "curl" => :strict,
+      "curl" => :misblamed,
       "cut" => :strict,
       "date" => :strict,
       "declare" => :absorbed,
@@ -443,51 +453,51 @@ defmodule JustBash.Commands.UnknownFlagsTest do
       "du" => :strict,
       "echo" => :operand,
       "env" => :strict,
-      "eval" => :strict,
+      "eval" => :misblamed,
       "exit" => :quiet,
       "expand" => :strict,
       "export" => :absorbed,
       "false" => :quiet,
       "file" => :strict,
-      "find" => :strict,
+      "find" => :misblamed,
       "fold" => :strict,
-      "getopts" => :strict,
+      "getopts" => :misblamed,
       "grep" => :strict,
       "head" => :strict,
       "hostname" => :absorbed,
       "id" => :absorbed,
-      "jq" => :strict,
-      "ln" => :strict,
+      "jq" => :misblamed,
+      "ln" => :misblamed,
       "local" => :absorbed,
       "ls" => :strict,
-      "markdown" => :strict,
-      "md" => :strict,
+      "markdown" => :misblamed,
+      "md" => :misblamed,
       "md5sum" => :strict,
       "mkdir" => :absorbed,
       "mktemp" => :absorbed,
-      "mv" => :strict,
+      "mv" => :misblamed,
       "nl" => :strict,
       "nproc" => :absorbed,
-      "od" => :strict,
+      "od" => :misblamed,
       "paste" => :strict,
       "printenv" => :absorbed,
       "printf" => :absorbed,
       "pwd" => :absorbed,
       "read" => :quiet,
       "readlink" => :strict,
-      "realpath" => :strict,
+      "realpath" => :misblamed,
       "return" => :absorbed,
       "rev" => :absorbed,
-      "rm" => :strict,
+      "rm" => :misblamed,
       "sed" => :strict,
-      "seq" => :strict,
+      "seq" => :misblamed,
       "set" => :strict,
-      "sha256sum" => :strict,
-      "shasum" => :strict,
-      "shift" => :strict,
+      "sha256sum" => :misblamed,
+      "shasum" => :misblamed,
+      "shift" => :misblamed,
       "sleep" => :absorbed,
       "sort" => :strict,
-      "source" => :strict,
+      "source" => :misblamed,
       "stat" => :strict,
       "tac" => :absorbed,
       "tail" => :strict,
@@ -495,20 +505,20 @@ defmodule JustBash.Commands.UnknownFlagsTest do
       "test" => :operand,
       "touch" => :absorbed,
       "tr" => :strict,
-      "trap" => :strict,
+      "trap" => :misblamed,
       "tree" => :strict,
       "true" => :operand,
-      "type" => :strict,
+      "type" => :misblamed,
       "typeset" => :absorbed,
       "uname" => :absorbed,
       "uniq" => :strict,
       "unset" => :absorbed,
-      "wc" => :strict,
-      "wget" => :strict,
+      "wc" => :misblamed,
+      "wget" => :misblamed,
       "which" => :strict,
       "whoami" => :absorbed,
       "xargs" => :strict,
-      "xxd" => :strict,
+      "xxd" => :misblamed,
       "yes" => :operand
     }
 
@@ -533,6 +543,15 @@ defmodule JustBash.Commands.UnknownFlagsTest do
       end
     end
 
+    # Every command the seven FlagParser callers cover has to be :strict, and
+    # naming them here means the matrix cannot certify the fix by accident:
+    # four of these exited non-zero before the fix as well.
+    test "every command on the shared flag parser rejects the flag itself" do
+      for name <- ~w(cp grep head ls sort tail uniq tr) do
+        assert @classification[name] == :strict
+      end
+    end
+
     # :operand and :absorbed are the same observation - the command exits 0 -
     # and differ only in whether that is correct. The distinction is carried by
     # the table above so that fixing an :absorbed command forces an edit here.
@@ -550,14 +569,23 @@ defmodule JustBash.Commands.UnknownFlagsTest do
       end
     end
 
+    # A non-zero exit is not evidence that the flag was rejected: demoting it to
+    # a filename and failing to open that file exits non-zero too, and leaves
+    # the command's real output on stdout. Only a command that says nothing on
+    # stdout and names the option in its diagnostic has actually rejected it.
     defp probe(name, flag) do
       {result, _} = JustBash.exec(bash(), "#{name} #{flag}")
 
       cond do
         result.exit_code == 0 -> :exit_zero
         result.stderr == "" -> :quiet
-        true -> :strict
+        rejected_the_option?(result) -> :strict
+        true -> :misblamed
       end
+    end
+
+    defp rejected_the_option?(result) do
+      result.stdout == "" and result.stderr =~ ~r/(invalid|unrecognized|illegal) option/
     end
   end
 end

--- a/test/commands/unknown_flags_test.exs
+++ b/test/commands/unknown_flags_test.exs
@@ -1,0 +1,377 @@
+defmodule JustBash.Commands.UnknownFlagsTest do
+  @moduledoc """
+  A flag a command does not implement must be reported, never absorbed.
+
+  Absorbing it is the worst available failure: `sort -Q file` used to treat
+  `-Q` as a filename, read nothing, and exit 0, so the caller was told the
+  empty result was the file's sorted contents.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.Commands.Registry
+
+  defp bash, do: JustBash.new(files: %{"/f.txt" => "a\nb\nc\n"})
+
+  describe "commands sharing JustBash.FlagParser" do
+    # The exact pair from issue #68, checked against GNU coreutils 9: both name
+    # the offending character and point at --help, and sort exits 2 where uniq
+    # exits 1. Only grep prints a Usage line on a bad option; coreutils does not.
+    test "sort reports an unknown short flag instead of returning nothing" do
+      {result, _} = JustBash.exec(bash(), "sort -Q /f.txt")
+
+      assert result.exit_code == 2
+      assert result.stdout == ""
+
+      assert result.stderr ==
+               "sort: invalid option -- 'Q'\nTry 'sort --help' for more information.\n"
+    end
+
+    test "uniq reports an unknown short flag instead of returning nothing" do
+      {result, _} = JustBash.exec(bash(), "uniq -Z /f.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+
+      assert result.stderr ==
+               "uniq: invalid option -- 'Z'\nTry 'uniq --help' for more information.\n"
+    end
+
+    # `-q` is a real GNU head flag that is not implemented here. Rejecting it
+    # names the actual problem; the old message ("cannot open '-q' for
+    # reading") blamed a file that was never on the command line.
+    test "head names the flag, not a file it invented" do
+      {result, _} = JustBash.exec(bash(), "head -q /f.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+
+      assert result.stderr ==
+               "head: invalid option -- 'q'\nTry 'head --help' for more information.\n"
+
+      refute result.stderr =~ "cannot open"
+    end
+
+    test "tail names the flag, not a file it invented" do
+      {result, _} = JustBash.exec(bash(), "tail -q /f.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+
+      assert result.stderr ==
+               "tail: invalid option -- 'q'\nTry 'tail --help' for more information.\n"
+    end
+
+    # `ls -Q` used to exit 1 *and still print the listing*, so the exit code
+    # and the output disagreed about whether the command had run.
+    test "ls rejects an unknown flag without printing a listing" do
+      {result, _} = JustBash.exec(bash(), "ls -Q /")
+
+      assert result.exit_code == 2
+      assert result.stdout == ""
+      assert result.stderr == "ls: invalid option -- 'Q'\nTry 'ls --help' for more information.\n"
+    end
+
+    test "cp rejects an unknown flag before copying anything" do
+      {result, after_bash} = JustBash.exec(bash(), "cp -Z /f.txt /g.txt")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "cp: invalid option -- 'Z'\nTry 'cp --help' for more information.\n"
+
+      {check, _} = JustBash.exec(after_bash, "cat /g.txt")
+      assert check.exit_code == 1
+    end
+
+    test "grep rejects an unknown flag instead of searching for it" do
+      {result, _} = JustBash.exec(bash(), "grep -Z a /f.txt")
+
+      assert result.exit_code == 2
+      assert result.stdout == ""
+
+      assert result.stderr ==
+               "grep: invalid option -- 'Z'\n" <>
+                 "Usage: grep [OPTION]... PATTERNS [FILE]...\n" <>
+                 "Try 'grep --help' for more information.\n"
+    end
+
+    # GNU reports the offending character out of a cluster, not the cluster.
+    test "a cluster is reported by the character that is not implemented" do
+      {result, _} = JustBash.exec(bash(), "sort -rQ /f.txt")
+
+      assert result.exit_code == 2
+      assert result.stderr =~ "sort: invalid option -- 'Q'\n"
+    end
+
+    # A long option is named in full: `invalid option -- '-'` identifies nothing.
+    test "an unknown long option is named in full" do
+      {result, _} = JustBash.exec(bash(), "sort --jb-not-a-flag /f.txt")
+
+      assert result.exit_code == 2
+
+      assert result.stderr ==
+               "sort: unrecognized option '--jb-not-a-flag'\n" <>
+                 "Try 'sort --help' for more information.\n"
+    end
+
+    test "a value flag with nothing after it is a missing argument, not a file" do
+      {result, _} = JustBash.exec(bash(), "head -n")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+
+      assert result.stderr ==
+               "head: option requires an argument -- 'n'\n" <>
+                 "Try 'head --help' for more information.\n"
+    end
+
+    # `--` still ends option parsing, so an option-shaped operand after it is
+    # a filename, not a flag to reject.
+    test "an option-shaped operand after -- is not rejected as a flag" do
+      {result, _} = JustBash.exec(bash(), "sort -- -Q")
+
+      refute result.stderr =~ "invalid option"
+    end
+
+    # A lone `-` is not option-shaped, so it stays an operand. (Reading it as
+    # stdin is a separate gap in sort, untouched here.)
+    test "a lone dash is still an operand" do
+      {result, _} = JustBash.exec(bash(), "printf 'b\\na\\n' | sort -")
+
+      assert result.exit_code == 0
+      refute result.stderr =~ "invalid option"
+    end
+  end
+
+  describe "tr" do
+    test "rejects an unknown character inside a flag cluster" do
+      {result, _} = JustBash.exec(bash(), "echo abc | tr -dX b")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "tr: invalid option -- 'X'\nTry 'tr --help' for more information.\n"
+    end
+
+    test "reports the first unknown character of a cluster" do
+      {result, _} = JustBash.exec(bash(), "echo abc | tr -dQZ b")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "tr: invalid option -- 'Q'\n"
+    end
+
+    # A single unknown character used to fall past the flag clauses and become
+    # one of tr's character sets, so `tr -x b` translated nothing and said so
+    # with exit 0.
+    test "a single unknown flag is not mistaken for a character set" do
+      {result, _} = JustBash.exec(bash(), "echo abc | tr -x b")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "tr: invalid option -- 'x'\nTry 'tr --help' for more information.\n"
+    end
+
+    test "an unknown long option is named in full" do
+      {result, _} = JustBash.exec(bash(), "echo abc | tr --jb-not-a-flag b")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "tr: unrecognized option '--jb-not-a-flag'\n"
+    end
+
+    test "implemented flags still work" do
+      {result, _} = JustBash.exec(bash(), "echo abc | tr -d b")
+
+      assert result.exit_code == 0
+      assert result.stdout == "ac\n"
+    end
+
+    # `-` is not option-shaped on its own, and a set may legitimately contain
+    # characters that look like flags once `--` has ended option parsing.
+    test "a dash is still usable as a character set" do
+      {result, _} = JustBash.exec(bash(), "echo a-b | tr -- '-' '_'")
+
+      assert result.exit_code == 0
+      assert result.stdout == "a_b\n"
+    end
+  end
+
+  describe "flag values are not coerced" do
+    # `parse_value/1` used to turn every integer-looking value into an integer,
+    # so `sort -t 1` handed String.split/2 the number 1 and crashed the shell.
+    test "sort -t takes a one-character delimiter, not a number" do
+      bash = JustBash.new(files: %{"/f.txt" => "b1x\na1y\n"})
+      {result, _} = JustBash.exec(bash, "sort -t 1 -k2 /f.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == "b1x\na1y\n"
+    end
+
+    test "head -n still takes a count" do
+      {result, _} = JustBash.exec(bash(), "head -n 2 /f.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == "a\nb\n"
+    end
+  end
+
+  describe "the whole registry" do
+    @probe_flags ["--jb-not-a-flag", "-Z"]
+
+    # Every name in `Commands.Registry`, classified by what it does with a flag
+    # it does not implement. The table is compared to observed behaviour as a
+    # whole, so a new command cannot join the registry without being classified
+    # and a command cannot change category unnoticed.
+    #
+    #   :strict   - non-zero exit with a diagnostic on stderr. What every
+    #               option-parsing command should do.
+    #   :quiet    - non-zero exit with no diagnostic. These three parse no
+    #               options at all; bash is equally silent.
+    #   :operand  - exit 0 is correct: bash also treats the argument as data.
+    #               `echo -Z` prints `-Z`, `test -Z` is a non-empty string.
+    #   :absorbed - STILL WRONG. Exits 0 with the flag ignored, exactly the way
+    #               `sort -Q` did. These are the hand-rolled `parse_args`
+    #               commands that issue #68 explicitly defers migrating onto
+    #               FlagParser (migrating first would have spread the bug, not
+    #               fixed it). Listed by name so the list can only shrink.
+    @classification %{
+      "." => :strict,
+      ":" => :operand,
+      "[" => :absorbed,
+      "arch" => :absorbed,
+      "awk" => :absorbed,
+      "base64" => :strict,
+      "basename" => :absorbed,
+      "break" => :absorbed,
+      "cat" => :strict,
+      "cd" => :strict,
+      "chmod" => :strict,
+      "chown" => :strict,
+      "comm" => :strict,
+      "command" => :strict,
+      "continue" => :absorbed,
+      "cp" => :strict,
+      "curl" => :strict,
+      "cut" => :strict,
+      "date" => :strict,
+      "declare" => :absorbed,
+      "diff" => :strict,
+      "dirname" => :absorbed,
+      "du" => :strict,
+      "echo" => :operand,
+      "env" => :strict,
+      "eval" => :strict,
+      "exit" => :quiet,
+      "expand" => :strict,
+      "export" => :absorbed,
+      "false" => :quiet,
+      "file" => :strict,
+      "find" => :strict,
+      "fold" => :strict,
+      "getopts" => :strict,
+      "grep" => :strict,
+      "head" => :strict,
+      "hostname" => :absorbed,
+      "id" => :absorbed,
+      "jq" => :strict,
+      "ln" => :strict,
+      "local" => :absorbed,
+      "ls" => :strict,
+      "markdown" => :strict,
+      "md" => :strict,
+      "md5sum" => :strict,
+      "mkdir" => :absorbed,
+      "mktemp" => :absorbed,
+      "mv" => :strict,
+      "nl" => :strict,
+      "nproc" => :absorbed,
+      "od" => :strict,
+      "paste" => :strict,
+      "printenv" => :absorbed,
+      "printf" => :absorbed,
+      "pwd" => :absorbed,
+      "read" => :quiet,
+      "readlink" => :strict,
+      "realpath" => :strict,
+      "return" => :absorbed,
+      "rev" => :absorbed,
+      "rm" => :strict,
+      "sed" => :strict,
+      "seq" => :strict,
+      "set" => :strict,
+      "sha256sum" => :strict,
+      "shasum" => :strict,
+      "shift" => :strict,
+      "sleep" => :absorbed,
+      "sort" => :strict,
+      "source" => :strict,
+      "stat" => :strict,
+      "tac" => :absorbed,
+      "tail" => :strict,
+      "tee" => :strict,
+      "test" => :operand,
+      "touch" => :absorbed,
+      "tr" => :strict,
+      "trap" => :strict,
+      "tree" => :strict,
+      "true" => :operand,
+      "type" => :strict,
+      "typeset" => :absorbed,
+      "uname" => :absorbed,
+      "uniq" => :strict,
+      "unset" => :absorbed,
+      "wc" => :strict,
+      "wget" => :strict,
+      "which" => :strict,
+      "whoami" => :absorbed,
+      "xargs" => :strict,
+      "xxd" => :strict,
+      "yes" => :operand
+    }
+
+    test "no command silently accepts a flag it does not implement" do
+      observed = Map.new(Registry.list(), fn name -> {name, classify(name)} end)
+      expected = Map.new(@classification, fn {name, kind} -> {name, observable(kind)} end)
+
+      assert observed == expected
+    end
+
+    # A diagnostic nobody can attribute is barely better than none, so a
+    # rejection has to name the program it came from.
+    test "a rejecting command names itself in the diagnostic" do
+      for {name, :strict} <- @classification, flag <- @probe_flags do
+        {result, _} = JustBash.exec(bash(), "#{name} #{flag}")
+        module = Registry.get(name)
+        canonical = hd(module.names())
+
+        assert String.starts_with?(result.stderr, ["bash: ", "#{name}: ", "#{canonical}: "]),
+               "#{name} #{flag} exited #{result.exit_code} with unattributable stderr " <>
+                 inspect(result.stderr)
+      end
+    end
+
+    # :operand and :absorbed are the same observation - the command exits 0 -
+    # and differ only in whether that is correct. The distinction is carried by
+    # the table above so that fixing an :absorbed command forces an edit here.
+    defp observable(:operand), do: :exit_zero
+    defp observable(:absorbed), do: :exit_zero
+    defp observable(other), do: other
+
+    defp classify(name) do
+      @probe_flags
+      |> Enum.map(&probe(name, &1))
+      |> Enum.uniq()
+      |> case do
+        [single] -> single
+        both -> both
+      end
+    end
+
+    defp probe(name, flag) do
+      {result, _} = JustBash.exec(bash(), "#{name} #{flag}")
+
+      cond do
+        result.exit_code == 0 -> :exit_zero
+        result.stderr == "" -> :quiet
+        true -> :strict
+      end
+    end
+  end
+end

--- a/test/commands/unknown_flags_test.exs
+++ b/test/commands/unknown_flags_test.exs
@@ -164,20 +164,33 @@ defmodule JustBash.Commands.UnknownFlagsTest do
     end
 
     # `--` still ends option parsing, so an option-shaped operand after it is
-    # a filename, not a flag to reject.
-    test "an option-shaped operand after -- is not rejected as a flag" do
+    # a filename, not a flag to reject. It is a filename that does not exist,
+    # and sort has to say so: answering with empty output at exit 0 is the
+    # symptom of issue #68 reappearing one `--` away from the command it quotes.
+    test "an option-shaped operand after -- is read as a file, not rejected as a flag" do
       {result, _} = JustBash.exec(bash(), "sort -- -Q")
 
       refute result.stderr =~ "invalid option"
+      assert result.exit_code == 2
+      assert result.stdout == ""
+      assert result.stderr == "sort: cannot read: -Q: No such file or directory\n"
     end
 
-    # A lone `-` is not option-shaped, so it stays an operand. (Reading it as
-    # stdin is a separate gap in sort, untouched here.)
-    test "a lone dash is still an operand" do
+    test "an operand after -- that does exist is sorted" do
+      {result, _} = JustBash.exec(bash(), "sort -- /f.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == "a\nb\nc\n"
+    end
+
+    # A lone `-` is not option-shaped, so it stays an operand - and the operand
+    # it names is standard input.
+    test "a lone dash is standard input, not a missing file" do
       {result, _} = JustBash.exec(bash(), "printf 'b\\na\\n' | sort -")
 
       assert result.exit_code == 0
-      refute result.stderr =~ "invalid option"
+      assert result.stdout == "a\nb\n"
+      assert result.stderr == ""
     end
   end
 

--- a/test/commands/unknown_flags_test.exs
+++ b/test/commands/unknown_flags_test.exs
@@ -330,6 +330,55 @@ defmodule JustBash.Commands.UnknownFlagsTest do
     end
   end
 
+  # `Try '<cmd> --help' for more information.` is printed by every rejection in
+  # this file. It has to lead somewhere: advising a second command that also
+  # fails is the same dead end issue #68 is about.
+  describe "the advice the diagnostics print" do
+    @flag_parser_commands ~w(cp grep head ls sort tail tr uniq)
+
+    test "--help succeeds on every command that advertises it" do
+      for name <- @flag_parser_commands do
+        {result, _} = JustBash.exec(bash(), "#{name} --help")
+
+        assert result.exit_code == 0, "#{name} --help exited #{result.exit_code}"
+        assert result.stderr == ""
+        assert result.stdout =~ "Usage: #{name} "
+      end
+    end
+
+    test "--help lists the flags the command actually implements" do
+      {result, _} = JustBash.exec(bash(), "sort --help")
+
+      assert result.stdout == """
+             Usage: sort [OPTION]... [FILE]...
+             Options this shell implements:
+               -f
+               -k VALUE
+               -n
+               -r
+               -t VALUE
+               -u
+             """
+    end
+
+    # A flag the command does not implement is still an error after --help
+    # exists, and the advice it prints now names a command that answers.
+    test "an unknown flag still points at a --help that works" do
+      {rejection, _} = JustBash.exec(bash(), "sort -Q /f.txt")
+      assert rejection.stderr =~ "Try 'sort --help' for more information."
+
+      {advice, _} = JustBash.exec(bash(), "sort --help")
+      assert advice.exit_code == 0
+    end
+
+    test "--help after -- is an operand, not a request for help" do
+      {result, _} = JustBash.exec(bash(), "sort -- --help")
+
+      assert result.exit_code == 2
+      assert result.stderr == "sort: cannot read: --help: No such file or directory\n"
+    end
+  end
+
   describe "flag values are not coerced" do
     # `parse_value/1` used to turn every integer-looking value into an integer,
     # so `sort -t 1` handed String.split/2 the number 1 and crashed the shell.

--- a/test/flag_parser_test.exs
+++ b/test/flag_parser_test.exs
@@ -102,6 +102,50 @@ defmodule JustBash.FlagParserTest do
     end
   end
 
+  describe "parse/2 with a cluster containing a value flag" do
+    # getopt lets a value option end a cluster of booleans: `sort -nk2` is
+    # `-n -k 2`. Peeling the attached value off character 0 only made the whole
+    # cluster unknown, and the diagnostic then named `k` - a flag sort has.
+    defp sort_like_spec do
+      %{
+        boolean: [:r, :n, :u],
+        value: [:t],
+        multi_value: [:k],
+        defaults: %{r: false, n: false, u: false, t: nil, k: []}
+      }
+    end
+
+    test "a run of booleans may be followed by a value flag with an attached value" do
+      assert {:ok, %{n: true, k: ["2"]}, []} = FlagParser.parse(["-nk2"], sort_like_spec())
+      assert {:ok, %{r: true, t: ":"}, []} = FlagParser.parse(["-rt:"], sort_like_spec())
+
+      assert {:ok, %{r: true, u: true, k: ["1,1n"]}, ["f"]} =
+               FlagParser.parse(["-ruk1,1n", "f"], sort_like_spec())
+    end
+
+    test "a value flag that ends a cluster takes the next argument" do
+      assert {:ok, %{r: true, k: ["2"]}, ["f"]} =
+               FlagParser.parse(["-rk", "2", "f"], sort_like_spec())
+    end
+
+    test "a value flag that ends a cluster with nothing after it is a missing argument" do
+      assert {:error, {:missing_value, "t"}} = FlagParser.parse(["-rt"], sort_like_spec())
+    end
+
+    # The offender has to be a character the spec does not describe at all.
+    # Naming an implemented flag sends the caller after the wrong problem.
+    test "the character named out of a cluster is one the spec does not have" do
+      assert {:error, {:unknown_flag, "Q"}} = FlagParser.parse(["-nQk2"], sort_like_spec())
+      assert {:error, {:unknown_flag, "Q"}} = FlagParser.parse(["-Qk2"], sort_like_spec())
+    end
+
+    # Everything after the value flag belongs to it, so a character that would
+    # otherwise be unknown is just part of the argument.
+    test "an unknown character inside a value flag's argument is not a flag" do
+      assert {:ok, %{r: true, t: "Q"}, []} = FlagParser.parse(["-rtQ"], sort_like_spec())
+    end
+  end
+
   describe "parse/2 with a flag the spec does not describe" do
     # Demoting the flag to an operand is what made `sort -Q file` read a file
     # named `-Q`, find nothing, and exit 0 with no diagnostic.

--- a/test/flag_parser_test.exs
+++ b/test/flag_parser_test.exs
@@ -194,6 +194,20 @@ defmodule JustBash.FlagParserTest do
 
       assert {:ok, %{a: false}, ["-x"]} = FlagParser.parse(["--", "-x"], spec)
     end
+
+    # `Try '<cmd> --help' for more information.` has to lead somewhere.
+    test "--help is a request for the usage, not an unknown flag" do
+      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
+
+      assert :help = FlagParser.parse(["--help"], spec)
+      assert :help = FlagParser.parse(["-a", "--help", "file"], spec)
+    end
+
+    test "--help after -- is an operand" do
+      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
+
+      assert {:ok, %{a: false}, ["--help"]} = FlagParser.parse(["--", "--help"], spec)
+    end
   end
 
   describe "value coercion" do
@@ -267,6 +281,65 @@ defmodule JustBash.FlagParserTest do
                {:invalid_value, "number of lines", "abc"},
                "usage\n"
              ) == "head: invalid number of lines: 'abc'\n"
+    end
+  end
+
+  describe "help/2" do
+    test "lists every spelling the spec accepts" do
+      spec = %{
+        boolean: [:a, :r],
+        value: [:t],
+        multi_value: [:k],
+        aliases: %{"R" => :r, "-recursive" => :r},
+        defaults: %{a: false, r: false, t: nil, k: []},
+        usage: "demo [OPTION]... [FILE]..."
+      }
+
+      assert FlagParser.help("demo", spec) == """
+             Usage: demo [OPTION]... [FILE]...
+             Options this shell implements:
+               -a
+               -k VALUE
+               -r, -R, --recursive
+               -t VALUE
+             """
+    end
+
+    # `flag_lookup/1` answers to a multi-character atom's own name too, so grep
+    # parses `-with_filename`. That is an artifact, not an option to advertise.
+    test "lists the short spelling of a multi-character flag, not its atom name" do
+      spec = %{
+        boolean: [:with_filename],
+        value: [],
+        aliases: %{"H" => :with_filename},
+        defaults: %{with_filename: false}
+      }
+
+      assert FlagParser.help("demo", spec) == """
+             Usage: demo [OPTION]...
+             Options this shell implements:
+               -H
+             """
+    end
+
+    test "falls back to the atom name when a flag has no other spelling" do
+      spec = %{boolean: [:verbose], value: [], defaults: %{verbose: false}}
+
+      assert FlagParser.help("demo", spec) == """
+             Usage: demo [OPTION]...
+             Options this shell implements:
+               -verbose
+             """
+    end
+
+    test "falls back to a generic synopsis when the spec gives none" do
+      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
+
+      assert FlagParser.help("demo", spec) == """
+             Usage: demo [OPTION]...
+             Options this shell implements:
+               -a
+             """
     end
   end
 end

--- a/test/flag_parser_test.exs
+++ b/test/flag_parser_test.exs
@@ -7,101 +7,198 @@ defmodule JustBash.FlagParserTest do
     test "parses boolean flags" do
       spec = %{boolean: [:a, :l, :v], value: [], defaults: %{a: false, l: false, v: false}}
 
-      assert {%{a: true, l: false, v: false}, []} = FlagParser.parse(["-a"], spec)
-      assert {%{a: false, l: true, v: false}, []} = FlagParser.parse(["-l"], spec)
-      assert {%{a: true, l: true, v: false}, []} = FlagParser.parse(["-a", "-l"], spec)
+      assert {:ok, %{a: true, l: false, v: false}, []} = FlagParser.parse(["-a"], spec)
+      assert {:ok, %{a: false, l: true, v: false}, []} = FlagParser.parse(["-l"], spec)
+      assert {:ok, %{a: true, l: true, v: false}, []} = FlagParser.parse(["-a", "-l"], spec)
     end
 
     test "parses combined boolean flags" do
       spec = %{boolean: [:a, :l, :v], value: [], defaults: %{a: false, l: false, v: false}}
 
-      assert {%{a: true, l: true, v: false}, []} = FlagParser.parse(["-al"], spec)
-      assert {%{a: true, l: true, v: false}, []} = FlagParser.parse(["-la"], spec)
-      assert {%{a: true, l: true, v: true}, []} = FlagParser.parse(["-alv"], spec)
+      assert {:ok, %{a: true, l: true, v: false}, []} = FlagParser.parse(["-al"], spec)
+      assert {:ok, %{a: true, l: true, v: false}, []} = FlagParser.parse(["-la"], spec)
+      assert {:ok, %{a: true, l: true, v: true}, []} = FlagParser.parse(["-alv"], spec)
     end
 
     test "parses value flags" do
-      spec = %{boolean: [], value: [:n, :d], defaults: %{n: 10, d: nil}}
+      spec = %{boolean: [], value: [:n, :d], integer: [:n], defaults: %{n: 10, d: nil}}
 
-      assert {%{n: 5, d: nil}, []} = FlagParser.parse(["-n", "5"], spec)
-      assert {%{n: 10, d: ","}, []} = FlagParser.parse(["-d", ","], spec)
-      assert {%{n: 20, d: ":"}, []} = FlagParser.parse(["-n", "20", "-d", ":"], spec)
+      assert {:ok, %{n: 5, d: nil}, []} = FlagParser.parse(["-n", "5"], spec)
+      assert {:ok, %{n: 10, d: ","}, []} = FlagParser.parse(["-d", ","], spec)
+      assert {:ok, %{n: 20, d: ":"}, []} = FlagParser.parse(["-n", "20", "-d", ":"], spec)
     end
 
     test "parses numeric shorthand for -n" do
-      spec = %{boolean: [], value: [:n], defaults: %{n: 10}}
+      spec = %{boolean: [], value: [:n], integer: [:n], defaults: %{n: 10}}
 
-      assert {%{n: 5}, []} = FlagParser.parse(["-5"], spec)
-      assert {%{n: 20}, ["file.txt"]} = FlagParser.parse(["-20", "file.txt"], spec)
+      assert {:ok, %{n: 5}, []} = FlagParser.parse(["-5"], spec)
+      assert {:ok, %{n: 20}, ["file.txt"]} = FlagParser.parse(["-20", "file.txt"], spec)
     end
 
     test "preserves remaining arguments" do
       spec = %{boolean: [:a, :l], value: [], defaults: %{a: false, l: false}}
 
-      assert {%{a: true, l: false}, ["file.txt"]} = FlagParser.parse(["-a", "file.txt"], spec)
-      assert {%{a: false, l: false}, ["foo", "bar"]} = FlagParser.parse(["foo", "bar"], spec)
+      assert {:ok, %{a: true, l: false}, ["file.txt"]} =
+               FlagParser.parse(["-a", "file.txt"], spec)
 
-      assert {%{a: true, l: true}, ["file1", "file2"]} =
+      assert {:ok, %{a: false, l: false}, ["foo", "bar"]} = FlagParser.parse(["foo", "bar"], spec)
+
+      assert {:ok, %{a: true, l: true}, ["file1", "file2"]} =
                FlagParser.parse(["-a", "file1", "-l", "file2"], spec)
     end
 
     test "stops parsing at --" do
       spec = %{boolean: [:a, :l], value: [], defaults: %{a: false, l: false}}
 
-      assert {%{a: true, l: false}, ["-l", "file"]} =
+      assert {:ok, %{a: true, l: false}, ["-l", "file"]} =
                FlagParser.parse(["-a", "--", "-l", "file"], spec)
 
-      assert {%{a: false, l: false}, ["-a", "-l"]} = FlagParser.parse(["--", "-a", "-l"], spec)
-    end
-
-    test "handles unknown flags as arguments" do
-      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
-
-      assert {%{a: false}, ["-x"]} = FlagParser.parse(["-x"], spec)
-      assert {%{a: true}, ["-unknown"]} = FlagParser.parse(["-a", "-unknown"], spec)
+      assert {:ok, %{a: false, l: false}, ["-a", "-l"]} =
+               FlagParser.parse(["--", "-a", "-l"], spec)
     end
 
     test "handles mixed boolean and value flags" do
       spec = %{
         boolean: [:a, :l, :r],
         value: [:n],
+        integer: [:n],
         defaults: %{a: false, l: false, r: false, n: 10}
       }
 
-      assert {%{a: true, l: true, r: false, n: 5}, ["file"]} =
+      assert {:ok, %{a: true, l: true, r: false, n: 5}, ["file"]} =
                FlagParser.parse(["-al", "-n", "5", "file"], spec)
     end
 
     test "uses default values" do
       spec = %{boolean: [:verbose], value: [:count], defaults: %{verbose: false, count: 42}}
 
-      assert {%{verbose: false, count: 42}, []} = FlagParser.parse([], spec)
+      assert {:ok, %{verbose: false, count: 42}, []} = FlagParser.parse([], spec)
     end
 
     test "handles empty arguments" do
       spec = %{boolean: [:a], value: [:n], defaults: %{a: false, n: 10}}
 
-      assert {%{a: false, n: 10}, []} = FlagParser.parse([], spec)
+      assert {:ok, %{a: false, n: 10}, []} = FlagParser.parse([], spec)
     end
 
     test "handles single dash as argument" do
       spec = %{boolean: [:a], value: [], defaults: %{a: false}}
 
-      assert {%{a: false}, ["-"]} = FlagParser.parse(["-"], spec)
+      assert {:ok, %{a: false}, ["-"]} = FlagParser.parse(["-"], spec)
     end
 
     test "parses sort-style flags" do
       spec = %{boolean: [:r, :u, :n], value: [], defaults: %{r: false, u: false, n: false}}
 
-      assert {%{r: true, u: false, n: true}, []} = FlagParser.parse(["-rn"], spec)
-      assert {%{r: true, u: false, n: true}, []} = FlagParser.parse(["-nr"], spec)
+      assert {:ok, %{r: true, u: false, n: true}, []} = FlagParser.parse(["-rn"], spec)
+      assert {:ok, %{r: true, u: false, n: true}, []} = FlagParser.parse(["-nr"], spec)
     end
 
     test "parses grep-style flags" do
       spec = %{boolean: [:i, :v], value: [], defaults: %{i: false, v: false}}
 
-      assert {%{i: true, v: false}, ["pattern", "file"]} =
+      assert {:ok, %{i: true, v: false}, ["pattern", "file"]} =
                FlagParser.parse(["-i", "pattern", "file"], spec)
+    end
+  end
+
+  describe "parse/2 with a flag the spec does not describe" do
+    # Demoting the flag to an operand is what made `sort -Q file` read a file
+    # named `-Q`, find nothing, and exit 0 with no diagnostic.
+    test "rejects an unknown flag instead of demoting it to an operand" do
+      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
+
+      assert {:error, {:unknown_flag, "x"}} = FlagParser.parse(["-x"], spec)
+      assert {:error, {:unknown_flag, "x"}} = FlagParser.parse(["-a", "-x"], spec)
+    end
+
+    test "names the offending character of a cluster, not the cluster" do
+      spec = %{boolean: [:a, :l], value: [], defaults: %{a: false, l: false}}
+
+      assert {:error, {:unknown_flag, "Q"}} = FlagParser.parse(["-alQ"], spec)
+      assert {:error, {:unknown_flag, "Q"}} = FlagParser.parse(["-Qal"], spec)
+    end
+
+    test "names a long option in full" do
+      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
+
+      assert {:error, {:unknown_flag, "--unknown"}} = FlagParser.parse(["-a", "--unknown"], spec)
+    end
+
+    # `-5` is only a count where `-n` takes one; elsewhere it is a bad option,
+    # the way `sort -5` is.
+    test "rejects a numeric flag when the spec has no -n" do
+      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
+
+      assert {:error, {:unknown_flag, "5"}} = FlagParser.parse(["-5"], spec)
+    end
+
+    test "reports a value flag with nothing after it" do
+      spec = %{boolean: [], value: [:d], defaults: %{d: nil}}
+
+      assert {:error, {:missing_value, "d"}} = FlagParser.parse(["-d"], spec)
+    end
+
+    test "stops at the first bad flag" do
+      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
+
+      assert {:error, {:unknown_flag, "x"}} = FlagParser.parse(["-x", "-y"], spec)
+    end
+
+    test "does not reject an operand after --" do
+      spec = %{boolean: [:a], value: [], defaults: %{a: false}}
+
+      assert {:ok, %{a: false}, ["-x"]} = FlagParser.parse(["--", "-x"], spec)
+    end
+  end
+
+  describe "value coercion" do
+    # Coercing every integer-looking value turned `sort -t 1` into a delimiter
+    # of `1`, which String.split/2 refuses.
+    test "keeps a value that is not declared :integer as a string" do
+      spec = %{boolean: [], value: [:t], defaults: %{t: nil}}
+
+      assert {:ok, %{t: "1"}, []} = FlagParser.parse(["-t", "1"], spec)
+      assert {:ok, %{t: "1"}, []} = FlagParser.parse(["-t1"], spec)
+    end
+
+    test "converts a value declared :integer" do
+      spec = %{boolean: [], value: [:c], integer: [:c], defaults: %{c: nil}}
+
+      assert {:ok, %{c: 12}, []} = FlagParser.parse(["-c", "12"], spec)
+      assert {:ok, %{c: 12}, []} = FlagParser.parse(["-c12"], spec)
+    end
+
+    test "leaves a non-numeric value alone even when declared :integer" do
+      spec = %{boolean: [], value: [:c], integer: [:c], defaults: %{c: nil}}
+
+      assert {:ok, %{c: "all"}, []} = FlagParser.parse(["-c", "all"], spec)
+    end
+
+    test "accumulates multi-value flags as strings" do
+      spec = %{boolean: [], value: [], multi_value: [:k], defaults: %{k: []}}
+
+      assert {:ok, %{k: ["1", "2,2n"]}, []} = FlagParser.parse(["-k", "1", "-k", "2,2n"], spec)
+    end
+  end
+
+  describe "format_error/3" do
+    test "words a short option the way GNU does" do
+      assert FlagParser.format_error("sort", {:unknown_flag, "Q"}, "usage\n") ==
+               "sort: invalid option -- 'Q'\nusage\n"
+    end
+
+    test "words a long option the way GNU does" do
+      assert FlagParser.format_error("sort", {:unknown_flag, "--nope"}, "usage\n") ==
+               "sort: unrecognized option '--nope'\nusage\n"
+    end
+
+    test "words a missing value the way GNU does" do
+      assert FlagParser.format_error("head", {:missing_value, "n"}, "") ==
+               "head: option requires an argument -- 'n'\n"
+
+      assert FlagParser.format_error("head", {:missing_value, "--lines"}, "") ==
+               "head: option '--lines' requires an argument\n"
     end
   end
 end

--- a/test/flag_parser_test.exs
+++ b/test/flag_parser_test.exs
@@ -213,10 +213,25 @@ defmodule JustBash.FlagParserTest do
       assert {:ok, %{c: 12}, []} = FlagParser.parse(["-c12"], spec)
     end
 
-    test "leaves a non-numeric value alone even when declared :integer" do
-      spec = %{boolean: [], value: [:c], integer: [:c], defaults: %{c: nil}}
+    # Handing the string back to a caller that just declared the flag numeric
+    # is how `head -n abc` reached Enum.take/2 and raised out of exec/2.
+    test "rejects a value declared :integer that is not a number" do
+      spec = %{
+        boolean: [],
+        value: [:c],
+        integer: [:c],
+        value_labels: %{c: "number of bytes"},
+        defaults: %{c: nil}
+      }
 
-      assert {:ok, %{c: "all"}, []} = FlagParser.parse(["-c", "all"], spec)
+      assert {:error, {:invalid_value, "number of bytes", "all"}} =
+               FlagParser.parse(["-c", "all"], spec)
+
+      assert {:error, {:invalid_value, "number of bytes", "12x"}} =
+               FlagParser.parse(["-c12x"], spec)
+
+      assert {:error, {:invalid_value, "number of bytes", ""}} =
+               FlagParser.parse(["-c", ""], spec)
     end
 
     test "accumulates multi-value flags as strings" do
@@ -243,6 +258,15 @@ defmodule JustBash.FlagParserTest do
 
       assert FlagParser.format_error("head", {:missing_value, "--lines"}, "") ==
                "head: option '--lines' requires an argument\n"
+    end
+
+    # GNU prints no `Try --help` line for a bad count, so neither do we.
+    test "words a bad count the way GNU does" do
+      assert FlagParser.format_error(
+               "head",
+               {:invalid_value, "number of lines", "abc"},
+               "usage\n"
+             ) == "head: invalid number of lines: 'abc'\n"
     end
   end
 end


### PR DESCRIPTION
Closes #68

## What was broken

`JustBash.FlagParser` turned a flag it did not recognise into a positional
operand (`lib/just_bash/flag_parser.ex:75`), so the flag became a filename.
For `sort` and `uniq` — which silently treat an unreadable file as empty —
that produced the worst available outcome: the file's contents dropped, and
exit 0 to say it worked.

```elixir
bash = JustBash.new(files: %{"/f.txt" => "a\nb\nc\n"})

for cmd <- ["sort -Q /f.txt", "uniq -Z /f.txt", "head -q /f.txt", "ls -Q /"] do
  {r, _} = JustBash.exec(bash, cmd)
  IO.puts("$ #{cmd}\n   exit=#{r.exit_code} stdout=#{inspect(r.stdout)} stderr=#{inspect(r.stderr)}")
end
```

| command | before | after | GNU coreutils 9 |
| --- | --- | --- | --- |
| `sort -Q /f.txt` | exit 0, stdout `""`, stderr `""` | exit 2, `sort: invalid option -- 'Q'` + `Try 'sort --help'…` | identical |
| `uniq -Z /f.txt` | exit 0, stdout `""`, stderr `""` | exit 1, `uniq: invalid option -- 'Z'` + `Try 'uniq --help'…` | identical |
| `head -q /f.txt` | exit 1, `head: cannot open '-q' for reading…` | exit 1, `head: invalid option -- 'q'` + `Try 'head --help'…` | exit 0 (`-q` is implemented there) |
| `ls -Q /` | exit 1 **and still printed the listing** | exit 2, `ls: invalid option -- 'Q'` + `Try 'ls --help'…` | exit 0 (`-Q` is implemented there) |

`head -q` and `ls -Q` are real coreutils flags that just are not implemented
here; rejecting them names the actual problem instead of blaming a file that
was never on the command line.

Three more, found on the way:

```
$ echo abc | tr -dX b     => "ac"   exit 0     (X silently dropped)
$ echo abc | tr -x b      => "abc"  exit 0     (-x became the from-set)
$ sort -t 1 -k2 /f.txt    => ** (FunctionClauseError) String.split/2 given the integer 1
```

## What the fix does

**1. `FlagParser` rejects instead of demoting.** `parse/2` now returns
`{:ok, flags, rest}` or `{:error, {:unknown_flag, flag}}` /
`{:error, {:missing_value, flag}}`. `format_error/3` renders it in GNU's
shape, checked against GNU coreutils 9 on this machine:

* short option named by its character (`invalid option -- 'Q'`), because that
  is the unit getopt stopped on — out of a cluster, `-rQ` reports `Q`;
* long option named in full (`unrecognized option '--jb-not-a-flag'`), because
  `invalid option -- '-'` identifies nothing;
* `option requires an argument -- 'n'` for a value flag with nothing after it,
  which used to become a file named `-n`;
* the `Try '<cmd> --help' for more information.` line, and coreutils' exit
  codes: 2 for `sort`, `ls` and `grep`, 1 for `cp`, `head`, `tail`, `uniq`.
  Only `grep` prints a `Usage:` line on a bad option; coreutils does not, so
  neither do we.

All seven callers (`cp`, `grep`, `head`, `ls`, `sort`, `tail`, `uniq`) surface
it. `--` still ends option parsing and a lone `-` is still an operand.

A cluster is parsed the way getopt parses one: booleans accumulate and a value
flag takes the rest of the cluster as its argument, or the next argument when
it is the last character, so `sort -nk2` is `-n -k 2` and `sort -rt: -k2`
sorts. The scan stops on the first character the spec does not describe **at
all**, so the diagnostic never names a flag the command implements.

A flag declared `:integer` is validated. `head -n abc`, `head -nq` and
`head -n ''` used to raise a `FunctionClauseError` out of `JustBash.exec/2` and
`head -c xy` printed the whole file at exit 0; all four are now
`head: invalid number of lines: 'abc'` at exit 1, GNU's wording, with no
`Try --help` line because GNU prints none for this one. The noun comes from a
`:value_labels` spec key, required of every `:integer` flag.

**`--help` answers.** Every rejection prints
`Try '<cmd> --help' for more information.`, so that command has to work.
`FlagParser.help/2` renders the usage out of the spec — it lists exactly what
the parser accepts and cannot drift from it:

```
$ sort --help
Usage: sort [OPTION]... [FILE]...
Options this shell implements:
  -f
  -k VALUE
  -n
  -r
  -t VALUE
  -u
```

All eight commands answer at exit 0. `--` still wins, so `sort -- --help` is an
operand. `--version` stays an unrecognized option, and the advice it prints now
leads somewhere.

**2. `tr`'s own copy.** The combined-flag reducer's catch-all discarded unknown
characters while consuming the token, and a single-character unknown flag fell
past the `byte_size(flags) > 1` guard into the operand clause and became a
character set. Both now report `tr: invalid option -- 'x'` at exit 1. `tr` also
learned `--`, so `echo a-b | tr -- '-' '_'` gives `a_b` as in GNU rather than
empty output.

`tr` also refuses to translate with one set. One set and no `-d`/`-s` used to
fall past every `run/2` head into `defp run(_input, _opts), do: ""`, so
`echo abc | tr -- -d` and `echo abc | tr x` answered with empty stdout at exit
0 — the failure this PR exists to remove. Both are now GNU's
`tr: missing operand after 'x'` + `Two strings must be given when translating.`
at exit 1.

**3. `parse_value/1` no longer coerces.** Only flags a spec declares
`:integer` are converted; `head` and `tail` declare `:n` and `:c`. Everything
else stays a string, so `sort -t 1 -k2` is a delimiter of `"1"` and sorts
instead of crashing. (The issue cites `cut -d 1` for this — `cut` has its own
hand-rolled parser and was never affected; `sort -t` is the real victim.)

**4. `sort` reports a file it cannot read.** `get_content/3` mapped every
`FS.read_file` error to `{"", fs}`, so `sort -- -Q` was still the exact symptom
of the issue: empty stdout, empty stderr, exit 0. It is now
`sort: cannot read: -Q: No such file or directory` at exit 2, as in GNU, and a
lone `-` reads standard input rather than naming a file that does not exist.

Per the issue's warning, the ~45 hand-rolled `parse_args` commands are **not**
migrated onto `FlagParser` here.

## New tests

`test/commands/unknown_flags_test.exs` (22 tests) — the repro from the issue as
exact-string assertions for all eight commands, cluster and long-option
wording, missing values, `--` and lone `-`, and the two value-coercion cases.

`test/flag_parser_test.exs` — updated to the new return shape, plus 12 new
tests covering every error path and the `:integer` opt-in.

**The registry-wide probe.** `test/commands/unknown_flags_test.exs` enumerates
all 92 names in `Commands.Registry` against `cmd --jb-not-a-flag` and `cmd -Z`
and compares the observed behaviour of the whole registry to a classification
table, so a new command cannot be added without being classified and none can
change category unnoticed. A second test asserts every rejecting command names
itself in the diagnostic, and a third pins the eight shared-parser commands to
`:strict` so the table cannot be edited to demote one.

A non-zero exit is **not** evidence that a flag was rejected: demoting it to a
filename and failing to open that file also exits non-zero, and leaves the
command's real output on stdout. `:strict` therefore requires empty stdout and
a diagnostic that names the *option*. Three of the five categories are honest
about the state of the tree:

* `:strict` (36) — the flag was rejected: non-zero exit, nothing on stdout, and
  `invalid option` / `unrecognized option` in the diagnostic. Where every
  command should be, and where the eight fixed here now are.
* `:misblamed` (21) — **still wrong**: non-zero, but the diagnostic is about a
  file the flag was turned into. `cat -Z /f.txt` says
  `cat: -Z: No such file or directory` and prints the file anyway.
* `:quiet` (`exit`, `false`, `read`) — non-zero, no diagnostic; bash is equally
  silent, they parse no options.
* `:operand` (`:`, `echo`, `test`, `true`, `yes`) — exit 0 is correct, bash also
  treats the argument as data.
* `:absorbed` (27) — **still wrong**: exits 0 with the flag ignored, exactly the
  way `sort -Q` did. These are the hand-rolled parsers the issue defers. They
  are listed by name rather than waved at, so fixing one forces an edit to the
  table and the list can only shrink.

Run against `82ee9e5` the classifier puts all eight shared-parser commands
outside `:strict` — `cp`/`head`/`ls`/`tail` `:misblamed`, `sort`/`uniq`
`:exit_zero`, `grep` `:quiet`, `tr` both — so the matrix fails on the baseline
for every caller this PR claims to fix.

No exception list was needed for "`-Z` legitimately implemented" — no command
in the registry implements `-Z`.

## Gates

```
$ mix compile --warnings-as-errors
(no output)

$ mix format --check-formatted
(no output; exit 0)

$ mix credo --strict
  Refactoring opportunities
┃ [F] ↘ Avoid `apply/2` and `apply/3` when the number of arguments is known.
┃       test/support/banned_fixture_apply.ex:4:16 #(BannedCallTracer.Fixture.Apply.run)

Analysis took 2.8 seconds (0.3s to load, 2.5s running 68 checks on 230 files)
5149 mods/funs, found 1 refactoring opportunity.
```
(the single finding is the pre-existing intentional test fixture — identical on `main`)

```
$ mix test
Finished in 32.6 seconds (32.2s async, 0.4s sync)
2 doctests, 62 properties, 4818 tests, 0 failures (5 excluded)

$ mix dialyzer
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done (passed successfully)
```

4752 tests before, 4818 after, no regressions.

## Left out

Nothing from the issue's scope. Three adjacent gaps in `tr` are noted and not
touched, because none is reachable through anything this PR adds: `tr -cs a`
returns `""` at exit 0 where GNU prints `abc`, and `tr a b c` / `tr -d a b`
reach `run/2`'s catch-all where GNU says `extra operand`.

