### PR TITLE
fix: exec/2 returns a shell result instead of raising, and always terminates

### DIFF
--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -388,14 +388,41 @@ defmodule JustBash do
   """
   @spec exec(t(), String.t()) :: {exec_result(), t()}
   def exec(bash, command) when is_binary(command) do
-    # Reset counters only for top-level exec (not nested eval/source)
+    # Reset counters and arm the wall clock only for top-level exec
+    # (not nested eval/source, which run inside the caller's budget)
     bash =
       if bash.interpreter.exec_depth == 0 do
-        %{bash | interpreter: State.reset_counters(bash.interpreter)}
+        interpreter =
+          bash.interpreter
+          |> State.reset_counters()
+          |> State.arm_deadline(Limit.deadline(bash.limits))
+
+        %{bash | interpreter: interpreter}
       else
         bash
       end
 
+    do_exec(bash, command)
+  rescue
+    # Containment, not defensive coding. `exec/2` is a trust boundary: it runs
+    # untrusted script text on behalf of a host that has no way to interpret an
+    # Elixir exception naming a JustBash internal. A raise reaching here is a
+    # bug in JustBash, but the host must still get a shell-shaped answer.
+    # Individual commands are contained closer to the raise; this is the net
+    # under everything else — expansion, redirection, control flow.
+    error ->
+      internal_error(bash, "#{inspect(error.__struct__)}: #{Exception.message(error)}")
+  catch
+    kind, reason ->
+      internal_error(bash, "#{kind}: #{inspect(reason)}")
+  end
+
+  defp internal_error(bash, detail) do
+    stderr = "bash: internal error (#{detail})\n"
+    {%{stdout: "", stderr: stderr, exit_code: 1, env: bash.env}, bash}
+  end
+
+  defp do_exec(bash, command) do
     JustBash.Telemetry.session_span(self(), fn ->
       case Parser.parse(command) do
         {:ok, ast} ->

--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -396,8 +396,13 @@ defmodule JustBash do
     # untrusted script text on behalf of a host that has no way to interpret an
     # Elixir exception naming a JustBash internal. A raise reaching here is a
     # bug in JustBash, but the host must still get a shell-shaped answer.
-    # Individual commands are contained closer to the raise; this is the net
-    # under everything else — expansion, redirection, control flow.
+    #
+    # This is the last resort only. Commands are contained at
+    # `Executor.contain_command_crash/3` and everything the statement loop runs
+    # — expansion, redirection, control flow — at `Executor.run_statement/2`,
+    # both of which keep the work that came before. Reaching *here* means the
+    # raise happened outside the statement loop (parsing, the EXIT trap), where
+    # there is no session state left to preserve.
     error ->
       internal_error(bash, "#{inspect(error.__struct__)}: #{Exception.message(error)}")
   catch
@@ -418,10 +423,7 @@ defmodule JustBash do
 
   defp arm_top_level(%__MODULE__{} = bash), do: bash
 
-  defp internal_error(bash, detail) do
-    stderr = "bash: internal error (#{detail})\n"
-    {%{stdout: "", stderr: stderr, exit_code: 1, env: bash.env}, bash}
-  end
+  defp internal_error(bash, detail), do: {Executor.internal_error(bash, detail), bash}
 
   defp do_exec(bash, command) do
     JustBash.Telemetry.session_span(self(), fn ->
@@ -523,14 +525,17 @@ defmodule JustBash do
   Same limits as `exec/2` — including `:max_wall_ms`, which is armed here too,
   so a script that spins is bounded by both entry points.
 
-  Unlike `exec/2`, this function is *not* a trust boundary. It propagates:
+  It differs from `exec/2` in what it does with a failure it cannot express as
+  a shell result. It raises a `RuntimeError` on a parse error, where `exec/2`
+  returns exit 2 with a `bash: syntax error: ...` diagnostic; and it propagates
+  any exception that escapes the interpreter's own containment — the EXIT trap
+  and telemetry are the paths that can still do that — where `exec/2` reports
+  `bash: internal error (...)`.
 
-  - a `RuntimeError` for a parse error, where `exec/2` returns exit 2 with a
-    `bash: syntax error: ...` diagnostic; and
-  - any exception raised by the interpreter or by a command, where `exec/2`
-    contains it and returns a shell-shaped result.
-
-  A host running untrusted script text wants `exec/2`.
+  A command that crashes and a raise from inside the statement loop are
+  contained by the interpreter itself, so both entry points get a shell result
+  for those. A host running untrusted script text should still prefer `exec/2`,
+  which is the documented trust boundary.
 
   ## Examples
 

--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -388,21 +388,9 @@ defmodule JustBash do
   """
   @spec exec(t(), String.t()) :: {exec_result(), t()}
   def exec(bash, command) when is_binary(command) do
-    # Reset counters and arm the wall clock only for top-level exec
-    # (not nested eval/source, which run inside the caller's budget)
-    bash =
-      if bash.interpreter.exec_depth == 0 do
-        interpreter =
-          bash.interpreter
-          |> State.reset_counters()
-          |> State.arm_deadline(Limit.deadline(bash.limits))
-
-        %{bash | interpreter: interpreter}
-      else
-        bash
-      end
-
-    do_exec(bash, command)
+    bash
+    |> arm_top_level()
+    |> do_exec(command)
   rescue
     # Containment, not defensive coding. `exec/2` is a trust boundary: it runs
     # untrusted script text on behalf of a host that has no way to interpret an
@@ -416,6 +404,19 @@ defmodule JustBash do
     kind, reason ->
       internal_error(bash, "#{kind}: #{inspect(reason)}")
   end
+
+  # Reset counters and arm the wall clock only for top-level execution; nested
+  # eval/source run inside the caller's budget rather than starting a fresh one.
+  defp arm_top_level(%__MODULE__{interpreter: %{exec_depth: 0}} = bash) do
+    interpreter =
+      bash.interpreter
+      |> State.reset_counters()
+      |> State.arm_deadline(Limit.deadline(bash.limits))
+
+    %{bash | interpreter: interpreter}
+  end
+
+  defp arm_top_level(%__MODULE__{} = bash), do: bash
 
   defp internal_error(bash, detail) do
     stderr = "bash: internal error (#{detail})\n"
@@ -517,7 +518,19 @@ defmodule JustBash do
   end
 
   @doc """
-  Execute a bash command, raising on parse errors.
+  Execute a bash command, raising instead of containing failures.
+
+  Same limits as `exec/2` — including `:max_wall_ms`, which is armed here too,
+  so a script that spins is bounded by both entry points.
+
+  Unlike `exec/2`, this function is *not* a trust boundary. It propagates:
+
+  - a `RuntimeError` for a parse error, where `exec/2` returns exit 2 with a
+    `bash: syntax error: ...` diagnostic; and
+  - any exception raised by the interpreter or by a command, where `exec/2`
+    contains it and returns a shell-shaped result.
+
+  A host running untrusted script text wants `exec/2`.
 
   ## Examples
 
@@ -526,6 +539,8 @@ defmodule JustBash do
   """
   @spec exec!(t(), String.t()) :: {exec_result(), t()}
   def exec!(bash, command) do
+    bash = arm_top_level(bash)
+
     JustBash.Telemetry.session_span(self(), fn ->
       case Parser.parse(command) do
         {:ok, ast} ->

--- a/lib/just_bash/commands/awk/evaluator.ex
+++ b/lib/just_bash/commands/awk/evaluator.ex
@@ -20,7 +20,8 @@ defmodule JustBash.Commands.Awk.Evaluator do
           variables: %{String.t() => String.t()},
           arrays: %{String.t() => map()},
           output: String.t(),
-          exit_code: non_neg_integer() | nil
+          exit_code: non_neg_integer() | nil,
+          deadline: Limit.Deadline.t() | nil
         }
 
   @doc """
@@ -50,7 +51,8 @@ defmodule JustBash.Commands.Awk.Evaluator do
       output: "",
       exit_code: nil,
       file_outputs: %{},
-      bash: Map.get(opts, :bash)
+      bash: Map.get(opts, :bash),
+      deadline: deadline(Map.get(opts, :bash))
     }
 
     state = execute_begin_blocks(state, program.begin_blocks)
@@ -928,8 +930,18 @@ defmodule JustBash.Commands.Awk.Evaluator do
   end
 
   # Loop helper functions
+  #
+  # An AWK program is a single shell command, so the interpreter's statement
+  # loop is never re-entered while one runs and the step counter charges the
+  # whole program as one step. These three constructs are the only unbounded
+  # loops in the evaluator, so each iteration checks the wall clock itself.
+
+  defp deadline(%{interpreter: %{deadline: deadline}}), do: deadline
+  defp deadline(_bash), do: nil
 
   defp execute_for_loop(cond_expr, update, body, state) do
+    Limit.check_deadline!(state.deadline)
+
     if truthy?(evaluate_expression(cond_expr, state)) do
       case execute_loop_body(body, state) do
         {:break, new_state} ->
@@ -949,6 +961,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   end
 
   defp execute_while_loop(cond_expr, body, state) do
+    Limit.check_deadline!(state.deadline)
     {cond_val, state} = evaluate_condition_with_state(cond_expr, state)
 
     if truthy?(cond_val) do
@@ -980,6 +993,8 @@ defmodule JustBash.Commands.Awk.Evaluator do
   end
 
   defp execute_do_while_loop(body, cond_expr, state) do
+    Limit.check_deadline!(state.deadline)
+
     case execute_loop_body(body, state) do
       {:break, new_state} ->
         new_state

--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -322,7 +322,10 @@ defmodule JustBash.Commands.Cp do
   end
 
   defp copy_tree(bash, {src, src_path}, {dest, dest_path}, opts) do
-    case FS.cp(bash.fs, src_path, dest_path, recursive: true) do
+    # A whole tree copy is one step, so the step counter cannot bound it.
+    cp_opts = [recursive: true, deadline: bash.interpreter.deadline]
+
+    case FS.cp(bash.fs, src_path, dest_path, cp_opts) do
       {:ok, fs} ->
         report(%{bash | fs: fs}, {src, src_path}, dest, opts)
 

--- a/lib/just_bash/commands/du.ex
+++ b/lib/just_bash/commands/du.ex
@@ -4,6 +4,7 @@ defmodule JustBash.Commands.Du do
 
   alias JustBash.Commands.Command
   alias JustBash.FS
+  alias JustBash.Limit
 
   @short_flags %{
     ?a => :all_files,
@@ -22,6 +23,8 @@ defmodule JustBash.Commands.Du do
         {Command.error(msg), bash}
 
       {:ok, opts} ->
+        # A whole traversal is one step, so the step counter cannot bound it.
+        opts = %{opts | deadline: bash.interpreter.deadline}
         targets = if opts.files == [], do: ["."], else: opts.files
 
         {output, stderr, grand_total} = process_targets(bash, targets, opts)
@@ -60,7 +63,8 @@ defmodule JustBash.Commands.Du do
       summarize: false,
       grand_total: false,
       max_depth: nil,
-      files: []
+      files: [],
+      deadline: nil
     })
   end
 
@@ -127,6 +131,8 @@ defmodule JustBash.Commands.Du do
   end
 
   defp calculate_dir_size(fs, path, display_path, opts, depth) do
+    Limit.check_deadline!(opts.deadline)
+
     case FS.readdir(fs, path) do
       {:ok, entries, _fs} ->
         {output, dir_size} =

--- a/lib/just_bash/commands/find.ex
+++ b/lib/just_bash/commands/find.ex
@@ -4,6 +4,7 @@ defmodule JustBash.Commands.Find do
 
   alias JustBash.Commands.Command
   alias JustBash.FS
+  alias JustBash.Limit
 
   @impl true
   def names, do: ["find"]
@@ -15,6 +16,8 @@ defmodule JustBash.Commands.Find do
         {Command.error(msg), bash}
 
       {:ok, opts} ->
+        # A whole traversal is one step, so the step counter cannot bound it.
+        opts = %{opts | deadline: bash.interpreter.deadline}
         paths = if opts.paths == [], do: ["."], else: opts.paths
 
         {results, stderr, exit_code} =
@@ -53,7 +56,8 @@ defmodule JustBash.Commands.Find do
       mindepth: nil,
       empty: false,
       print0: false,
-      exec_cmd: nil
+      exec_cmd: nil,
+      deadline: nil
     })
   end
 
@@ -135,6 +139,8 @@ defmodule JustBash.Commands.Find do
   end
 
   defp find_recursive(fs, full_path, display_path, opts, depth) do
+    Limit.check_deadline!(opts.deadline)
+
     if exceeds_maxdepth?(opts, depth) do
       {:ok, []}
     else

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -98,7 +98,7 @@ defmodule JustBash.Commands.Grep do
 
       case FS.stat(bash.fs, resolved) do
         {:ok, %VFS.Stat{type: :directory}, _fs} ->
-          find_files_recursive(bash.fs, resolved, file)
+          find_files_recursive(bash.fs, resolved, file, bash.interpreter.deadline)
 
         {:ok, _, _fs} ->
           [file]
@@ -113,7 +113,10 @@ defmodule JustBash.Commands.Grep do
   # the descent uses `lstat` and skips every link it meets along the way.
   # (`stat` would resolve them, and a link pointing back into the tree being
   # searched would make the recursion re-enter it — twice over, forever.)
-  defp find_files_recursive(fs, full_path, display_path) do
+  # A whole traversal is one step, so the step counter cannot bound it.
+  defp find_files_recursive(fs, full_path, display_path, deadline) do
+    Limit.check_deadline!(deadline)
+
     case FS.readdir(fs, full_path) do
       {:ok, entries, _fs} ->
         Enum.flat_map(entries, fn entry ->
@@ -122,7 +125,7 @@ defmodule JustBash.Commands.Grep do
 
           case FS.lstat(fs, child_full) do
             {:ok, %VFS.Stat{type: :directory}, _fs} ->
-              find_files_recursive(fs, child_full, child_display)
+              find_files_recursive(fs, child_full, child_display, deadline)
 
             {:ok, %VFS.Stat{type: :symlink}, _fs} ->
               []

--- a/lib/just_bash/commands/seq.ex
+++ b/lib/just_bash/commands/seq.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Seq do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Limit
 
   @impl true
   def names, do: ["seq"]
@@ -12,19 +13,14 @@ defmodule JustBash.Commands.Seq do
     case args do
       [last] ->
         case Integer.parse(last) do
-          {n, _} ->
-            output = Enum.map_join(1..n, "\n", &to_string/1) <> "\n"
-            {Command.ok(output), bash}
-
-          :error ->
-            {Command.error("seq: invalid argument\n"), bash}
+          {n, _} -> render(bash, 1..n)
+          :error -> {Command.error("seq: invalid argument\n"), bash}
         end
 
       [first, last] ->
         with {f, _} <- Integer.parse(first),
              {l, _} <- Integer.parse(last) do
-          output = Enum.map_join(f..l, "\n", &to_string/1) <> "\n"
-          {Command.ok(output), bash}
+          render(bash, f..l)
         else
           _ -> {Command.error("seq: invalid argument\n"), bash}
         end
@@ -33,9 +29,7 @@ defmodule JustBash.Commands.Seq do
         with {f, _} <- Integer.parse(first),
              {i, _} <- Integer.parse(incr),
              {l, _} <- Integer.parse(last) do
-          range = f..l//i
-          output = Enum.map_join(range, "\n", &to_string/1) <> "\n"
-          {Command.ok(output), bash}
+          render(bash, f..l//i)
         else
           _ -> {Command.error("seq: invalid argument\n"), bash}
         end
@@ -43,5 +37,17 @@ defmodule JustBash.Commands.Seq do
       _ ->
         {Command.error("seq: missing operand\n"), bash}
     end
+  end
+
+  # `seq 1 100000000` is one step and one command, so neither the step counter
+  # nor the interpreter's statement loop can see it. The range is walked under
+  # the wall clock instead.
+  defp render(bash, range) do
+    output =
+      range
+      |> Limit.enforce_deadline(bash.interpreter.deadline)
+      |> Enum.map_join("\n", &to_string/1)
+
+    {Command.ok(output <> "\n"), bash}
   end
 end

--- a/lib/just_bash/commands/tree.ex
+++ b/lib/just_bash/commands/tree.ex
@@ -4,6 +4,7 @@ defmodule JustBash.Commands.Tree do
 
   alias JustBash.Commands.Command
   alias JustBash.FS
+  alias JustBash.Limit
 
   @impl true
   def names, do: ["tree"]
@@ -16,7 +17,8 @@ defmodule JustBash.Commands.Tree do
 
       {:ok, opts} ->
         dirs = if opts.dirs == [], do: ["."], else: opts.dirs
-        ctx = %{fs: bash.fs, opts: opts}
+        # A whole traversal is one step, so the step counter cannot bound it.
+        ctx = %{fs: bash.fs, opts: opts, deadline: bash.interpreter.deadline}
         {output, stderr, dir_count, file_count} = process_directories(ctx, bash.cwd, dirs)
         summary = format_summary(dir_count, file_count, opts.dirs_only)
         exit_code = if stderr != "", do: 1, else: 0
@@ -124,6 +126,7 @@ defmodule JustBash.Commands.Tree do
   end
 
   defp build_entries(ctx, parent_path, entries, prefix, depth) do
+    Limit.check_deadline!(ctx.deadline)
     entries_count = length(entries)
 
     entries

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -33,7 +33,7 @@ defmodule JustBash.FS do
 
   @type mkdir_opts :: [parents: boolean()]
   @type rm_opts :: [recursive: boolean()]
-  @type cp_opts :: [recursive: boolean()]
+  @type cp_opts :: [recursive: boolean(), deadline: Limit.Deadline.t() | nil]
   @type write_opts :: [mode: non_neg_integer(), mtime: DateTime.t()]
 
   @doc """
@@ -222,21 +222,14 @@ defmodule JustBash.FS do
   end
 
   @doc """
-  See `VFS.walk/3`, plus one option vfs does not have.
+  See `VFS.walk/3`.
 
-  `:deadline` — a `JustBash.Limit.Deadline` (or `nil`). A traversal is a single
-  step as far as the step counter is concerned, so a large or pathological tree
-  is otherwise unbounded; with a deadline, each entry yielded checks the wall
-  clock and raises `JustBash.Limit.ExceededError` once it has passed.
+  This is an unbounded enumeration and no command in `lib/` uses it; a caller
+  that walks an untrusted tree should pipe it through
+  `JustBash.Limit.enforce_deadline/2`, the way `JustBash.Commands.Seq` does.
   """
   @spec walk(t(), String.t(), keyword()) :: Enumerable.t()
-  def walk(fs, root, opts \\ []) do
-    {deadline, walk_opts} = Keyword.pop(opts, :deadline)
-
-    fs
-    |> VFS.walk(root, walk_opts)
-    |> Limit.enforce_deadline(deadline)
-  end
+  defdelegate walk(fs, root, opts \\ []), to: VFS
 
   # ── POSIX extensions (dispatched through JustBash.FS.POSIX) ─────────────
 
@@ -280,6 +273,11 @@ defmodule JustBash.FS do
   resolved through any symlinked components before that test, so a
   destination that only *reaches* the source through a link is caught
   too.
+
+  `:deadline` — a `JustBash.Limit.Deadline` (or `nil`). A recursive copy is a
+  single step as far as the step counter is concerned, so a large tree is
+  otherwise unbounded; with a deadline, each directory descended into checks
+  the wall clock and raises `JustBash.Limit.ExceededError` once it has passed.
   """
   @spec cp(t(), String.t(), String.t(), cp_opts()) :: {:ok, t()} | {:error, Error.t()}
   def cp(fs, src, dest, opts \\ []) do
@@ -477,6 +475,8 @@ defmodule JustBash.FS do
   end
 
   defp cp_children(fs, src_norm, dest_norm, opts) do
+    Limit.check_deadline!(Keyword.get(opts, :deadline))
+
     with {:ok, children, fs} <- readdir(fs, src_norm) do
       Enum.reduce_while(children, {:ok, fs}, fn child, {:ok, acc_fs} ->
         src_child = join_child(src_norm, child)

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -25,6 +25,7 @@ defmodule JustBash.FS do
 
   alias JustBash.FS.Memory
   alias JustBash.FS.POSIX
+  alias JustBash.Limit
   alias VFS.Error
   alias VFS.Path, as: VPath
 
@@ -220,9 +221,22 @@ defmodule JustBash.FS do
     VFS.rm(fs, path, opts)
   end
 
-  @doc "See `VFS.walk/3`."
+  @doc """
+  See `VFS.walk/3`, plus one option vfs does not have.
+
+  `:deadline` — a `JustBash.Limit.Deadline` (or `nil`). A traversal is a single
+  step as far as the step counter is concerned, so a large or pathological tree
+  is otherwise unbounded; with a deadline, each entry yielded checks the wall
+  clock and raises `JustBash.Limit.ExceededError` once it has passed.
+  """
   @spec walk(t(), String.t(), keyword()) :: Enumerable.t()
-  defdelegate walk(fs, root, opts \\ []), to: VFS
+  def walk(fs, root, opts \\ []) do
+    {deadline, walk_opts} = Keyword.pop(opts, :deadline)
+
+    fs
+    |> VFS.walk(root, walk_opts)
+    |> Limit.enforce_deadline(deadline)
+  end
 
   # ── POSIX extensions (dispatched through JustBash.FS.POSIX) ─────────────
 

--- a/lib/just_bash/interpreter/executor.ex
+++ b/lib/just_bash/interpreter/executor.ex
@@ -264,8 +264,13 @@ defmodule JustBash.Interpreter.Executor do
   def execute_command(bash, %AST.SimpleCommand{name: nil, assignments: assignments}, _stdin) do
     # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
     try do
-      new_bash = execute_assignments(bash, assignments)
-      {%{stdout: "", stderr: "", exit_code: 0}, new_bash}
+      {new_bash, effects} = execute_assignments(bash, assignments)
+      {stderr, subst_exit_code, _assigns} = Expansion.take_substitutions(effects)
+
+      # With no command to claim `$?`, a bare assignment reports the exit status
+      # of the last command substitution it ran — `x=$(cat /nope)` is exit 1 in
+      # bash. Verified against GNU bash 3.2.57.
+      {%{stdout: "", stderr: stderr, exit_code: subst_exit_code || 0}, new_bash}
     rescue
       e in ArithmeticError ->
         {%{stdout: "", stderr: "bash: #{Exception.message(e)}\n", exit_code: 1}, bash}
@@ -377,7 +382,7 @@ defmodule JustBash.Interpreter.Executor do
   # --- Simple Command Execution (with implicit try for UnsetVariableError) ---
 
   defp do_execute_simple_command(bash, name, args, assignments, redirs, stdin) do
-    temp_bash = execute_assignments(bash, assignments)
+    {temp_bash, assign_effects} = execute_assignments(bash, assignments)
     {cmd_name, cmd_assigns} = Expansion.expand_word_parts(temp_bash, name.parts)
 
     # Apply any assignments from ${VAR:=default} expansions
@@ -386,23 +391,33 @@ defmodule JustBash.Interpreter.Executor do
     # Expand args sequentially, applying any assignments between each
     # This ensures side effects like $((x++)) are visible to subsequent args
     # Use prepend for O(1) and reverse at end for correct order
-    {expanded_args_reversed, temp_bash} =
-      Enum.reduce(args, {[], temp_bash}, fn arg, {acc, current_bash} ->
+    {expanded_args_reversed, temp_bash, arg_effects} =
+      Enum.reduce(args, {[], temp_bash, []}, fn arg, {acc, current_bash, effects} ->
         {expanded, arg_assigns} = Expansion.expand_word_with_glob(current_bash, arg.parts)
         current_bash = apply_pending_assignments(current_bash, arg_assigns)
         # Prepend expanded (which is a list) reversed, so final reverse gives correct order
-        {Enum.reverse(expanded) ++ acc, current_bash}
+        {Enum.reverse(expanded) ++ acc, current_bash, [effects, arg_assigns]}
       end)
 
     expanded_args = Enum.reverse(expanded_args_reversed)
+
+    # A diagnostic produced while expanding goes to the shell's stderr, not
+    # through the command's redirections — bash performs redirections after
+    # expansion, so `echo $(cat /nope) 2>/dev/null` still prints it.
+    {expansion_stderr, _code, _assigns} =
+      (assign_effects ++ cmd_assigns ++ List.flatten(arg_effects))
+      |> Expansion.take_substitutions()
 
     # Extract heredoc content as stdin if present
     {heredoc_stdin, non_heredoc_redirs} = Redirection.extract_heredoc_stdin(temp_bash, redirs)
     effective_stdin = heredoc_stdin || stdin
 
-    with_redirections(temp_bash, non_heredoc_redirs, fn temp_bash ->
-      invoke_command(temp_bash, cmd_name, expanded_args, effective_stdin)
-    end)
+    {result, new_bash} =
+      with_redirections(temp_bash, non_heredoc_redirs, fn temp_bash ->
+        invoke_command(temp_bash, cmd_name, expanded_args, effective_stdin)
+      end)
+
+    {%{result | stderr: expansion_stderr <> result.stderr}, new_bash}
   rescue
     e in Expansion.UnsetVariableError ->
       {%{stdout: "", stderr: "bash: #{Exception.message(e)}\n", exit_code: 1}, bash}
@@ -739,9 +754,16 @@ defmodule JustBash.Interpreter.Executor do
     end)
   end
 
+  # Returns the updated shell plus the expansion side effects the assignments
+  # produced, so the caller can surface a command substitution's diagnostic and
+  # exit status — see `Expansion.take_substitutions/1`.
   defp execute_assignments(bash, assignments) do
-    Enum.reduce(assignments, bash, fn %AST.Assignment{name: name, value: value, array: array},
-                                      acc ->
+    Enum.reduce(assignments, {bash, []}, fn %AST.Assignment{
+                                              name: name,
+                                              value: value,
+                                              array: array
+                                            },
+                                            {acc, effects} ->
       case array do
         nil ->
           # Scalar assignment
@@ -756,7 +778,7 @@ defmodule JustBash.Interpreter.Executor do
           # Expand variable references in associative array subscripts
           # e.g. arr[$key] should store as arr[expanded_key]
           resolved_name = expand_assignment_subscript(acc, name)
-          %{acc | env: Map.put(acc.env, resolved_name, expanded_value)}
+          {%{acc | env: Map.put(acc.env, resolved_name, expanded_value)}, effects ++ pending}
 
         elements when is_list(elements) ->
           # Array assignment: arr=(a b c) or arr=($(echo "a b c"))
@@ -789,7 +811,7 @@ defmodule JustBash.Interpreter.Executor do
           first_element = Map.get(env, "#{name}[0]", "")
           env = Map.put(env, name, first_element)
 
-          %{acc | env: env}
+          {%{acc | env: env}, effects}
       end
     end)
   end
@@ -834,12 +856,15 @@ defmodule JustBash.Interpreter.Executor do
     end
   end
 
-  # Apply pending variable assignments from expansions like ${VAR:=default} or $((x++))
+  # Apply pending variable assignments from expansions like ${VAR:=default} or
+  # $((x++)). Command-substitution traces travel in the same list — see
+  # `Expansion.take_substitutions/1` — but assign nothing.
   defp apply_pending_assignments(bash, []), do: bash
 
-  defp apply_pending_assignments(bash, assignments) do
-    Enum.reduce(assignments, bash, fn {name, value}, acc ->
-      %{acc | env: Map.put(acc.env, name, value)}
+  defp apply_pending_assignments(bash, effects) do
+    Enum.reduce(effects, bash, fn
+      {:substitution, _stderr, _code}, acc -> acc
+      {name, value}, acc -> %{acc | env: Map.put(acc.env, name, value)}
     end)
   end
 

--- a/lib/just_bash/interpreter/executor.ex
+++ b/lib/just_bash/interpreter/executor.ex
@@ -79,6 +79,10 @@ defmodule JustBash.Interpreter.Executor do
     if bash.interpreter.halted do
       {%{stdout: "", stderr: "", exit_code: 1}, bash}
     else
+      # The statement loop is the only place a script can spin indefinitely
+      # while every counting limit stays flat, so the wall clock is checked here.
+      Limit.check_deadline!(bash)
+
       tracked_before = bash.interpreter.output_bytes
       {result, new_bash} = do_execute_statement(bash, stmt)
 
@@ -194,16 +198,20 @@ defmodule JustBash.Interpreter.Executor do
   """
   @spec execute_pipeline(JustBash.t(), AST.Pipeline.t()) :: {result(), JustBash.t()}
   def execute_pipeline(bash, %AST.Pipeline{commands: commands, negated: negated}) do
-    # Track all exit codes for pipefail (prepend for O(1), reverse at end)
-    {final_result, final_bash, exit_codes_reversed} =
-      Enum.reduce(commands, {%{stdout: "", stderr: "", exit_code: 0}, bash, []}, fn cmd,
-                                                                                    {prev_result,
-                                                                                     current_bash,
-                                                                                     codes} ->
+    # Track all exit codes for pipefail (prepend for O(1), reverse at end).
+    # Only stdout is piped onwards; every stage's stderr goes to the shell's
+    # stderr, so it is accumulated as iodata rather than overwritten.
+    {final_result, final_bash, exit_codes_reversed, stderr_io} =
+      Enum.reduce(commands, {%{stdout: "", stderr: "", exit_code: 0}, bash, [], []}, fn cmd,
+                                                                                        {prev_result,
+                                                                                         current_bash,
+                                                                                         codes,
+                                                                                         errs} ->
         {result, new_bash} = execute_command(current_bash, cmd, prev_result.stdout)
-        {result, new_bash, [result.exit_code | codes]}
+        {result, new_bash, [result.exit_code | codes], [errs, result.stderr]}
       end)
 
+    final_result = %{final_result | stderr: IO.iodata_to_binary(stderr_io)}
     exit_codes = Enum.reverse(exit_codes_reversed)
 
     # Set PIPESTATUS array with exit codes from each command in the pipeline
@@ -842,8 +850,34 @@ defmodule JustBash.Interpreter.Executor do
 
       module ->
         bash = Limit.step!(bash)
-        module.execute(bash, args, stdin)
+        invoke_builtin(bash, cmd, module, args, stdin)
     end
+  end
+
+  # Containment, not defensive coding: a builtin that raises is a bug, but the
+  # ~90 registry commands run on behalf of a host that cannot act on an Elixir
+  # exception naming a JustBash internal. This gives them the same treatment
+  # `execute_custom_command/5` already gives host-supplied commands.
+  defp invoke_builtin(bash, cmd, module, args, stdin) do
+    # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
+    try do
+      module.execute(bash, args, stdin)
+    rescue
+      # These have handlers further up that produce a better diagnostic than
+      # "crashed", and a limit breach must keep unwinding to halt the script.
+      e in [Limit.ExceededError, Expansion.UnsetVariableError, ArithmeticError] ->
+        reraise e, __STACKTRACE__
+
+      error ->
+        command_crashed(bash, cmd, "#{inspect(error.__struct__)}: #{Exception.message(error)}")
+    catch
+      kind, reason ->
+        command_crashed(bash, cmd, "#{kind}: #{inspect(reason)}")
+    end
+  end
+
+  defp command_crashed(bash, cmd, detail) do
+    {%{stdout: "", stderr: "bash: #{cmd}: command crashed (#{detail})\n", exit_code: 1}, bash}
   end
 
   @control_signal_keys [:__break__, :__continue__, :__return__]

--- a/lib/just_bash/interpreter/executor.ex
+++ b/lib/just_bash/interpreter/executor.ex
@@ -40,9 +40,7 @@ defmodule JustBash.Interpreter.Executor do
         if b.interpreter.halted do
           {:halt, {b, out, err, 1, true}}
         else
-          {result, new_bash} = execute_statement(b, stmt)
-          new_env = Map.put(new_bash.env, "?", to_string(result.exit_code))
-          new_bash = %{new_bash | last_exit_code: result.exit_code, env: new_env}
+          {result, new_bash} = run_statement(b, stmt)
           acc = {new_bash, [out, result.stdout], [err, result.stderr], result.exit_code, false}
 
           if new_bash.shell_opts.errexit and result.exit_code != 0 and
@@ -64,6 +62,59 @@ defmodule JustBash.Interpreter.Executor do
     }
 
     {result, final_bash}
+  end
+
+  # Containment, not defensive coding: `JustBash.exec/2` is a trust boundary and
+  # a raise reaching here is a bug in JustBash, but a host driving the sandbox
+  # has no way to act on an Elixir exception naming a JustBash internal.
+  #
+  # It is contained *here*, in the statement loop, rather than at `exec/2`,
+  # because this is where the last known-good shell lives: the accumulated
+  # output of the statements that already ran, and the struct they left behind.
+  # Rescuing at `exec/2` can only see the parameter, so it silently rolls the
+  # whole session back. The neighbouring `Limit.ExceededError` handler in
+  # `execute_statement/2` already keeps prior work; this matches it.
+  defp run_statement(bash, stmt) do
+    {result, new_bash} = execute_statement(bash, stmt)
+    new_env = Map.put(new_bash.env, "?", to_string(result.exit_code))
+    {result, %{new_bash | last_exit_code: result.exit_code, env: new_env}}
+  rescue
+    error ->
+      detail = "#{inspect(error.__struct__)}: #{Exception.message(error)}"
+      {internal_error(bash, detail), put_in(bash.interpreter.halted, true)}
+  end
+
+  @internal_error_bytes 512
+  @internal_error_overhead byte_size("bash: internal error ()\n")
+
+  @doc """
+  Build the shell-shaped result for an exception that escaped containment.
+
+  Public so `JustBash.exec/2`'s outer net reports the same way the statement
+  loop does. `Exception.message/1` is unbounded from the sandbox's point of
+  view — `inspect/1` alone allows 4096 bytes per binary and 50 collection
+  elements — so a `MatchError` or `KeyError` carrying interpreter or filesystem
+  state could inline sandbox file contents into a stderr the host asked to be
+  capped. The detail is truncated to fit `:max_output_bytes`, or 512 bytes,
+  whichever is smaller.
+  """
+  @spec internal_error(JustBash.t(), String.t()) :: result()
+  def internal_error(bash, detail) do
+    budget = max(internal_error_cap(bash.limits) - @internal_error_overhead, 0)
+    stderr = "bash: internal error (#{truncate_utf8(detail, budget)})\n"
+    %{stdout: "", stderr: stderr, exit_code: 1, env: bash.env}
+  end
+
+  defp internal_error_cap(%Limit{max_output_bytes: max_output_bytes}),
+    do: min(@internal_error_bytes, max_output_bytes)
+
+  defp internal_error_cap(nil), do: @internal_error_bytes
+
+  defp truncate_utf8(binary, max_bytes) when byte_size(binary) <= max_bytes, do: binary
+
+  defp truncate_utf8(binary, max_bytes) do
+    prefix = binary_part(binary, 0, max_bytes)
+    if String.valid?(prefix), do: prefix, else: truncate_utf8(binary, max_bytes - 1)
   end
 
   defp has_short_circuit_operators?(%AST.Statement{operators: operators}) do
@@ -429,34 +480,78 @@ defmodule JustBash.Interpreter.Executor do
   defp invoke_command(bash, cmd_name, args, stdin) do
     case Map.get(bash.functions, cmd_name) do
       nil ->
-        JustBash.Telemetry.command_span(cmd_name, args, fn ->
-          {result, new_bash} =
-            case Map.get(bash.commands, cmd_name) do
-              nil -> execute_builtin(bash, cmd_name, args, stdin)
-              module -> execute_custom_command(bash, cmd_name, module, args, stdin)
-            end
-
-          # A JustBash.CLI router stashes the resolved subcommand path here; surface it
-          # in telemetry and strip it before the result reaches the shell.
-          {subcommand, result} = Map.pop(result, :__subcommand__)
-
-          stop_metadata = %{
-            exit_code: result.exit_code,
-            bytes_in: byte_size(stdin),
-            bytes_out: byte_size(result.stdout) + byte_size(result.stderr)
-          }
-
-          stop_metadata =
-            if subcommand,
-              do: Map.put(stop_metadata, :subcommand, subcommand),
-              else: stop_metadata
-
-          {{result, new_bash}, stop_metadata}
+        contain_command_crash(bash, cmd_name, fn ->
+          dispatch_with_span(bash, cmd_name, args, stdin)
         end)
 
       func_body ->
         execute_function(bash, func_body, args)
     end
+  end
+
+  defp dispatch_with_span(bash, cmd_name, args, stdin) do
+    JustBash.Telemetry.command_span(cmd_name, args, fn ->
+      {result, new_bash} =
+        case Map.get(bash.commands, cmd_name) do
+          nil -> execute_builtin(bash, cmd_name, args, stdin)
+          module -> execute_custom_command(bash, cmd_name, module, args, stdin)
+        end
+
+      # A JustBash.CLI router stashes the resolved subcommand path here; surface it
+      # in telemetry and strip it before the result reaches the shell.
+      {subcommand, result} = Map.pop(result, :__subcommand__)
+
+      stop_metadata = %{
+        exit_code: result.exit_code,
+        bytes_in: byte_size(stdin),
+        bytes_out: byte_size(result.stdout) + byte_size(result.stderr)
+      }
+
+      stop_metadata =
+        if subcommand,
+          do: Map.put(stop_metadata, :subcommand, subcommand),
+          else: stop_metadata
+
+      {{result, new_bash}, stop_metadata}
+    end)
+  end
+
+  # Containment, not defensive coding: a command that raises is a bug, but the
+  # ~90 registry commands and any host-supplied command run on behalf of a
+  # caller that has no way to act on an Elixir exception naming a JustBash
+  # internal, so it must still get a shell-shaped answer.
+  #
+  # This sits *outside* `command_span/3` on purpose. Containing the raise
+  # inside it means `:telemetry.span/3` never sees the exception, and the
+  # documented `[:just_bash, :command, :exception]` event silently stops
+  # firing — turning a loud failure class into an ordinary exit 1,
+  # indistinguishable in metrics from a script legitimately failing.
+  defp contain_command_crash(bash, cmd_name, dispatch) do
+    # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
+    try do
+      dispatch.()
+    rescue
+      # These have handlers further up that produce a better diagnostic than
+      # "crashed", and a limit breach must keep unwinding to halt the script.
+      e in [Limit.ExceededError, Expansion.UnsetVariableError, ArithmeticError] ->
+        reraise e, __STACKTRACE__
+
+      error ->
+        command_crashed(
+          bash,
+          cmd_name,
+          "#{inspect(error.__struct__)}: #{Exception.message(error)}"
+        )
+    catch
+      kind, reason ->
+        command_crashed(bash, cmd_name, "#{kind}: #{inspect(reason)}")
+    end
+  end
+
+  defp command_crashed(bash, cmd_name, detail) do
+    kind = if Map.has_key?(bash.commands, cmd_name), do: "custom command", else: "command"
+    stderr = "bash: #{cmd_name}: #{kind} crashed (#{detail})\n"
+    {%{stdout: "", stderr: stderr, exit_code: 1}, bash}
   end
 
   # --- Redirections ---
@@ -875,62 +970,26 @@ defmodule JustBash.Interpreter.Executor do
 
       module ->
         bash = Limit.step!(bash)
-        invoke_builtin(bash, cmd, module, args, stdin)
+        module.execute(bash, args, stdin)
     end
-  end
-
-  # Containment, not defensive coding: a builtin that raises is a bug, but the
-  # ~90 registry commands run on behalf of a host that cannot act on an Elixir
-  # exception naming a JustBash internal. This gives them the same treatment
-  # `execute_custom_command/5` already gives host-supplied commands.
-  defp invoke_builtin(bash, cmd, module, args, stdin) do
-    # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
-    try do
-      module.execute(bash, args, stdin)
-    rescue
-      # These have handlers further up that produce a better diagnostic than
-      # "crashed", and a limit breach must keep unwinding to halt the script.
-      e in [Limit.ExceededError, Expansion.UnsetVariableError, ArithmeticError] ->
-        reraise e, __STACKTRACE__
-
-      error ->
-        command_crashed(bash, cmd, "#{inspect(error.__struct__)}: #{Exception.message(error)}")
-    catch
-      kind, reason ->
-        command_crashed(bash, cmd, "#{kind}: #{inspect(reason)}")
-    end
-  end
-
-  defp command_crashed(bash, cmd, detail) do
-    {%{stdout: "", stderr: "bash: #{cmd}: command crashed (#{detail})\n", exit_code: 1}, bash}
   end
 
   @control_signal_keys [:__break__, :__continue__, :__return__]
 
+  # A raise here is contained by `contain_command_crash/3`, outside the
+  # telemetry span, so a host-supplied command that crashes is reported the
+  # same way a registry one is — and stays visible in telemetry.
   defp execute_custom_command(bash, cmd_name, command, args, stdin) do
     bash = Limit.step!(bash)
 
-    # credo:disable-for-next-line Credo.Check.Readability.PreferImplicitTry
-    try do
-      case dispatch_custom_command(command, bash, args, stdin) do
-        {%{stdout: stdout, stderr: stderr, exit_code: exit_code} = result, %JustBash{} = new_bash}
-        when is_binary(stdout) and is_binary(stderr) and is_integer(exit_code) and exit_code >= 0 ->
-          # Strip any internal control-flow signals that could leak from custom commands
-          {Map.drop(result, @control_signal_keys), new_bash}
+    case dispatch_custom_command(command, bash, args, stdin) do
+      {%{stdout: stdout, stderr: stderr, exit_code: exit_code} = result, %JustBash{} = new_bash}
+      when is_binary(stdout) and is_binary(stderr) and is_integer(exit_code) and exit_code >= 0 ->
+        # Strip any internal control-flow signals that could leak from custom commands
+        {Map.drop(result, @control_signal_keys), new_bash}
 
-        _ ->
-          custom_command_error(bash, cmd_name, "custom command returned an invalid result")
-      end
-    rescue
-      error ->
-        message =
-          "custom command crashed (#{inspect(error.__struct__)}: #{Exception.message(error)})"
-
-        custom_command_error(bash, cmd_name, message)
-    catch
-      kind, reason ->
-        message = "custom command #{kind}: #{inspect(reason)}"
-        custom_command_error(bash, cmd_name, message)
+      _ ->
+        custom_command_error(bash, cmd_name, "custom command returned an invalid result")
     end
   end
 

--- a/lib/just_bash/interpreter/expansion.ex
+++ b/lib/just_bash/interpreter/expansion.ex
@@ -23,12 +23,26 @@ defmodule JustBash.Interpreter.Expansion do
     def message(%{variable: var}), do: "#{var}: unbound variable"
   end
 
-  @typedoc "Pending variable assignments from expansions like ${VAR:=default} or $((x++))"
-  @type pending_assignments :: [{String.t(), String.t()}]
+  @typedoc "A variable assignment from an expansion like ${VAR:=default} or $((x++))"
+  @type assignment :: {String.t(), String.t()}
+
+  @typedoc """
+  What a command substitution did, on its way out to the enclosing command.
+
+  Its diagnostic belongs on the shell's stderr — bash writes it there even when
+  the enclosing command redirects stderr, since the expansion happens before
+  the redirection is performed — and its exit status is what a bare assignment
+  reports as `$?`.
+  """
+  @type substitution :: {:substitution, String.t(), non_neg_integer()}
+
+  @typedoc "Side effects an expansion hands back to the enclosing command."
+  @type pending_assignments :: [assignment() | substitution()]
 
   @doc """
   Expand word parts into a string, handling all substitution types.
-  Returns the expanded string and any pending variable assignments.
+  Returns the expanded string and any side effects — see `pending_assignments/0`
+  and `take_substitutions/1`.
 
   ## Examples
 
@@ -63,12 +77,33 @@ defmodule JustBash.Interpreter.Expansion do
     result
   end
 
-  # Apply assignments to bash env (for internal use during expansion)
+  @doc """
+  Split the command-substitution traces out of a list of expansion side effects.
+
+  Returns the accumulated stderr, the exit status of the *last* substitution
+  that ran (`nil` when none did — bash reports the last one as `$?` for a bare
+  assignment), and the assignments left over.
+  """
+  @spec take_substitutions(pending_assignments()) ::
+          {String.t(), non_neg_integer() | nil, [assignment()]}
+  def take_substitutions(effects) do
+    {stderr_io, exit_code, assignments} =
+      Enum.reduce(effects, {[], nil, []}, fn
+        {:substitution, stderr, code}, {errs, _prev, assigns} -> {[errs, stderr], code, assigns}
+        assignment, {errs, code, assigns} -> {errs, code, [assignment | assigns]}
+      end)
+
+    {IO.iodata_to_binary(stderr_io), exit_code, Enum.reverse(assignments)}
+  end
+
+  # Apply assignments to bash env (for internal use during expansion).
+  # Substitution traces travel in the same list but assign nothing.
   defp apply_assignments_to_bash(bash, []), do: bash
 
-  defp apply_assignments_to_bash(bash, assignments) do
-    Enum.reduce(assignments, bash, fn {name, value}, acc ->
-      %{acc | env: Map.put(acc.env, name, value)}
+  defp apply_assignments_to_bash(bash, effects) do
+    Enum.reduce(effects, bash, fn
+      {:substitution, _stderr, _code}, acc -> acc
+      {name, value}, acc -> %{acc | env: Map.put(acc.env, name, value)}
     end)
   end
 
@@ -153,7 +188,7 @@ defmodule JustBash.Interpreter.Expansion do
   end
 
   defp expand_part(bash, %AST.CommandSubstitution{body: body}) do
-    {execute_command_substitution(bash, body), []}
+    execute_command_substitution(bash, body)
   end
 
   defp expand_part(bash, %AST.ArithmeticExpression{} = expr) do
@@ -181,9 +216,10 @@ defmodule JustBash.Interpreter.Expansion do
   defp execute_arithmetic_expansion(bash, %AST.ArithmeticExpression{raw: raw, expression: _expr})
        when raw != nil do
     # Expression contains command substitution - expand it first, then parse and evaluate
-    expanded_str = expand_arithmetic_cmd_subs(bash, raw)
+    {expanded_str, effects} = expand_arithmetic_cmd_subs(bash, raw)
     parsed_expr = Arithmetic.parse(expanded_str)
-    evaluate_arithmetic_expr(bash, parsed_expr)
+    {value, assignments} = evaluate_arithmetic_expr(bash, parsed_expr)
+    {value, effects ++ assignments}
   end
 
   defp execute_arithmetic_expansion(bash, %AST.ArithmeticExpression{expression: inner_expr}) do
@@ -208,32 +244,38 @@ defmodule JustBash.Interpreter.Expansion do
   # Expand command substitutions in arithmetic expression string
   # Handles $(...) and backticks
   defp expand_arithmetic_cmd_subs(bash, str) do
-    str
-    |> expand_dollar_cmd_subs(bash)
-    |> expand_backtick_cmd_subs(bash)
+    {str, dollar_effects} = expand_dollar_cmd_subs(str, bash)
+    {str, backtick_effects} = expand_backtick_cmd_subs(str, bash)
+    {str, dollar_effects ++ backtick_effects}
   end
 
   defp expand_dollar_cmd_subs(str, bash) do
     # Pattern: $(...)  - need to handle nested parens
-    do_expand_dollar_cmd_subs(str, bash, "")
+    do_expand_dollar_cmd_subs(str, bash, "", [])
   end
 
-  defp do_expand_dollar_cmd_subs("", _bash, acc), do: acc
+  defp do_expand_dollar_cmd_subs("", _bash, acc, effects), do: {acc, Enum.reverse(effects)}
 
-  defp do_expand_dollar_cmd_subs("$(" <> rest, bash, acc) do
+  defp do_expand_dollar_cmd_subs("$(" <> rest, bash, acc, effects) do
     # Find matching close paren
     case find_cmd_sub_end(rest, 0, "") do
       {cmd, remaining} ->
-        output = execute_command_substitution(bash, parse_cmd_sub(cmd))
-        do_expand_dollar_cmd_subs(remaining, bash, acc <> output)
+        {output, new_effects} = execute_command_substitution(bash, parse_cmd_sub(cmd))
+
+        do_expand_dollar_cmd_subs(
+          remaining,
+          bash,
+          acc <> output,
+          Enum.reverse(new_effects) ++ effects
+        )
 
       :error ->
-        do_expand_dollar_cmd_subs(rest, bash, acc <> "$(")
+        do_expand_dollar_cmd_subs(rest, bash, acc <> "$(", effects)
     end
   end
 
-  defp do_expand_dollar_cmd_subs(<<c::binary-size(1), rest::binary>>, bash, acc) do
-    do_expand_dollar_cmd_subs(rest, bash, acc <> c)
+  defp do_expand_dollar_cmd_subs(<<c::binary-size(1), rest::binary>>, bash, acc, effects) do
+    do_expand_dollar_cmd_subs(rest, bash, acc <> c, effects)
   end
 
   defp find_cmd_sub_end("", _depth, _acc), do: :error
@@ -254,24 +296,30 @@ defmodule JustBash.Interpreter.Expansion do
 
   defp expand_backtick_cmd_subs(str, bash) do
     # Pattern: `...`
-    do_expand_backtick_cmd_subs(str, bash, "")
+    do_expand_backtick_cmd_subs(str, bash, "", [])
   end
 
-  defp do_expand_backtick_cmd_subs("", _bash, acc), do: acc
+  defp do_expand_backtick_cmd_subs("", _bash, acc, effects), do: {acc, Enum.reverse(effects)}
 
-  defp do_expand_backtick_cmd_subs("`" <> rest, bash, acc) do
+  defp do_expand_backtick_cmd_subs("`" <> rest, bash, acc, effects) do
     case find_backtick_end(rest, "") do
       {cmd, remaining} ->
-        output = execute_command_substitution(bash, parse_cmd_sub(cmd))
-        do_expand_backtick_cmd_subs(remaining, bash, acc <> output)
+        {output, new_effects} = execute_command_substitution(bash, parse_cmd_sub(cmd))
+
+        do_expand_backtick_cmd_subs(
+          remaining,
+          bash,
+          acc <> output,
+          Enum.reverse(new_effects) ++ effects
+        )
 
       :error ->
-        do_expand_backtick_cmd_subs(rest, bash, acc <> "`")
+        do_expand_backtick_cmd_subs(rest, bash, acc <> "`", effects)
     end
   end
 
-  defp do_expand_backtick_cmd_subs(<<c::binary-size(1), rest::binary>>, bash, acc) do
-    do_expand_backtick_cmd_subs(rest, bash, acc <> c)
+  defp do_expand_backtick_cmd_subs(<<c::binary-size(1), rest::binary>>, bash, acc, effects) do
+    do_expand_backtick_cmd_subs(rest, bash, acc <> c, effects)
   end
 
   defp find_backtick_end("", _acc), do: :error
@@ -299,9 +347,18 @@ defmodule JustBash.Interpreter.Expansion do
     end)
   end
 
+  # The substitution runs in a subshell, so its `bash` is discarded — but its
+  # stderr and exit status are not the subshell's to keep.
   defp execute_command_substitution(bash, %AST.Script{} = script) do
     {result, _bash} = Executor.execute_script(bash, script)
-    String.trim_trailing(result.stdout, "\n")
+
+    {String.trim_trailing(result.stdout, "\n"),
+     [{:substitution, result.stderr, result.exit_code}]}
+  end
+
+  defp command_substitution_output(bash, script) do
+    {output, _effects} = execute_command_substitution(bash, script)
+    output
   end
 
   @doc """
@@ -439,7 +496,7 @@ defmodule JustBash.Interpreter.Expansion do
   end
 
   defp expand_for_loop_part(bash, %AST.CommandSubstitution{body: body}, _ifs) do
-    {execute_command_substitution(bash, body), true}
+    {command_substitution_output(bash, body), true}
   end
 
   defp expand_for_loop_part(bash, %AST.ArithmeticExpansion{expression: expr}, _ifs) do

--- a/lib/just_bash/interpreter/expansion/brace.ex
+++ b/lib/just_bash/interpreter/expansion/brace.ex
@@ -5,10 +5,19 @@ defmodule JustBash.Interpreter.Expansion.Brace do
   Handles:
   - List expansion: {a,b,c}
   - Range expansion: {1..10}, {a..z}, {1..10..2}
+
+  ## Bounds
+
+  This is the one expansion whose output size is not bounded by anything the
+  input already holds: `{1..1000000}` is twelve characters, and nesting
+  multiplies. The word list is therefore produced under two bounds — the
+  cardinality cap of `Limit.check_expansion_words!/2` and the wall clock — both
+  applied as each word is produced rather than after the list exists.
   """
 
   alias JustBash.AST
   alias JustBash.Interpreter.Expansion
+  alias JustBash.Limit
 
   @typedoc "Pending variable assignments from expansions"
   @type pending_assignments :: Expansion.pending_assignments()
@@ -31,24 +40,35 @@ defmodule JustBash.Interpreter.Expansion.Brace do
   @spec expand_with_brace(JustBash.t(), [AST.word_part()]) ::
           {[String.t()], pending_assignments()}
   def expand_with_brace(bash, parts) do
+    {_count, words, assigns} = expand_into(bash, parts, {0, [], []})
+    {Enum.reverse(words), Enum.reverse(assigns)}
+  end
+
+  # One accumulator is threaded through the whole cartesian walk instead of
+  # each level concatenating its children's results. That keeps the walk linear
+  # in the number of words rather than quadratic — `echo {1..100000}` was 18 s
+  # before — and, more importantly, gives the bounds a single place that sees
+  # every word at the moment it is produced.
+  defp expand_into(bash, parts, {count, words, assigns} = acc) do
     case find_brace_expansion(parts) do
       nil ->
-        {expanded, assignments} = Expansion.expand_word_parts(bash, parts)
-        {[expanded], assignments}
+        Limit.check_deadline!(bash)
+        count = count + 1
+        Limit.check_expansion_words!(bash, count)
+        {word, new_assigns} = Expansion.expand_word_parts(bash, parts)
+        {count, [word | words], prepend_reversed(new_assigns, assigns)}
 
       {prefix_parts, brace_exp, suffix_parts} ->
-        expanded_items = expand_brace_items(bash, brace_exp.items)
-
-        {words, all_assigns} =
-          Enum.reduce(expanded_items, {[], []}, fn item, {words_acc, assigns_acc} ->
-            new_parts = prefix_parts ++ [%AST.Literal{value: item}] ++ suffix_parts
-            {new_words, new_assigns} = expand_with_brace(bash, new_parts)
-            {words_acc ++ new_words, assigns_acc ++ new_assigns}
-          end)
-
-        {words, all_assigns}
+        bash
+        |> expand_brace_items(brace_exp.items)
+        |> Enum.reduce(acc, fn item, item_acc ->
+          new_parts = prefix_parts ++ [%AST.Literal{value: item}] ++ suffix_parts
+          expand_into(bash, new_parts, item_acc)
+        end)
     end
   end
+
+  defp prepend_reversed(new, assigns), do: Enum.reduce(new, assigns, &[&1 | &2])
 
   @doc """
   Expand brace expansion items (words and ranges).
@@ -61,6 +81,9 @@ defmodule JustBash.Interpreter.Expansion.Brace do
         words
 
       {:range, start_val, end_val, step} ->
+        # A range is the one item that materializes its whole list in one go,
+        # so it is measured before it is built.
+        Limit.check_expansion_words!(bash, range_size(start_val, end_val, step))
         expand_range(start_val, end_val, step)
     end)
   end
@@ -98,6 +121,28 @@ defmodule JustBash.Interpreter.Expansion.Brace do
   end
 
   # Private helpers
+
+  # How long `expand_range/3` would make the list, without making it. Mirrors
+  # that function's clauses exactly, including its "empty when the step runs
+  # the wrong way" case; anything it would reject outright is left for it to
+  # reject.
+  defp range_size(start_val, end_val, step)
+       when is_integer(start_val) and is_integer(end_val) do
+    step = step || if start_val <= end_val, do: 1, else: -1
+
+    if (step > 0 and start_val <= end_val) or (step < 0 and start_val >= end_val) do
+      div(abs(end_val - start_val), abs(step)) + 1
+    else
+      0
+    end
+  end
+
+  defp range_size(start_val, end_val, step)
+       when is_binary(start_val) and is_binary(end_val) do
+    range_size(:binary.first(start_val), :binary.first(end_val), step)
+  end
+
+  defp range_size(_start_val, _end_val, _step), do: 0
 
   defp find_brace_expansion(parts) do
     find_brace_expansion_loop(parts, [])

--- a/lib/just_bash/interpreter/expansion/glob.ex
+++ b/lib/just_bash/interpreter/expansion/glob.ex
@@ -9,6 +9,12 @@ defmodule JustBash.Interpreter.Expansion.Glob do
   """
 
   alias JustBash.FS
+  alias JustBash.Limit
+
+  # The filesystem plus the deadline the walk below is answerable to. Bundled
+  # rather than passed separately so every step of the descent carries the
+  # bound without widening five signatures.
+  @typep walk :: {FS.t(), Limit.Deadline.t() | nil}
 
   @doc """
   Check if a string contains glob metacharacters.
@@ -35,7 +41,8 @@ defmodule JustBash.Interpreter.Expansion.Glob do
     base_dir = if is_absolute, do: "/", else: bash.cwd
     prefix = if is_absolute, do: "/", else: ""
 
-    matches = expand_segments(bash.fs, base_dir, prefix, segments, has_trailing_slash)
+    walk = {bash.fs, bash.interpreter.deadline}
+    matches = expand_segments(walk, base_dir, prefix, segments, has_trailing_slash)
 
     if matches == [], do: [pattern], else: Enum.sort(matches)
   end
@@ -55,7 +62,8 @@ defmodule JustBash.Interpreter.Expansion.Glob do
 
   # Recursively expand segments, handling wildcards at any level
   # has_trailing_slash indicates if original pattern ended with /
-  defp expand_segments(_fs, _current_path, prefix, [], has_trailing_slash) do
+  @spec expand_segments(walk(), String.t(), String.t(), [String.t()], boolean()) :: [String.t()]
+  defp expand_segments(_walk, _current_path, prefix, [], has_trailing_slash) do
     # No more segments - return current path if it's not just the prefix
     if prefix == "" or prefix == "/" do
       []
@@ -66,10 +74,10 @@ defmodule JustBash.Interpreter.Expansion.Glob do
     end
   end
 
-  defp expand_segments(fs, current_path, prefix, [segment | rest], has_trailing_slash) do
+  defp expand_segments({fs, _deadline} = walk, current_path, prefix, [segment | rest], slash?) do
     if has_glob_chars?(segment) do
       # This segment has wildcards - expand it
-      expand_wildcard_segment(fs, current_path, prefix, segment, rest, has_trailing_slash)
+      expand_wildcard_segment(walk, current_path, prefix, segment, rest, slash?)
     else
       # No wildcards - just append and continue
       next_path = join_path(current_path, segment)
@@ -77,7 +85,7 @@ defmodule JustBash.Interpreter.Expansion.Glob do
 
       case FS.stat(fs, next_path) do
         {:ok, _, _} ->
-          expand_segments(fs, next_path, next_prefix, rest, has_trailing_slash)
+          expand_segments(walk, next_path, next_prefix, rest, slash?)
 
         {:error, _} ->
           # Path doesn't exist
@@ -86,29 +94,33 @@ defmodule JustBash.Interpreter.Expansion.Glob do
     end
   end
 
-  defp expand_wildcard_segment(fs, current_path, prefix, segment, rest, has_trailing_slash) do
+  defp expand_wildcard_segment({fs, deadline} = walk, current_path, prefix, segment, rest, slash?) do
     regex_pattern = glob_pattern_to_regex(segment)
 
     with {:ok, regex} <- Regex.compile("^" <> regex_pattern <> "$"),
          {:ok, entries, _fs} <- FS.readdir(fs, current_path) do
-      matching = Enum.filter(entries, &matches_pattern?(&1, regex, segment))
-
-      Enum.flat_map(matching, fn entry ->
-        expand_matched_entry(fs, current_path, prefix, entry, rest, has_trailing_slash)
+      # A directory read is the unit of work this descent multiplies, so the
+      # deadline is checked per matched entry — the same treatment `find` and
+      # `grep -r` get. A whole glob is one step, so nothing else bounds it.
+      entries
+      |> Enum.filter(&matches_pattern?(&1, regex, segment))
+      |> Limit.enforce_deadline(deadline)
+      |> Enum.flat_map(fn entry ->
+        expand_matched_entry(walk, current_path, prefix, entry, rest, slash?)
       end)
     else
       _ -> []
     end
   end
 
-  defp expand_matched_entry(fs, current_path, prefix, entry, rest, has_trailing_slash) do
+  defp expand_matched_entry({fs, _deadline} = walk, current_path, prefix, entry, rest, slash?) do
     next_path = join_path(current_path, entry)
     next_prefix = join_prefix(prefix, entry)
 
     if rest == [] do
-      finalize_match(fs, next_path, next_prefix, has_trailing_slash)
+      finalize_match(fs, next_path, next_prefix, slash?)
     else
-      continue_expansion(fs, next_path, next_prefix, rest, has_trailing_slash)
+      continue_expansion(walk, next_path, next_prefix, rest, slash?)
     end
   end
 
@@ -124,10 +136,10 @@ defmodule JustBash.Interpreter.Expansion.Glob do
     end
   end
 
-  defp continue_expansion(fs, path, prefix, rest, has_trailing_slash) do
+  defp continue_expansion({fs, _deadline} = walk, path, prefix, rest, has_trailing_slash) do
     case FS.stat(fs, path) do
       {:ok, %VFS.Stat{type: :directory}, _fs} ->
-        expand_segments(fs, path, prefix, rest, has_trailing_slash)
+        expand_segments(walk, path, prefix, rest, has_trailing_slash)
 
       _ ->
         []

--- a/lib/just_bash/interpreter/state.ex
+++ b/lib/just_bash/interpreter/state.ex
@@ -21,6 +21,11 @@ defmodule JustBash.Interpreter.State do
     associative arrays (`declare -A`). Used during `${arr[key]}` expansion to
     decide whether to treat the subscript as a string key or integer index.
 
+  - `deadline` — the `JustBash.Limit.Deadline` armed by the current top-level
+    `JustBash.exec/2`, or `nil` when limits are disabled. Checked by the
+    statement loop so a script that burns wall clock without doing countable
+    work still terminates.
+
   - `call_depth` — current shell function call depth. Incremented on each
     function entry, restored to the caller's depth on return. Checked against
     `bash.max_call_depth` to prevent unbounded recursion from consuming all
@@ -43,7 +48,8 @@ defmodule JustBash.Interpreter.State do
           output_bytes: non_neg_integer(),
           exec_depth: non_neg_integer(),
           max_exec_depth: non_neg_integer(),
-          halted: boolean()
+          halted: boolean(),
+          deadline: JustBash.Limit.Deadline.t() | nil
         }
 
   defstruct stdin: nil,
@@ -54,7 +60,8 @@ defmodule JustBash.Interpreter.State do
             output_bytes: 0,
             exec_depth: 0,
             max_exec_depth: 0,
-            halted: false
+            halted: false,
+            deadline: nil
 
   @doc "Returns a fresh interpreter state."
   @spec new() :: t()
@@ -65,4 +72,8 @@ defmodule JustBash.Interpreter.State do
   def reset_counters(%__MODULE__{} = state) do
     %{state | step_count: 0, output_bytes: 0, max_exec_depth: 0, halted: false}
   end
+
+  @doc "Arm the wall clock deadline for a new top-level execution."
+  @spec arm_deadline(t(), JustBash.Limit.Deadline.t() | nil) :: t()
+  def arm_deadline(%__MODULE__{} = state, deadline), do: %{state | deadline: deadline}
 end

--- a/lib/just_bash/limit.ex
+++ b/lib/just_bash/limit.ex
@@ -36,6 +36,10 @@ defmodule JustBash.Limit do
   that burns wall clock without doing countable work — the shape both of this
   project's historical hangs took. Nested `eval`/`source` run inside the
   top-level call's budget rather than starting a fresh one.
+
+  `:max_steps` does double duty: a whole word is one step no matter what it
+  expands into, so it is also the cap on how many words a single word may
+  expand into — see `check_expansion_words!/2`.
   """
 
   defmodule ExceededError do
@@ -45,6 +49,7 @@ defmodule JustBash.Limit do
     ## Kinds
 
     - `:step_limit` — too many computation steps
+    - `:expansion_limit` — one word expanded into too many words
     - `:output_limit` — stdout + stderr exceeded byte cap
     - `:file_size_limit` — single file write exceeded byte cap
     - `:regex_pattern_limit` — regex pattern string too large
@@ -171,6 +176,34 @@ defmodule JustBash.Limit do
     end
 
     %{bash | interpreter: %{interp | step_count: count}}
+  end
+
+  @doc """
+  Bound how many words one word may expand into. Raises `ExceededError` if exceeded.
+
+  The step counter cannot see this: a word is a single step regardless of the
+  size of the list it names, so `{1..1000000}` — twelve characters — is one
+  step and a million words. That is counted work, not merely slow work, so the
+  bound is `:max_steps` rather than the wall clock; the clock is checked
+  alongside it so a budget large enough to permit the list still cannot be
+  spent entirely on building it.
+
+  Call this with the running count as the list is produced, not with the
+  finished list's length — the point is to refuse before the memory is spent.
+  """
+  @spec check_expansion_words!(JustBash.t(), non_neg_integer()) :: :ok
+  def check_expansion_words!(%{limits: nil}, _count), do: :ok
+
+  def check_expansion_words!(%{limits: limits}, count) do
+    if count > limits.max_steps do
+      raise ExceededError,
+        kind: :expansion_limit,
+        message: "word expansion limit exceeded (#{limits.max_steps} words)",
+        limit: limits.max_steps,
+        actual: count
+    end
+
+    :ok
   end
 
   @doc "Track output bytes. Raises `ExceededError` if limit is reached."

--- a/lib/just_bash/limit.ex
+++ b/lib/just_bash/limit.ex
@@ -4,7 +4,7 @@ defmodule JustBash.Limit do
 
   Prevents untrusted scripts from exhausting memory or CPU by enforcing
   hard caps on computation steps, output size, file size, regex patterns,
-  and execution nesting depth.
+  execution nesting depth, and elapsed wall clock time.
 
   ## Usage
 
@@ -19,6 +19,23 @@ defmodule JustBash.Limit do
 
       # No limits (not recommended for untrusted input)
       bash = JustBash.new(limits: false)
+
+  ## Bounds
+
+  | key | `:strict` | `:default` | `:relaxed` |
+  | --- | --- | --- | --- |
+  | `:max_steps` | 10_000 | 100_000 | 1_000_000 |
+  | `:max_output_bytes` | 65_536 | 1_048_576 | 10_485_760 |
+  | `:max_file_bytes` | 65_536 | 1_048_576 | 10_485_760 |
+  | `:max_regex_pattern_bytes` | 10_000 | 10_000 | 10_000 |
+  | `:max_exec_depth` | 128 | 128 | 128 |
+  | `:max_wall_ms` | 1_000 | 5_000 | 30_000 |
+
+  Every bound but the last counts work. `:max_wall_ms` bounds elapsed time for
+  a single `JustBash.exec/2`, which is the only bound that catches a script
+  that burns wall clock without doing countable work — the shape both of this
+  project's historical hangs took. Nested `eval`/`source` run inside the
+  top-level call's budget rather than starting a fresh one.
   """
 
   defmodule ExceededError do
@@ -32,8 +49,26 @@ defmodule JustBash.Limit do
     - `:file_size_limit` — single file write exceeded byte cap
     - `:regex_pattern_limit` — regex pattern string too large
     - `:exec_depth_limit` — eval/source nesting too deep
+    - `:wall_clock_limit` — a single `JustBash.exec/2` ran too long
     """
     defexception [:kind, :message, :limit, :actual]
+  end
+
+  defmodule Deadline do
+    @moduledoc """
+    The instant a single `JustBash.exec/2` must be finished by.
+
+    `at_ms` is read from `System.monotonic_time/1`, which never jumps
+    backwards when the wall clock is adjusted, so a deadline armed once at the
+    top of an execution stays meaningful for its whole duration. `max_wall_ms`
+    is carried alongside purely so the diagnostic can name the bound that was
+    breached.
+    """
+
+    @type t :: %__MODULE__{at_ms: integer(), max_wall_ms: pos_integer()}
+
+    @enforce_keys [:at_ms, :max_wall_ms]
+    defstruct [:at_ms, :max_wall_ms]
   end
 
   @enforce_keys [
@@ -41,14 +76,16 @@ defmodule JustBash.Limit do
     :max_output_bytes,
     :max_file_bytes,
     :max_regex_pattern_bytes,
-    :max_exec_depth
+    :max_exec_depth,
+    :max_wall_ms
   ]
   defstruct [
     :max_steps,
     :max_output_bytes,
     :max_file_bytes,
     :max_regex_pattern_bytes,
-    :max_exec_depth
+    :max_exec_depth,
+    :max_wall_ms
   ]
 
   @type t :: %__MODULE__{
@@ -56,15 +93,21 @@ defmodule JustBash.Limit do
           max_output_bytes: pos_integer(),
           max_file_bytes: pos_integer(),
           max_regex_pattern_bytes: pos_integer(),
-          max_exec_depth: pos_integer()
+          max_exec_depth: pos_integer(),
+          max_wall_ms: pos_integer()
         }
 
+  # 5 seconds: every script in this repo's corpus finishes in single-digit
+  # milliseconds, so the default is three orders of magnitude of headroom —
+  # generous enough that a legitimate script never trips it, small enough that
+  # an agent waiting on the sandbox is never blocked for long.
   @default_values %{
     max_steps: 100_000,
     max_output_bytes: 1_048_576,
     max_file_bytes: 1_048_576,
     max_regex_pattern_bytes: 10_000,
-    max_exec_depth: 128
+    max_exec_depth: 128,
+    max_wall_ms: 5_000
   }
 
   @valid_keys Map.keys(@default_values)
@@ -75,14 +118,21 @@ defmodule JustBash.Limit do
   def new(:default), do: defaults()
 
   def new(:strict),
-    do: %{defaults() | max_steps: 10_000, max_output_bytes: 65_536, max_file_bytes: 65_536}
+    do: %{
+      defaults()
+      | max_steps: 10_000,
+        max_output_bytes: 65_536,
+        max_file_bytes: 65_536,
+        max_wall_ms: 1_000
+    }
 
   def new(:relaxed),
     do: %{
       defaults()
       | max_steps: 1_000_000,
         max_output_bytes: 10_485_760,
-        max_file_bytes: 10_485_760
+        max_file_bytes: 10_485_760,
+        max_wall_ms: 30_000
     }
 
   def new(opts) when is_list(opts) do
@@ -154,6 +204,66 @@ defmodule JustBash.Limit do
     end
 
     %{bash | interpreter: %{interp | exec_depth: depth, max_exec_depth: max_depth}}
+  end
+
+  # --- Wall clock ---
+
+  @doc """
+  Arm a deadline for one top-level execution, or `nil` when limits are off.
+
+  Call this once per `JustBash.exec/2` and carry the result; `check_deadline!/1`
+  then costs a single monotonic clock read and an integer comparison, so it is
+  affordable on the interpreter's statement loop.
+  """
+  @spec deadline(t() | nil) :: Deadline.t() | nil
+  def deadline(nil), do: nil
+
+  def deadline(%__MODULE__{max_wall_ms: max_wall_ms}) do
+    %Deadline{at_ms: System.monotonic_time(:millisecond) + max_wall_ms, max_wall_ms: max_wall_ms}
+  end
+
+  @doc """
+  Raise `ExceededError` if an armed deadline has passed.
+
+  Accepts a `Deadline`, a `JustBash` struct carrying one, or `nil` for "no
+  bound". Counting limits cannot see a loop that burns time without doing
+  countable work, which is how both of this project's historical hangs escaped
+  every other bound.
+  """
+  @spec check_deadline!(Deadline.t() | JustBash.t() | nil) :: :ok
+  def check_deadline!(nil), do: :ok
+
+  def check_deadline!(%Deadline{at_ms: at_ms, max_wall_ms: max_wall_ms}) do
+    if System.monotonic_time(:millisecond) > at_ms do
+      raise ExceededError,
+        kind: :wall_clock_limit,
+        message: "execution wall clock limit exceeded (#{max_wall_ms} ms)",
+        limit: max_wall_ms,
+        actual: elapsed_ms(at_ms, max_wall_ms)
+    end
+
+    :ok
+  end
+
+  def check_deadline!(%{interpreter: %{deadline: deadline}}), do: check_deadline!(deadline)
+
+  defp elapsed_ms(at_ms, max_wall_ms),
+    do: max_wall_ms + System.monotonic_time(:millisecond) - at_ms
+
+  @doc """
+  Wrap an enumerable so each element it yields first checks `deadline`.
+
+  Used by `JustBash.FS.walk/3`: a traversal is a single command as far as the
+  step counter is concerned, so without this a pathological tree is unbounded.
+  """
+  @spec enforce_deadline(Enumerable.t(), Deadline.t() | nil) :: Enumerable.t()
+  def enforce_deadline(enumerable, nil), do: enumerable
+
+  def enforce_deadline(enumerable, %Deadline{} = deadline) do
+    Stream.map(enumerable, fn element ->
+      check_deadline!(deadline)
+      element
+    end)
   end
 
   # --- Pure check functions (no state mutation) ---

--- a/lib/just_bash/limit.ex
+++ b/lib/just_bash/limit.ex
@@ -253,8 +253,10 @@ defmodule JustBash.Limit do
   @doc """
   Wrap an enumerable so each element it yields first checks `deadline`.
 
-  Used by `JustBash.FS.walk/3`: a traversal is a single command as far as the
-  step counter is concerned, so without this a pathological tree is unbounded.
+  Used by `JustBash.Commands.Seq`: a whole command is a single step as far as
+  the step counter is concerned, so without this `seq 1 100000000` is
+  unbounded. Commands whose loop is not already an enumerable call
+  `check_deadline!/1` directly instead — see `JustBash.Commands.Find`.
   """
   @spec enforce_deadline(Enumerable.t(), Deadline.t() | nil) :: Enumerable.t()
   def enforce_deadline(enumerable, nil), do: enumerable

--- a/lib/just_bash/telemetry.ex
+++ b/lib/just_bash/telemetry.ex
@@ -27,6 +27,10 @@ defmodule JustBash.Telemetry do
     * Measurement: `%{duration: native_time, monotonic_time: integer}`
     * Metadata: `%{session: pid(), kind: :error | :exit | :throw, reason: term,
       stacktrace: list, telemetry_span_context: reference()}`
+    * Rare by design: the interpreter contains a crashed command and a raise
+      from the statement loop, so those produce a `:stop` with a non-zero
+      `exit_code` — plus a `[:just_bash, :command, :exception]` when a command
+      was the cause — rather than an exception here.
 
   ### Command Execution
 
@@ -47,6 +51,10 @@ defmodule JustBash.Telemetry do
     * Measurement: `%{duration: native_time, monotonic_time: integer}`
     * Metadata: `%{command: String.t(), args: list(String.t()), kind: atom,
       reason: term, stacktrace: list, telemetry_span_context: reference()}`
+    * A command that raises is *contained* — `JustBash.exec/2` still returns a
+      shell result — but the containment sits outside this span deliberately,
+      so a crash stays distinguishable from a script that legitimately fails.
+      The `:stop` event does not fire for the same command.
 
   ### For Loop Execution
 

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -120,6 +120,116 @@ defmodule JustBash.SandboxContractTest do
     end
   end
 
+  describe "an internal error" do
+    test "keeps the output and the session state of the statements before it" do
+      # Containment must not mean amnesia. The neighbouring Limit.ExceededError
+      # handler already behaves this way; this one must match it.
+      script = "echo hi > /f.txt; export FOO=bar; echo before; wreck-env; echo $HOME"
+      {result, bash} = JustBash.exec(probe_bash(), script)
+
+      assert result.exit_code == 1
+      assert result.stdout == "before\n"
+      assert result.stderr =~ "bash: internal error ("
+
+      {result, _bash} = JustBash.exec(bash, "cat /f.txt; echo FOO=$FOO")
+      assert result.stdout == "hi\nFOO=bar\n"
+    end
+
+    test "halts the rest of the script, the way a limit breach does" do
+      {result, _bash} = JustBash.exec(probe_bash(), "echo before; wreck-env; echo after")
+
+      assert result.exit_code == 1
+      assert result.stdout == "before\n"
+      refute result.stdout =~ "after"
+    end
+
+    test "a limit breach keeps the output of the statements before it" do
+      # The behaviour the internal-error path is being held to.
+      bash = JustBash.new(limits: [max_steps: 4])
+      script = "echo a > /f.txt; echo one; echo two; echo three; echo four; echo five"
+      {result, bash} = JustBash.exec(bash, script)
+
+      assert result.exit_code == 1
+      assert result.stdout == "one\ntwo\nthree\n"
+
+      {result, _bash} = JustBash.exec(bash, "cat /f.txt")
+      assert result.stdout == "a\n"
+    end
+
+    test "has a stderr that respects max_output_bytes" do
+      # `Exception.message/1` is unbounded from the sandbox's point of view —
+      # `inspect/1` alone allows 4096 bytes per binary — so a MatchError or
+      # KeyError carrying interpreter or filesystem state could inline sandbox
+      # file contents into a stderr the host asked to be capped.
+      bash = probe_bash(limits: [max_output_bytes: 100])
+      {result, _bash} = JustBash.exec(bash, "wreck-env; echo $HOME")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "bash: internal error ("
+      assert byte_size(result.stderr) <= 100
+    end
+
+    test "has a stderr that stays bounded under generous limits" do
+      {result, _bash} = JustBash.exec(probe_bash(limits: :relaxed), "wreck-env; echo $HOME")
+
+      assert result.exit_code == 1
+      assert byte_size(result.stderr) <= 512
+    end
+  end
+
+  describe "telemetry" do
+    # Containing a crash must not retire the documented
+    # [:just_bash, :command, :exception] event: the failure class this PR
+    # contains used to be loud, and a host can already subscribe to it.
+    setup do
+      handler = "sandbox-contract-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler,
+        [:just_bash, :command, :exception],
+        fn event, measurements, metadata, _config ->
+          # Other async modules share this global handler; only forward the
+          # commands this module drives.
+          if metadata.command in ["cat", "boom", "echo"] do
+            send(test_pid, {:telemetry, event, measurements, metadata})
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+      :ok
+    end
+
+    test "a contained registry crash still emits [:just_bash, :command, :exception]" do
+      {result, _bash} = JustBash.exec(probe_bash(), "wreck; cat /etc/hosts")
+
+      assert result.exit_code == 1
+      assert_receive {:telemetry, [:just_bash, :command, :exception], measurements, metadata}
+      assert metadata.command == "cat"
+      assert metadata.kind == :error
+      assert metadata.reason == :function_clause
+      assert is_list(metadata.stacktrace)
+      assert is_integer(measurements.duration)
+    end
+
+    test "a contained custom-command crash still emits [:just_bash, :command, :exception]" do
+      {result, _bash} = JustBash.exec(probe_bash(), "boom")
+
+      assert result.exit_code == 1
+      assert_receive {:telemetry, [:just_bash, :command, :exception], _measurements, metadata}
+      assert metadata.command == "boom"
+    end
+
+    test "a command that does not raise emits no exception event" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "echo ok")
+
+      assert result.exit_code == 0
+      refute_receive {:telemetry, [:just_bash, :command, :exception], _, _}, 50
+    end
+  end
+
   describe "exec!/2" do
     test "arms the wall clock like exec/2" do
       # Unlike `max_steps`, the wall clock has to be armed, so an entry point
@@ -135,19 +245,23 @@ defmodule JustBash.SandboxContractTest do
       assert elapsed_us < 300_000
     end
 
-    test "propagates an interpreter exception rather than containing it" do
-      # The documented difference from `exec/2`: `exec!/2` is the uncontained
-      # entry point. A host running untrusted script text wants `exec/2`.
-      assert catch_error(JustBash.exec!(probe_bash(), "wreck-env; echo $HOME"))
+    test "contains an internal error, because the statement loop does" do
+      # The containment lives in the interpreter now, not in `exec/2`'s rescue,
+      # so both public entry points get it.
+      {result, _bash} = JustBash.exec!(probe_bash(), "wreck-env; echo $HOME")
 
-      {result, _bash} = JustBash.exec(probe_bash(), "wreck-env; echo $HOME")
       assert result.exit_code == 1
+      assert result.stderr =~ "bash: internal error ("
     end
 
-    test "raises on a parse error" do
+    test "raises on a parse error, where exec/2 returns a syntax-error result" do
       assert_raise RuntimeError, ~r/Parse error/, fn ->
         JustBash.exec!(JustBash.new(), "echo 'unterminated")
       end
+
+      {result, _bash} = JustBash.exec(JustBash.new(), "echo 'unterminated")
+      assert result.exit_code == 2
+      assert result.stderr =~ "bash: syntax error:"
     end
   end
 
@@ -416,7 +530,9 @@ defmodule JustBash.SandboxContractTest do
       assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
     end
 
-    test "an awk loop that terminates on its own is untouched", %{bash: bash} do
+    test "an awk loop that terminates on its own is untouched" do
+      # A budget the shared 50 ms one cannot flake against under a loaded suite.
+      bash = JustBash.new(limits: [max_wall_ms: 30_000])
       result = bounded_exec(bash, "awk 'BEGIN{for(i=0;i<3;i++){print i}}'")
 
       assert result.exit_code == 0
@@ -448,9 +564,12 @@ defmodule JustBash.SandboxContractTest do
         {elapsed_us, {result, _bash}} =
           :timer.tc(fn -> JustBash.exec(bash, unquote(script) <> " > /dev/null") end)
 
+        # The exit code is the discriminator — unbounded, each of these returns
+        # exit 0 with empty stderr. `elapsed_us` is the overrun guard: the
+        # review measured 4.9-8.1 s on a larger tree under a 1 ms budget.
         assert result.exit_code == 1
         assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
-        assert elapsed_us < 300_000
+        assert elapsed_us < 1_000_000
       end
     end
 

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -8,7 +8,6 @@ defmodule JustBash.SandboxContractTest do
 
   use ExUnit.Case, async: true
 
-  alias JustBash.FS
   alias JustBash.Limit
 
   # --- Probes ---
@@ -121,6 +120,37 @@ defmodule JustBash.SandboxContractTest do
     end
   end
 
+  describe "exec!/2" do
+    test "arms the wall clock like exec/2" do
+      # Unlike `max_steps`, the wall clock has to be armed, so an entry point
+      # that skips arming silently has no bound at all.
+      bash = probe_bash(limits: [max_wall_ms: 30, max_steps: 10_000_000])
+
+      {elapsed_us, {result, final}} =
+        :timer.tc(fn -> JustBash.exec!(bash, "for i in $(seq 1 100); do spin; done") end)
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (30 ms)"
+      assert final.interpreter.deadline != nil
+      assert elapsed_us < 300_000
+    end
+
+    test "propagates an interpreter exception rather than containing it" do
+      # The documented difference from `exec/2`: `exec!/2` is the uncontained
+      # entry point. A host running untrusted script text wants `exec/2`.
+      assert catch_error(JustBash.exec!(probe_bash(), "wreck-env; echo $HOME"))
+
+      {result, _bash} = JustBash.exec(probe_bash(), "wreck-env; echo $HOME")
+      assert result.exit_code == 1
+    end
+
+    test "raises on a parse error" do
+      assert_raise RuntimeError, ~r/Parse error/, fn ->
+        JustBash.exec!(JustBash.new(), "echo 'unterminated")
+      end
+    end
+  end
+
   describe "a crashed command reports through composition" do
     # Oracle: GNU bash 3.2/5.x. `cmd | cat`, `echo $(cmd)` and `if cmd; then fi`
     # are all exit 0 — the pipeline reports its last stage, and `if` with no
@@ -218,23 +248,104 @@ defmodule JustBash.SandboxContractTest do
       assert result.stdout == "ok\n"
     end
 
-    test "bounds a traversal, which the step counter charges as a single step" do
-      # `find` never returned through a symlink cycle (#53). The cycle is gone,
-      # but nothing structural stopped the next one — a whole tree walk is one
-      # step, so only the wall clock can bound it.
-      files = for i <- 1..1000, into: %{}, do: {"/tree/#{rem(i, 10)}/#{i}/f.txt", "x"}
-      bash = JustBash.new(files: files, limits: [max_wall_ms: 1, max_steps: 10_000_000])
-
-      {result, _bash} = JustBash.exec(bash, "find /tree")
-
-      assert result.exit_code == 1
-      assert result.stderr =~ "execution wall clock limit exceeded (1 ms)"
-    end
-
     test "rejects a non-positive value like every other bound" do
       assert_raise ArgumentError, ~r/positive integers/, fn ->
         Limit.new(max_wall_ms: 0)
       end
+    end
+  end
+
+  describe "a loop inside a single command" do
+    # The statement loop is never re-entered while one command spins, and a
+    # whole command is one step, so only a deadline checked *inside* the
+    # command's own loop bounds it. This is the shape of the `printf '%b'`
+    # hang (56c74b8) issue #69 cites. Each probe runs under a task so a
+    # regression fails the test instead of hanging the suite.
+    setup do
+      {:ok, bash: JustBash.new(limits: [max_wall_ms: 50, max_steps: 10_000_000])}
+    end
+
+    defp bounded_exec(bash, script) do
+      task = Task.async(fn -> JustBash.exec(bash, script) end)
+
+      case Task.yield(task, 5_000) || Task.shutdown(task, :brutal_kill) do
+        {:ok, {result, _bash}} -> result
+        nil -> flunk("`#{script}` did not terminate within 5s")
+      end
+    end
+
+    test "awk's while loop is bounded", %{bash: bash} do
+      result = bounded_exec(bash, "awk 'BEGIN{while(1){x=x+1}}'")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
+    end
+
+    test "awk's for loop is bounded", %{bash: bash} do
+      result = bounded_exec(bash, "awk 'BEGIN{for(i=0;i>=0;i++){}}'")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
+    end
+
+    test "awk's do-while loop is bounded", %{bash: bash} do
+      result = bounded_exec(bash, "awk 'BEGIN{do{x=x+1}while(1)}'")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
+    end
+
+    test "seq's range walk is bounded", %{bash: bash} do
+      result = bounded_exec(bash, "seq 1 100000000")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
+    end
+
+    test "an awk loop that terminates on its own is untouched", %{bash: bash} do
+      result = bounded_exec(bash, "awk 'BEGIN{for(i=0;i<3;i++){print i}}'")
+
+      assert result.exit_code == 0
+      assert result.stdout == "0\n1\n2\n"
+    end
+  end
+
+  describe "a recursive traversal" do
+    # `find` never returned through a symlink cycle (#53). The cycle is gone,
+    # but nothing structural stopped the next one — a whole tree walk is one
+    # step, so only the wall clock can bound it, and every recursive command
+    # hand-rolls its own descent. Unbounded, these run 300-700 ms on this tree.
+    setup do
+      files = for i <- 1..2000, into: %{}, do: {"/tree/#{rem(i, 20)}/#{i}/f.txt", "hello #{i}"}
+
+      {:ok,
+       files: files,
+       bash: JustBash.new(files: files, limits: [max_wall_ms: 50, max_steps: 10_000_000])}
+    end
+
+    for {command, script} <- [
+          {"find", "find /tree"},
+          {"grep -r", "grep -r hello /tree"},
+          {"du", "du /tree"},
+          {"tree", "tree /tree"},
+          {"cp -r", "cp -r /tree /copy"}
+        ] do
+      test "#{command} is bounded by the wall clock", %{bash: bash} do
+        {elapsed_us, {result, _bash}} =
+          :timer.tc(fn -> JustBash.exec(bash, unquote(script) <> " > /dev/null") end)
+
+        assert result.exit_code == 1
+        assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
+        assert elapsed_us < 300_000
+      end
+    end
+
+    test "a traversal that fits inside the budget is untouched", %{files: files} do
+      bash = JustBash.new(files: files, limits: [max_wall_ms: 30_000])
+      {result, _bash} = JustBash.exec(bash, "find /tree -name f.txt | wc -l")
+
+      assert result.exit_code == 0
+      assert result.stdout == "2000\n"
     end
   end
 
@@ -256,33 +367,22 @@ defmodule JustBash.SandboxContractTest do
     end
   end
 
-  describe "FS.walk/3 deadline" do
-    setup do
-      fs =
-        Enum.reduce(1..20, FS.new(), fn i, acc ->
-          {:ok, acc} = FS.mkdir(acc, "/d/#{i}", parents: true)
-          {:ok, acc} = FS.write_file(acc, "/d/#{i}/f", "x")
-          acc
-        end)
-
-      {:ok, fs: fs}
+  describe "Limit.enforce_deadline/2" do
+    test "passes the enumerable through untouched without a deadline" do
+      assert 1..20 |> Limit.enforce_deadline(nil) |> Enum.count() == 20
     end
 
-    test "walks normally without a deadline", %{fs: fs} do
-      assert fs |> FS.walk("/d") |> Enum.count() == 20
-    end
-
-    test "walks normally with a deadline that has not passed", %{fs: fs} do
+    test "yields every element while the deadline holds" do
       deadline = Limit.deadline(Limit.new(max_wall_ms: 10_000))
-      assert fs |> FS.walk("/d", deadline: deadline) |> Enum.count() == 20
+      assert 1..20 |> Limit.enforce_deadline(deadline) |> Enum.count() == 20
     end
 
-    test "raises once the deadline has passed", %{fs: fs} do
+    test "raises once the deadline has passed" do
       expired = Limit.deadline(Limit.new(max_wall_ms: 1))
       Process.sleep(5)
 
       assert_raise Limit.ExceededError, ~r/wall clock limit exceeded/, fn ->
-        fs |> FS.walk("/d", deadline: expired) |> Enum.to_list()
+        1..20 |> Limit.enforce_deadline(expired) |> Enum.to_list()
       end
     end
   end

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -202,6 +202,120 @@ defmodule JustBash.SandboxContractTest do
     end
   end
 
+  describe "command substitution" do
+    # Oracle: GNU bash 3.2.57. A substitution's diagnostic always reaches the
+    # shell's stderr — even past a `2>` on the enclosing command, since the
+    # expansion happens before the redirection is performed. Its exit status is
+    # reported as `$?` only when nothing else in the statement claims `$?`:
+    # a bare assignment takes the *last* substitution's status, while a command
+    # (including the `export`/`local` builtins) reports its own.
+    test "a diagnostic from inside a substitution reaches the caller" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "echo $(cat /nope)")
+
+      assert result.stdout == "\n"
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "a diagnostic survives a redirection on the enclosing command" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "echo $(cat /nope) 2>/dev/null")
+
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "a diagnostic from a quoted substitution reaches the caller" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "echo \"$(cat /nope)\"")
+
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "a diagnostic from a substitution nested in a parameter expansion reaches the caller" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "echo ${x:-$(cat /nope)}")
+
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "every substitution in a command reports" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "echo $(cat /nope) $(cat /nada)")
+
+      assert result.stderr ==
+               "cat: /nope: No such file or directory\ncat: /nada: No such file or directory\n"
+    end
+
+    test "a bare assignment reports the substitution's exit code as $?" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "x=$(cat /nope); echo code=$? x=$x")
+
+      assert result.stdout == "code=1 x=\n"
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "a bare assignment whose substitution succeeds stays at zero" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "x=$(echo hi); echo code=$? x=$x")
+
+      assert result.stdout == "code=0 x=hi\n"
+      assert result.stderr == ""
+    end
+
+    test "a bare assignment with no substitution stays at zero" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "x=1; echo code=$? x=$x")
+
+      assert result.stdout == "code=0 x=1\n"
+    end
+
+    test "a bare assignment reports the last substitution of several" do
+      {result, _bash} =
+        JustBash.exec(JustBash.new(), "y=$(cat /nope) x=$(cat /nada); echo code=$?")
+
+      assert result.stdout == "code=1\n"
+
+      assert result.stderr ==
+               "cat: /nope: No such file or directory\ncat: /nada: No such file or directory\n"
+    end
+
+    test "a failing substitution is the script's exit code when it is the last statement" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "x=$(cat /nope)")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "a crashed command inside a substitution is not a silent success" do
+      {result, _bash} = JustBash.exec(probe_bash(), "x=$(boom)")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "custom command crashed"
+    end
+
+    test "export keeps its own exit code, per POSIX" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "export x=$(cat /nope); echo code=$?")
+
+      assert result.stdout == "code=0\n"
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "local keeps its own exit code, per POSIX" do
+      script = "f() { local y=$(cat /nope); echo code=$?; }; f"
+      {result, _bash} = JustBash.exec(JustBash.new(), script)
+
+      assert result.stdout == "code=0\n"
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "a command reports its own exit code, not the substitution's" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "echo $(cat /nope); echo code=$?")
+
+      assert result.stdout == "\ncode=0\n"
+    end
+
+    test "an assignment prefixing a command reports both diagnostics" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "x=$(cat /nope) cat /nada; echo code=$?")
+
+      assert result.stdout == "code=1\n"
+
+      assert result.stderr ==
+               "cat: /nope: No such file or directory\ncat: /nada: No such file or directory\n"
+    end
+  end
+
   describe "max_wall_ms" do
     test "is part of the default limits" do
       assert Limit.defaults().max_wall_ms == 5_000

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -568,6 +568,87 @@ defmodule JustBash.SandboxContractTest do
     end
   end
 
+  describe "an expansion that generates from a short input" do
+    # A word is one step, so the step counter never sees inside an expansion —
+    # and brace expansion is the one path where a handful of characters names
+    # an arbitrarily large word list. Measured on the pre-fix tree under
+    # `:strict`: `echo {1..100000}` took 18.3 s and `echo {1..1000000}` never
+    # returned. Each probe runs under a task so a regression fails the test
+    # instead of wedging the suite.
+    setup do
+      {:ok, bash: JustBash.new(limits: [max_wall_ms: 50, max_steps: 5_000])}
+    end
+
+    for {label, script} <- [
+          {"a flat range", "echo {1..1000000}"},
+          {"a nested product", "echo {1..300}{1..300}{1..300}"},
+          {"a list crossed with a range", "echo {a,b,c}{1..500000}"},
+          {"a `for` list", "for i in {1..1000000}; do :; done"},
+          {"an array assignment", "a=({1..1000000}); echo ${#a[@]}"}
+        ] do
+      test "#{label} is bounded", %{bash: bash} do
+        result = bounded_exec(bash, unquote(script))
+
+        # Unbounded, each of these is exit 0 with empty stderr — when it
+        # returns at all.
+        assert result.exit_code == 1
+        assert result.stderr =~ "limit exceeded"
+      end
+    end
+
+    test "a range is refused before it is built, not after" do
+      # A range materializes in one go, so counting words as they arrive is too
+      # late — the memory is already spent. `elapsed_us` is what distinguishes
+      # the two: measured, this range costs 880 ms and ~1 GB to build and 0 ms
+      # to measure. The clock gets room it cannot need so cardinality answers.
+      bash = JustBash.new(limits: [max_steps: 100, max_wall_ms: 30_000])
+
+      {elapsed_us, {result, _bash}} =
+        :timer.tc(fn -> JustBash.exec(bash, "echo {1..20000000}") end)
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "word expansion limit exceeded (100 words)"
+      assert elapsed_us < 200_000
+    end
+
+    test "a product of ranges each inside the bound is still counted" do
+      # Neither range is refusable on its own — 50 is well under the cap — so
+      # the 2,500 words their product names are caught only by counting as the
+      # walk produces them. The clock again has room it cannot need.
+      bash = JustBash.new(limits: [max_steps: 100, max_wall_ms: 30_000])
+      {result, _bash} = JustBash.exec(bash, "echo {1..50}{1..50}")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "word expansion limit exceeded (100 words)"
+    end
+
+    test "the wall clock still bounds a word list the cardinality cap allows" do
+      # A million words is inside a ten-million step budget, so cardinality has
+      # nothing to say; only the deadline checked inside the walk stops this.
+      bash = JustBash.new(limits: [max_steps: 10_000_000, max_wall_ms: 50])
+      result = bounded_exec(bash, "echo {1..1000}{1..1000}")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
+    end
+
+    test "an expansion that fits inside the budget is untouched" do
+      bash = JustBash.new(limits: [max_steps: 100, max_wall_ms: 30_000])
+      {result, _bash} = JustBash.exec(bash, "echo {1..5} {a..e} {x,y}{1..3}")
+
+      assert result.exit_code == 0
+      assert result.stdout == "1 2 3 4 5 a b c d e x1 x2 x3 y1 y2 y3\n"
+    end
+
+    test "a word list right at the bound is allowed" do
+      bash = JustBash.new(limits: [max_steps: 100, max_wall_ms: 30_000])
+      {result, _bash} = JustBash.exec(bash, "echo {1..10}{1..10} | wc -w")
+
+      assert result.exit_code == 0
+      assert result.stdout == "100\n"
+    end
+  end
+
   describe "a recursive traversal" do
     # `find` never returned through a symlink cycle (#53). The cycle is gone,
     # but nothing structural stopped the next one — a whole tree walk is one
@@ -586,7 +667,11 @@ defmodule JustBash.SandboxContractTest do
           {"grep -r", "grep -r hello /tree"},
           {"du", "du /tree"},
           {"tree", "tree /tree"},
-          {"cp -r", "cp -r /tree /copy"}
+          {"cp -r", "cp -r /tree /copy"},
+          # Glob expansion descends the tree itself, one directory read per
+          # wildcard segment, and is the one traversal that happens before a
+          # command is even chosen. Unbounded, this one runs ~295 ms.
+          {"glob expansion", "echo /tree/*/*/*"}
         ] do
       test "#{command} is bounded by the wall clock", %{bash: bash} do
         {elapsed_us, {result, _bash}} =

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -63,6 +63,15 @@ defmodule JustBash.SandboxContractTest do
     end
   end
 
+  # A telemetry handler is global, so other async modules hit it too; only the
+  # commands this module drives are forwarded to the waiting test.
+  def forward_exception(event, measurements, %{command: command} = metadata, test_pid)
+      when command in ["cat", "boom", "echo"] do
+    send(test_pid, {:telemetry, event, measurements, metadata})
+  end
+
+  def forward_exception(_event, _measurements, _metadata, _test_pid), do: :ok
+
   defp probe_bash(opts \\ []) do
     JustBash.new(
       [commands: %{"boom" => Boom, "wreck" => Wreck, "wreck-env" => WreckEnv, "spin" => Spin}] ++
@@ -188,14 +197,8 @@ defmodule JustBash.SandboxContractTest do
       :telemetry.attach(
         handler,
         [:just_bash, :command, :exception],
-        fn event, measurements, metadata, _config ->
-          # Other async modules share this global handler; only forward the
-          # commands this module drives.
-          if metadata.command in ["cat", "boom", "echo"] do
-            send(test_pid, {:telemetry, event, measurements, metadata})
-          end
-        end,
-        nil
+        &__MODULE__.forward_exception/4,
+        test_pid
       )
 
       on_exit(fn -> :telemetry.detach(handler) end)

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -447,7 +447,9 @@ defmodule JustBash.SandboxContractTest do
       assert result.exit_code == 1
       assert result.stderr =~ "execution wall clock limit exceeded (30 ms)"
       assert final.interpreter.step_count < 10_000_000
-      assert elapsed_us < 2_000_000
+      # On the order of the bound it guards, not 66x it: a deadline that fired
+      # sixty times late must not pass.
+      assert elapsed_us < 300_000
     end
 
     test "a script that finishes inside the budget is untouched" do
@@ -459,21 +461,44 @@ defmodule JustBash.SandboxContractTest do
     end
 
     test "the deadline is rearmed for each top-level exec" do
-      bash = probe_bash(limits: [max_wall_ms: 200])
+      # Six execs of ~55 ms against a 200 ms budget. Each one on its own is
+      # comfortably inside the budget, so the run only stays green if every
+      # exec starts a fresh one — arming once and never refreshing runs out
+      # partway through.
+      bash = probe_bash(limits: [max_wall_ms: 200, max_steps: 10_000_000])
 
-      {result, bash} = JustBash.exec(bash, "spin; spin; echo one")
-      assert result.stdout == "one\n"
+      Enum.reduce(1..6, bash, fn i, bash ->
+        {result, bash} = JustBash.exec(bash, "spin; spin; spin; spin; spin; echo #{i}")
 
-      {result, _bash} = JustBash.exec(bash, "spin; spin; echo two")
-      assert result.stdout == "two\n"
+        assert result.exit_code == 0, "exec #{i}: #{result.stderr}"
+        assert result.stdout == "#{i}\n"
+        bash
+      end)
+    end
+
+    test "each exec's deadline is a later instant than the previous one's" do
+      # The structural half of the same guarantee, immune to how fast the
+      # machine is: rearming must move `at_ms` forward.
+      bash = probe_bash(limits: [max_wall_ms: 5_000])
+
+      {_result, first} = JustBash.exec(bash, "echo one")
+      Process.sleep(5)
+      {_result, second} = JustBash.exec(first, "echo two")
+
+      assert second.interpreter.deadline.at_ms > first.interpreter.deadline.at_ms
     end
 
     test "limits: false disables the wall clock too" do
       bash = probe_bash(limits: false)
-      {result, _bash} = JustBash.exec(bash, "spin; echo ok")
+      {result, bash} = JustBash.exec(bash, "spin; echo ok")
 
       assert result.exit_code == 0
       assert result.stdout == "ok\n"
+      # Structural, because 10 ms of work passes under any non-degenerate
+      # budget: `Limit.deadline(nil)` must not quietly hand back a
+      # default-budget deadline.
+      assert bash.limits == nil
+      assert bash.interpreter.deadline == nil
     end
 
     test "rejects a non-positive value like every other bound" do

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -1,0 +1,289 @@
+defmodule JustBash.SandboxContractTest do
+  @moduledoc """
+  The two guarantees `JustBash.exec/2` owes a host that runs untrusted script
+  text: it returns, and it returns a shell-shaped result rather than raising.
+
+  See issue #69.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias JustBash.FS
+  alias JustBash.Limit
+
+  # --- Probes ---
+
+  defmodule Boom do
+    @behaviour JustBash.Commands.Command
+
+    @impl true
+    def names, do: ["boom"]
+
+    @impl true
+    def execute(_bash, _args, _stdin), do: raise(ArgumentError, "from inside a command")
+  end
+
+  # Hands back a structurally valid result alongside a wrecked `JustBash` struct,
+  # so the *next* command — a registry builtin — is the one that raises.
+  defmodule Wreck do
+    @behaviour JustBash.Commands.Command
+
+    @impl true
+    def names, do: ["wreck"]
+
+    @impl true
+    def execute(bash, _args, _stdin) do
+      {%{stdout: "", stderr: "", exit_code: 0}, %{bash | fs: :not_a_filesystem}}
+    end
+  end
+
+  # Same idea, but the wreckage is in `env`, so the raise happens during
+  # expansion — outside command dispatch entirely.
+  defmodule WreckEnv do
+    @behaviour JustBash.Commands.Command
+
+    @impl true
+    def names, do: ["wreck-env"]
+
+    @impl true
+    def execute(bash, _args, _stdin) do
+      {%{stdout: "", stderr: "", exit_code: 0}, %{bash | env: :not_a_map}}
+    end
+  end
+
+  defmodule Spin do
+    @behaviour JustBash.Commands.Command
+
+    @impl true
+    def names, do: ["spin"]
+
+    @impl true
+    def execute(bash, _args, _stdin) do
+      Process.sleep(10)
+      {%{stdout: "", stderr: "", exit_code: 0}, bash}
+    end
+  end
+
+  defp probe_bash(opts \\ []) do
+    JustBash.new(
+      [commands: %{"boom" => Boom, "wreck" => Wreck, "wreck-env" => WreckEnv, "spin" => Spin}] ++
+        opts
+    )
+  end
+
+  describe "exec/2 contains an unexpected raise" do
+    test "a custom command that raises becomes a non-zero exit" do
+      {result, _bash} = JustBash.exec(probe_bash(), "boom")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "bash: boom: custom command crashed (ArgumentError:"
+    end
+
+    test "a registry builtin that raises becomes a non-zero exit" do
+      {result, _bash} = JustBash.exec(probe_bash(), "wreck; cat /etc/hosts")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "bash: cat: command crashed (FunctionClauseError:"
+      assert result.stdout == ""
+    end
+
+    test "a raise from outside command dispatch becomes a non-zero exit" do
+      {result, _bash} = JustBash.exec(probe_bash(), "wreck-env; echo $HOME")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "bash: internal error ("
+    end
+
+    test "an argument a builtin cannot parse does not escape as an Elixir exception" do
+      # `head -n abc` raised FunctionClauseError out of exec/2. The diagnostic
+      # text is the arg-parsing layer's business; the contract here is only that
+      # the host gets a shell result back.
+      {result, _bash} = JustBash.exec(JustBash.new(), "head -n abc")
+
+      assert result.exit_code != 0
+      assert result.stderr != ""
+    end
+
+    test "a contained crash does not halt the rest of the script" do
+      {result, _bash} = JustBash.exec(probe_bash(), "boom; echo after")
+
+      assert result.stdout == "after\n"
+      assert result.stderr =~ "custom command crashed"
+    end
+
+    test "limit breaches keep their own diagnostic rather than reading as a crash" do
+      bash = JustBash.new(limits: [max_steps: 5])
+      {result, _bash} = JustBash.exec(bash, "for i in 1 2 3 4 5 6 7 8 9 10; do echo $i; done")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution step limit exceeded"
+      refute result.stderr =~ "crashed"
+    end
+  end
+
+  describe "a crashed command reports through composition" do
+    # Oracle: GNU bash 3.2/5.x. `cmd | cat`, `echo $(cmd)` and `if cmd; then fi`
+    # are all exit 0 — the pipeline reports its last stage, and `if` with no
+    # matching branch is success. What must survive is the diagnostic.
+    test "stderr from a non-final pipeline stage reaches the caller" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "cat /nope | cat")
+
+      assert result.exit_code == 0
+      assert result.stderr == "cat: /nope: No such file or directory\n"
+    end
+
+    test "a crash in a non-final pipeline stage reaches the caller" do
+      {result, _bash} = JustBash.exec(probe_bash(), "boom | cat")
+
+      assert result.exit_code == 0
+      assert result.stderr =~ "custom command crashed"
+    end
+
+    test "every failing stage of a pipeline reports" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "cat /nope | cat /nada | cat")
+
+      assert result.stderr ==
+               "cat: /nope: No such file or directory\ncat: /nada: No such file or directory\n"
+    end
+
+    test "a redirected stage stays silent" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "cat /nope 2>/dev/null | cat")
+
+      assert result.stderr == ""
+    end
+
+    test "PIPESTATUS still records the failing stage" do
+      {result, _bash} = JustBash.exec(JustBash.new(), "cat /nope | cat; echo ${PIPESTATUS[0]}")
+
+      assert result.stdout == "1\n"
+    end
+
+    test "pipefail still surfaces the failing stage's exit code" do
+      {result, _bash} = JustBash.exec(probe_bash(), "set -o pipefail; boom | cat")
+
+      assert result.exit_code == 1
+    end
+
+    test "a crash inside an if condition takes the else branch" do
+      {result, _bash} = JustBash.exec(probe_bash(), "if boom; then echo yes; else echo no; fi")
+
+      assert result.exit_code == 0
+      assert result.stdout == "no\n"
+    end
+  end
+
+  describe "max_wall_ms" do
+    test "is part of the default limits" do
+      assert Limit.defaults().max_wall_ms == 5_000
+      assert Limit.new(:strict).max_wall_ms == 1_000
+      assert Limit.new(:relaxed).max_wall_ms == 30_000
+      assert Limit.new(max_wall_ms: 42).max_wall_ms == 42
+    end
+
+    test "bounds a script that spins without approaching any other limit" do
+      bash = probe_bash(limits: [max_wall_ms: 30, max_steps: 10_000_000])
+
+      {elapsed_us, {result, final}} =
+        :timer.tc(fn -> JustBash.exec(bash, "for i in $(seq 1 200); do spin; done") end)
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (30 ms)"
+      assert final.interpreter.step_count < 10_000_000
+      assert elapsed_us < 2_000_000
+    end
+
+    test "a script that finishes inside the budget is untouched" do
+      bash = JustBash.new(limits: [max_wall_ms: 5_000])
+      {result, _bash} = JustBash.exec(bash, "for i in 1 2 3; do echo $i; done")
+
+      assert result.exit_code == 0
+      assert result.stdout == "1\n2\n3\n"
+    end
+
+    test "the deadline is rearmed for each top-level exec" do
+      bash = probe_bash(limits: [max_wall_ms: 200])
+
+      {result, bash} = JustBash.exec(bash, "spin; spin; echo one")
+      assert result.stdout == "one\n"
+
+      {result, _bash} = JustBash.exec(bash, "spin; spin; echo two")
+      assert result.stdout == "two\n"
+    end
+
+    test "limits: false disables the wall clock too" do
+      bash = probe_bash(limits: false)
+      {result, _bash} = JustBash.exec(bash, "spin; echo ok")
+
+      assert result.exit_code == 0
+      assert result.stdout == "ok\n"
+    end
+
+    test "bounds a traversal, which the step counter charges as a single step" do
+      # `find` never returned through a symlink cycle (#53). The cycle is gone,
+      # but nothing structural stopped the next one — a whole tree walk is one
+      # step, so only the wall clock can bound it.
+      files = for i <- 1..1000, into: %{}, do: {"/tree/#{rem(i, 10)}/#{i}/f.txt", "x"}
+      bash = JustBash.new(files: files, limits: [max_wall_ms: 1, max_steps: 10_000_000])
+
+      {result, _bash} = JustBash.exec(bash, "find /tree")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (1 ms)"
+    end
+
+    test "rejects a non-positive value like every other bound" do
+      assert_raise ArgumentError, ~r/positive integers/, fn ->
+        Limit.new(max_wall_ms: 0)
+      end
+    end
+  end
+
+  describe "Limit.check_deadline!/1" do
+    test "passes when there is no deadline" do
+      assert Limit.check_deadline!(nil) == :ok
+    end
+
+    test "passes before the deadline and raises after it" do
+      deadline = Limit.deadline(Limit.new(max_wall_ms: 10_000))
+      assert Limit.check_deadline!(deadline) == :ok
+
+      expired = Limit.deadline(Limit.new(max_wall_ms: 1))
+      Process.sleep(5)
+
+      assert_raise Limit.ExceededError, ~r/wall clock limit exceeded \(1 ms\)/, fn ->
+        Limit.check_deadline!(expired)
+      end
+    end
+  end
+
+  describe "FS.walk/3 deadline" do
+    setup do
+      fs =
+        Enum.reduce(1..20, FS.new(), fn i, acc ->
+          {:ok, acc} = FS.mkdir(acc, "/d/#{i}", parents: true)
+          {:ok, acc} = FS.write_file(acc, "/d/#{i}/f", "x")
+          acc
+        end)
+
+      {:ok, fs: fs}
+    end
+
+    test "walks normally without a deadline", %{fs: fs} do
+      assert fs |> FS.walk("/d") |> Enum.count() == 20
+    end
+
+    test "walks normally with a deadline that has not passed", %{fs: fs} do
+      deadline = Limit.deadline(Limit.new(max_wall_ms: 10_000))
+      assert fs |> FS.walk("/d", deadline: deadline) |> Enum.count() == 20
+    end
+
+    test "raises once the deadline has passed", %{fs: fs} do
+      expired = Limit.deadline(Limit.new(max_wall_ms: 1))
+      Process.sleep(5)
+
+      assert_raise Limit.ExceededError, ~r/wall clock limit exceeded/, fn ->
+        fs |> FS.walk("/d", deadline: expired) |> Enum.to_list()
+      end
+    end
+  end
+end

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -522,10 +522,18 @@ defmodule JustBash.SandboxContractTest do
     end
 
     defp bounded_exec(bash, script) do
-      task = Task.async(fn -> JustBash.exec(bash, script) end)
+      {_elapsed_us, result} = bounded_exec_timed(bash, script)
+      result
+    end
+
+    # The clock is read *inside* the task, so a probe that asserts on elapsed
+    # time measures the run itself rather than the yield, and still fails at 5s
+    # instead of wedging the suite.
+    defp bounded_exec_timed(bash, script) do
+      task = Task.async(fn -> :timer.tc(fn -> JustBash.exec(bash, script) end) end)
 
       case Task.yield(task, 5_000) || Task.shutdown(task, :brutal_kill) do
-        {:ok, {result, _bash}} -> result
+        {:ok, {elapsed_us, {result, _bash}}} -> {elapsed_us, result}
         nil -> flunk("`#{script}` did not terminate within 5s")
       end
     end
@@ -603,8 +611,7 @@ defmodule JustBash.SandboxContractTest do
       # to measure. The clock gets room it cannot need so cardinality answers.
       bash = JustBash.new(limits: [max_steps: 100, max_wall_ms: 30_000])
 
-      {elapsed_us, {result, _bash}} =
-        :timer.tc(fn -> JustBash.exec(bash, "echo {1..20000000}") end)
+      {elapsed_us, result} = bounded_exec_timed(bash, "echo {1..20000000}")
 
       assert result.exit_code == 1
       assert result.stderr =~ "word expansion limit exceeded (100 words)"
@@ -616,7 +623,7 @@ defmodule JustBash.SandboxContractTest do
       # the 2,500 words their product names are caught only by counting as the
       # walk produces them. The clock again has room it cannot need.
       bash = JustBash.new(limits: [max_steps: 100, max_wall_ms: 30_000])
-      {result, _bash} = JustBash.exec(bash, "echo {1..50}{1..50}")
+      result = bounded_exec(bash, "echo {1..50}{1..50}")
 
       assert result.exit_code == 1
       assert result.stderr =~ "word expansion limit exceeded (100 words)"
@@ -634,7 +641,7 @@ defmodule JustBash.SandboxContractTest do
 
     test "an expansion that fits inside the budget is untouched" do
       bash = JustBash.new(limits: [max_steps: 100, max_wall_ms: 30_000])
-      {result, _bash} = JustBash.exec(bash, "echo {1..5} {a..e} {x,y}{1..3}")
+      result = bounded_exec(bash, "echo {1..5} {a..e} {x,y}{1..3}")
 
       assert result.exit_code == 0
       assert result.stdout == "1 2 3 4 5 a b c d e x1 x2 x3 y1 y2 y3\n"
@@ -642,7 +649,7 @@ defmodule JustBash.SandboxContractTest do
 
     test "a word list right at the bound is allowed" do
       bash = JustBash.new(limits: [max_steps: 100, max_wall_ms: 30_000])
-      {result, _bash} = JustBash.exec(bash, "echo {1..10}{1..10} | wc -w")
+      result = bounded_exec(bash, "echo {1..10}{1..10} | wc -w")
 
       assert result.exit_code == 0
       assert result.stdout == "100\n"


### PR DESCRIPTION
Closes #69

`JustBash.exec/2` owes a host two things when it runs untrusted script text: it
returns, and it returns a shell result rather than an Elixir exception. Neither
was contractual. Both are now, with tests as the net.

> **Updated after review.** The first round of this PR kept both guarantees only
> at the edges: containment sat in `exec/2`'s rescue (which rolls the session
> back) and inside the telemetry span (which retired a documented event), and
> the wall clock was only checked between statements, on one entry point, and in
> one traversal. Eight confirmed findings are addressed in commits `554d8d9`
> through `16c85b3`; the description below is the current state.
> [Finding-by-finding resolutions.](https://github.com/elixir-ai-tools/just_bash/pull/73#issuecomment-5205027570)

## 1. A raise from a builtin escaped `exec/2`

Only custom commands had a catch-all (`executor.ex:865`). The ~90 registry
commands had none, and `exec/2` had no `rescue` at all — only `Parser.parse`
errors were handled. The issue cites the `cp` `MatchError` from #52 and a `date`
`FunctionClauseError` found during #67; both are fixed, but the hole they came
through was not.

A live one still on `main`:

```elixir
{r, _} = JustBash.exec(JustBash.new(), "head -n abc")
** (FunctionClauseError) no function clause matching in Enum.take/2
```

And, from the issue's own probe shape — a command that hands back a wrecked
`JustBash` struct, so the *next* registry command is the one that raises:

```elixir
{r, _} = JustBash.exec(bash, "wreck; cat /etc/hosts")
** (FunctionClauseError) no function clause matching in VFS.impl_module/1
```

**Fix.** Containment happens at two levels, both chosen so that nothing already
done is lost:

- `Executor.contain_command_crash/3` wraps command dispatch, giving registry
  commands the treatment host-supplied ones already had:
  `bash: cat: command crashed (FunctionClauseError: ...)`, exit 1, script
  continues. It sits **outside** `Telemetry.command_span/3` deliberately, so
  `:telemetry.span/3` still sees the exception and the documented
  `[:just_bash, :command, :exception]` event keeps firing — containing it inside
  the span silently retired that event for every command in the registry.
  `execute_custom_command/5`'s own rescue folded into the same place, so a
  host-supplied command that crashes is now visible in telemetry too; it never
  was.
- `Executor.run_statement/2` wraps everything else the statement loop runs —
  expansion, redirection, control flow — reporting
  `bash: internal error (...)`, halting the script, and **keeping the output and
  the shell state of the statements that already ran**. That is why it lives in
  the statement loop rather than in `exec/2`: a rescue on `exec/2` is a clause of
  its implicit `try` and can only see the parameter, so it silently rolls the
  whole session back. This matches the neighbouring `Limit.ExceededError`
  handler, which already behaved that way.

`exec/2` keeps an outer net as a last resort, for raises outside the statement
loop (parsing, the EXIT trap). Its stderr is truncated to
`min(512, max_output_bytes)` on a UTF-8 boundary: `Exception.message/1` is
unbounded from the sandbox's point of view — `inspect/1` alone allows 4096 bytes
per binary — so a `MatchError` carrying interpreter or filesystem state could
otherwise inline sandbox file contents into a stderr the host asked to be capped.

Every rescue carries a comment saying this is deliberate containment at a trust
boundary, not defensive coding: a raise reaching them is a bug in JustBash, but a
host driving the sandbox has no way to act on an exception naming a JustBash
internal, so it must still get a shell-shaped answer. The type-specific rescues
stay — `Limit.ExceededError`, `Expansion.UnsetVariableError` and `ArithmeticError`
are re-raised so their existing handlers keep producing the better message (and
so a limit breach keeps unwinding to halt the script).

Because containment now lives in the interpreter rather than in `exec/2`,
`exec!/2` inherits it. What `exec!/2` still propagates — a `RuntimeError` on a
parse error, and anything raised outside the statement loop — is now stated in
its `@doc` instead of the old "raising on parse errors".

### Related: what composition actually loses

The issue reports the *exit code* being dropped through pipelines and command
substitution. Checked against the oracle first (GNU bash 3.2.57):

```console
$ bash -c 'cat /nope | cat; echo "code=$?"'
cat: /nope: No such file or directory
code=0
$ bash -c 'echo $(cat /nope); echo "code=$?"'
cat: /nope: No such file or directory

code=0
$ bash -c 'x=$(cat /nope); echo "code=$?"'
cat: /nope: No such file or directory
code=1
```

A pipeline reports its last stage, and a command reports its own status — so
those exit codes were already right, and the tests assert them against bash
rather than "fixing" them. A **bare assignment** is the one form where bash does
propagate the substitution's status, and it is the last substitution that wins
(`y=$(cat /nope) x=$(cat /nada)` is code=1; `x=$(cat /nope) y=$(echo ok)` is
code=0). `export`, `local` and `declare` keep their own status.

What *was* lost, in both paths, is the diagnostic:

- `execute_pipeline/2` now accumulates every stage's stderr as iodata (only
  stdout is piped onward). `2>/dev/null` on a stage still silences that stage,
  and `PIPESTATUS` and `pipefail` are unchanged.
- `execute_command_substitution/2` now returns a `{:substitution, stderr,
  exit_code}` trace alongside the assignments an expansion already hands back,
  so it travels out of arbitrarily nested expansions — `"$(...)"`,
  `${x:-$(...)}`, `$(( $(...) + 1 ))`, backticks — without a second channel.
  `Expansion.take_substitutions/1` splits the traces out at the two consumers: a
  simple command prepends the accumulated stderr to its result *outside*
  `with_redirections/3` (bash performs redirections after expansion, so
  `echo $(cat /nope) 2>/dev/null` still prints the diagnostic), and a bare
  assignment reports the last substitution's status as `$?`.

**Still out of scope:** array literals (`arr=($(cat /nope))`) and for-loop word
lists (`for i in $(cat /nope)`) discard expansion side effects entirely and stay
silent. Both also drop `${VAR:=default}` assignments, which predates this PR, so
that path wants its own change.

## 2. `Limit` had no wall-clock bound

```elixir
JustBash.Limit.defaults() |> Map.keys()
#=> [:max_exec_depth, :max_file_bytes, :max_regex_pattern_bytes, :max_output_bytes, :max_steps]
```

Every bound counted work. Both historical hangs burned wall clock without
consuming a step — `printf '%b'` recycling its format (`56c74b8`), `find`
looping a symlink cycle (#53) — so nothing fired.

**Fix.** `max_wall_ms`, defaulting to **5_000 ms** (1_000 strict, 30_000
relaxed). Documented in a bounds table in `JustBash.Limit`'s moduledoc. 5s is
three orders of magnitude above what any script in this repo's corpus takes:
generous enough that a legitimate script never trips it, small enough that an
agent waiting on the sandbox is never blocked for long.

A `Limit.Deadline` struct (`at_ms` from `System.monotonic_time/1`, plus
`max_wall_ms` so the diagnostic can name the bound) is armed **once** per
top-level execution — by `exec/2` *and* `exec!/2`, which share `arm_top_level/1`
— and carried in `Interpreter.State`. `Limit.check_deadline!/1` is then one clock
read and an integer comparison: no timestamp per step, no allocation.

It is checked everywhere a script can burn time without doing countable work.
The statement loop is not enough on its own — a shell-level `while true; do :;
done` was already bounded by `max_steps` and `Loop`'s iteration cap, and the
shape that actually escaped every bound is "one command, many iterations":

- the interpreter statement loop (`Executor.execute_statement/2`);
- **a loop inside a single command** — awk's `for`, `while` and `do-while`
  (`awk 'BEGIN{while(1){x=x+1}}'` hung forever), and `seq`'s range walk
  (`seq 1 100000000`), via `Limit.enforce_deadline/2`. sed has no label/branch
  support, printf's format recycling terminates, and the expansion paths are
  bounded by the statement loop;
- **every recursive traversal** — `find`, `grep -r`, `du`, `tree`, and `cp -r`
  (whose recursion lives in `FS.cp/4`, which gained a `:deadline` option). A
  whole traversal is charged as a single step, so on an 8000-file tree with a
  1 ms budget the unbounded ones ran 4.5-8.1 seconds at exit 0 with empty
  stderr. `rm -rf` is a bulk prune rather than a hand-rolled descent and is
  unaffected (3 ms on the same tree).

It raises `Limit.ExceededError` with `kind: :wall_clock_limit`, so the existing
rescue in `execute_statement/2` reports it and halts, exactly like the other
bounds:

```
bash: execution wall clock limit exceeded (30 ms)
```

Nested `eval`/`source` run inside the top-level call's budget rather than
starting a fresh one.

## Tests

`test/sandbox_contract_test.exs`, 62 tests. Every one was watched failing before
its fix. Probes are synthetic and stable rather than leaning on any one command's
arg parsing, so a sibling PR fixing `head` cannot silently retire them:

- `Boom` — the issue's custom-behaviour module, raises on `execute/3`.
- `Wreck` / `WreckEnv` — return a valid result plus a corrupted `JustBash`
  struct, so the raise happens inside a *registry* builtin, and inside
  *expansion*, respectively.
- `Spin` — `Process.sleep(10)` per call, for a deterministic wall-clock probe.

Covering: containment for custom, registry and non-dispatch raises, and that an
internal error keeps the prior statements' output and session state (with the
`Limit.ExceededError` handler pinned alongside as the reference behaviour);
that a contained crash does not halt the rest of the script; that a limit breach
keeps its own diagnostic; that `head -n abc` returns a shell result; pipeline
stderr for one, several and redirected stages, with `PIPESTATUS` and `pipefail`
unchanged; fifteen command-substitution forms checked against the oracle;
`exec!/2`'s wall clock, containment and parse-error contract; `max_wall_ms`
defaults and presets; awk's three loop forms and `seq` bounded under a `Task` so
a regression fails rather than hangs; five recursive commands bounded on a
2000-file tree; that the deadline is rearmed per execution, asserted both
behaviourally and structurally; that `limits: false` leaves `deadline == nil`;
and that a contained crash still emits `[:just_bash, :command, :exception]`.

The three wall-clock tests were each verified red against the mutation they are
named for — arming only when `deadline == nil`, and `deadline(nil)` returning a
default-budget deadline.

## Gates

`mix compile --warnings-as-errors --force`
```
Compiling 168 files (.ex)
Generated just_bash app
```

`mix format --check-formatted`
```
(no output, exit 0)
```

`mix credo --strict`
```
  Refactoring opportunities

┃ [F] ↘ Avoid `apply/2` and `apply/3` when the number of arguments is known.
┃       test/support/banned_fixture_apply.ex:4:16 #(BannedCallTracer.Fixture.Apply.run)

Analysis took 1.7 seconds (0.09s to load, 1.6s running 68 checks on 230 files)
5149 mods/funs, found 1 refactoring opportunity.
```
The single finding is the intentional test fixture; identical on `main`.

`mix test`
```
Finished in 23.8 seconds (23.5s async, 0.2s sync)
2 doctests, 62 properties, 4814 tests, 0 failures (5 excluded)
```

`mix dialyzer`
```
ignore_warnings: .dialyzer_ignore.exs
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done in 0m3.1s
done (passed successfully)
```

## Note for reviewers

`JustBash.BannedCallTracer`'s grep heuristic flags `= System` on any source
line, so `check_deadline!/1` reads the clock in expression position rather than
binding it. That is why the raise path calls `System.monotonic_time/1` a second
time via `elapsed_ms/2` instead of reusing a bound value; the hot path still
does exactly one read.

`FS.walk/3`'s `:deadline` option from the first round is gone: it never had a
caller in `lib/`, and `Limit.enforce_deadline/2` is the general mechanism, now
reached from `seq`. Commands whose loop is not already an enumerable call
`check_deadline!/1` directly.
