### PR TITLE
fix: filesystem commands name the actual error kind, and the Oils spec parser reads the format

### DIFF
--- a/lib/just_bash.ex
+++ b/lib/just_bash.ex
@@ -664,8 +664,8 @@ defmodule JustBash do
       {:ok, script, fs} ->
         exec(%{bash | fs: fs}, script)
 
-      {:error, _reason} ->
-        error_msg = "#{path}: No such file or directory\n"
+      {:error, error} ->
+        error_msg = "#{path}: #{FS.strerror(error)}\n"
         {%{stdout: "", stderr: error_msg, exit_code: 1, env: bash.env}, bash}
     end
   end

--- a/lib/just_bash/commands/awk.ex
+++ b/lib/just_bash/commands/awk.ex
@@ -177,7 +177,7 @@ defmodule JustBash.Commands.Awk do
 
         case FS.read_file(fs, resolved) do
           {:ok, content, fs} -> {:cont, {:ok, acc ++ [{resolved, content}], fs}}
-          {:error, _} -> {:halt, {:error, "awk: #{file}: No such file or directory\n"}}
+          {:error, error} -> {:halt, {:error, "awk: #{file}: #{FS.strerror(error)}\n"}}
         end
       end)
 

--- a/lib/just_bash/commands/awk.ex
+++ b/lib/just_bash/commands/awk.ex
@@ -14,6 +14,7 @@ defmodule JustBash.Commands.Awk do
 
   alias JustBash.Commands.Awk.{Evaluator, Parser}
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -84,8 +85,8 @@ defmodule JustBash.Commands.Awk do
   # Returns {:ok, [{filename, content}, ...], bash} for multi-file support
   defp get_file_data(bash, [], stdin), do: {:ok, [{"", stdin}], bash}
 
-  defp get_file_data(bash, files, _stdin) do
-    read_files_with_names(bash, files)
+  defp get_file_data(bash, files, stdin) do
+    read_files_with_names(bash, files, stdin)
   end
 
   defp parse_args(args) do
@@ -170,13 +171,13 @@ defmodule JustBash.Commands.Awk do
     end
   end
 
-  defp read_files_with_names(bash, files) do
+  defp read_files_with_names(bash, files, stdin) do
     result =
       Enum.reduce_while(files, {:ok, [], bash.fs}, fn file, {:ok, acc, fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
+        name = if StdinOperand.stdin?(file), do: file, else: FS.resolve_path(bash.cwd, file)
 
-        case FS.read_file(fs, resolved) do
-          {:ok, content, fs} -> {:cont, {:ok, acc ++ [{resolved, content}], fs}}
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
+          {:ok, content, fs} -> {:cont, {:ok, acc ++ [{name, content}], fs}}
           {:error, error} -> {:halt, {:error, "awk: #{file}: #{FS.strerror(error)}\n"}}
         end
       end)

--- a/lib/just_bash/commands/base64.ex
+++ b/lib/just_bash/commands/base64.ex
@@ -99,7 +99,7 @@ defmodule JustBash.Commands.Base64 do
 
     case FS.read_file(fs, resolved) do
       {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
-      {:error, _} -> {:halt, {:error, "base64: #{file}: No such file or directory\n"}}
+      {:error, error} -> {:halt, {:error, "base64: #{file}: #{FS.strerror(error)}\n"}}
     end
   end
 

--- a/lib/just_bash/commands/base64.ex
+++ b/lib/just_bash/commands/base64.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Base64 do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -23,13 +24,8 @@ defmodule JustBash.Commands.Base64 do
     end
   end
 
-  defp get_content(opts, bash, stdin) do
-    if opts.files == [] or opts.files == ["-"] do
-      {{:ok, stdin}, bash}
-    else
-      read_files(bash, opts.files)
-    end
-  end
+  defp get_content(%{files: []}, bash, stdin), do: {{:ok, stdin}, bash}
+  defp get_content(opts, bash, stdin), do: read_files(bash, opts.files, stdin)
 
   defp process_content({:error, msg}, _opts), do: {:error, msg}
 
@@ -72,6 +68,11 @@ defmodule JustBash.Commands.Base64 do
     end
   end
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts) do
+    parse_args(rest, %{opts | files: opts.files ++ ["-"]})
+  end
+
   defp parse_args(["-" <> _ = arg | _rest], _opts) do
     {:error, "base64: invalid option '#{arg}'\n"}
   end
@@ -80,10 +81,10 @@ defmodule JustBash.Commands.Base64 do
     parse_args(rest, %{opts | files: opts.files ++ [file]})
   end
 
-  defp read_files(bash, files) do
+  defp read_files(bash, files, stdin) do
     result =
       Enum.reduce_while(files, {:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
-        read_single_file(bash, fs, file, acc)
+        read_single_file(bash, fs, file, stdin, acc)
       end)
 
     case result do
@@ -92,12 +93,8 @@ defmodule JustBash.Commands.Base64 do
     end
   end
 
-  defp read_single_file(_bash, fs, "-", acc), do: {:cont, {:ok, acc, fs}}
-
-  defp read_single_file(bash, fs, file, acc) do
-    resolved = FS.resolve_path(bash.cwd, file)
-
-    case FS.read_file(fs, resolved) do
+  defp read_single_file(bash, fs, file, stdin, acc) do
+    case StdinOperand.read(fs, bash.cwd, file, stdin) do
       {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
       {:error, error} -> {:halt, {:error, "base64: #{file}: #{FS.strerror(error)}\n"}}
     end

--- a/lib/just_bash/commands/chmod.ex
+++ b/lib/just_bash/commands/chmod.ex
@@ -50,8 +50,8 @@ defmodule JustBash.Commands.Chmod do
           {:ok, _, new_fs} ->
             {err, code, new_fs}
 
-          {:error, _} ->
-            {err <> "chmod: cannot access '#{path}': No such file or directory\n", 1, fs}
+          {:error, error} ->
+            {err <> "chmod: cannot access '#{path}': #{FS.strerror(error)}\n", 1, fs}
         end
       end)
 

--- a/lib/just_bash/commands/chown.ex
+++ b/lib/just_bash/commands/chown.ex
@@ -48,8 +48,8 @@ defmodule JustBash.Commands.Chown do
           {:ok, _, new_fs} ->
             {err, code, new_fs}
 
-          {:error, _} ->
-            {err <> "chown: cannot access '#{path}': No such file or directory\n", 1, fs}
+          {:error, error} ->
+            {err <> "chown: cannot access '#{path}': #{FS.strerror(error)}\n", 1, fs}
         end
       end)
 

--- a/lib/just_bash/commands/comm.ex
+++ b/lib/just_bash/commands/comm.ex
@@ -95,7 +95,7 @@ defmodule JustBash.Commands.Comm do
 
     case FS.read_file(fs, resolved) do
       {:ok, content, fs} -> {:ok, content, fs}
-      {:error, _} -> {:error, "comm: #{file}: No such file or directory\n"}
+      {:error, error} -> {:error, "comm: #{file}: #{FS.strerror(error)}\n"}
     end
   end
 

--- a/lib/just_bash/commands/comm.ex
+++ b/lib/just_bash/commands/comm.ex
@@ -80,6 +80,11 @@ defmodule JustBash.Commands.Comm do
     parse_args(rest, %{opts | suppress1: true, suppress2: true, suppress3: true})
   end
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts) do
+    parse_args(rest, %{opts | files: opts.files ++ ["-"]})
+  end
+
   defp parse_args(["-" <> _ = arg | _rest], _opts) do
     {:error, "comm: invalid option -- '#{arg}'\n"}
   end

--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -191,7 +191,7 @@ defmodule JustBash.Commands.Cp do
   end
 
   defp copy_one(bash, "", _dest, _opts),
-    do: {Command.error("cp: cannot stat '': No such file or directory\n"), bash}
+    do: {Command.error("cp: cannot stat '': #{FS.strerror(:enoent)}\n"), bash}
 
   defp copy_one(bash, src, "", opts), do: empty_dest(bash, src, opts)
 
@@ -425,13 +425,13 @@ defmodule JustBash.Commands.Cp do
   end
 
   defp empty_dest_error(:directory, %Options{mode: :recursive}),
-    do: Command.error("cp: cannot create directory '': No such file or directory\n")
+    do: Command.error("cp: cannot create directory '': #{FS.strerror(:enoent)}\n")
 
   defp empty_dest_error(:directory, %Options{mode: :shallow}),
     do: Command.error("cp: -r not specified; omitting directory ''\n")
 
   defp empty_dest_error(:file, _opts),
-    do: Command.error("cp: cannot create regular file '': No such file or directory\n")
+    do: Command.error("cp: cannot create regular file '': #{FS.strerror(:enoent)}\n")
 
   # The destination of a copy into a directory, spelled the way bash spells it
   # in messages: the directory operand with the source's basename appended. The

--- a/lib/just_bash/commands/cut.ex
+++ b/lib/just_bash/commands/cut.ex
@@ -15,9 +15,9 @@ defmodule JustBash.Commands.Cut do
         {Command.error(msg), bash}
 
       {:ok, opts} ->
-        {content, fs} = get_content(bash, opts.files, stdin)
+        {content, errors, exit_code, fs} = get_content(bash, opts.files, stdin)
         output = process_content(content, opts)
-        {Command.ok(output), %{bash | fs: fs}}
+        {Command.result(output, errors, exit_code), %{bash | fs: fs}}
     end
   end
 
@@ -79,15 +79,17 @@ defmodule JustBash.Commands.Cut do
     parse_args(rest, %{opts | files: opts.files ++ [file]})
   end
 
-  defp get_content(bash, [], stdin), do: {stdin, bash.fs}
+  defp get_content(bash, [], stdin), do: {stdin, "", 0, bash.fs}
 
+  # GNU cut names the operand it could not read, keeps going with the rest, and
+  # exits 1.
   defp get_content(bash, files, _stdin) do
-    Enum.reduce(files, {"", bash.fs}, fn file, {acc, fs} ->
+    Enum.reduce(files, {"", "", 0, bash.fs}, fn file, {acc, err, code, fs} ->
       resolved = FS.resolve_path(bash.cwd, file)
 
       case FS.read_file(fs, resolved) do
-        {:ok, content, fs} -> {acc <> content, fs}
-        {:error, _} -> {acc, fs}
+        {:ok, content, fs} -> {acc <> content, err, code, fs}
+        {:error, error} -> {acc, err <> "cut: #{file}: #{FS.strerror(error)}\n", 1, fs}
       end
     end)
   end

--- a/lib/just_bash/commands/cut.ex
+++ b/lib/just_bash/commands/cut.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Cut do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -71,6 +72,11 @@ defmodule JustBash.Commands.Cut do
     parse_args(rest, %{opts | suppress_no_delim: true})
   end
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts) do
+    parse_args(rest, %{opts | files: opts.files ++ ["-"]})
+  end
+
   defp parse_args(["-" <> _ = arg | _rest], _opts) do
     {:error, "cut: invalid option '#{arg}'\n"}
   end
@@ -83,11 +89,9 @@ defmodule JustBash.Commands.Cut do
 
   # GNU cut names the operand it could not read, keeps going with the rest, and
   # exits 1.
-  defp get_content(bash, files, _stdin) do
+  defp get_content(bash, files, stdin) do
     Enum.reduce(files, {"", "", 0, bash.fs}, fn file, {acc, err, code, fs} ->
-      resolved = FS.resolve_path(bash.cwd, file)
-
-      case FS.read_file(fs, resolved) do
+      case StdinOperand.read(fs, bash.cwd, file, stdin) do
         {:ok, content, fs} -> {acc <> content, err, code, fs}
         {:error, error} -> {acc, err <> "cut: #{file}: #{FS.strerror(error)}\n", 1, fs}
       end

--- a/lib/just_bash/commands/diff.ex
+++ b/lib/just_bash/commands/diff.ex
@@ -76,6 +76,11 @@ defmodule JustBash.Commands.Diff do
     parse_args(rest, %{opts | ignore_case: true})
   end
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts) do
+    parse_args(rest, %{opts | files: opts.files ++ ["-"]})
+  end
+
   defp parse_args(["-" <> _ = arg | _rest], _opts) do
     {:error, "diff: invalid option '#{arg}'\n"}
   end

--- a/lib/just_bash/commands/diff.ex
+++ b/lib/just_bash/commands/diff.ex
@@ -24,8 +24,8 @@ defmodule JustBash.Commands.Diff do
             {result, _} = compare_contents(content1, content2, file1, file2, opts)
             {result, bash}
           else
-            {:error, file} ->
-              {%{stdout: "", stderr: "diff: #{file}: No such file or directory\n", exit_code: 2},
+            {:error, {file, error}} ->
+              {%{stdout: "", stderr: "diff: #{file}: #{FS.strerror(error)}\n", exit_code: 2},
                bash}
           end
         end
@@ -91,7 +91,7 @@ defmodule JustBash.Commands.Diff do
 
     case FS.read_file(bash.fs, resolved) do
       {:ok, content, fs} -> {:ok, content, %{bash | fs: fs}}
-      {:error, _} -> {:error, file}
+      {:error, error} -> {:error, {file, error}}
     end
   end
 

--- a/lib/just_bash/commands/du.ex
+++ b/lib/just_bash/commands/du.ex
@@ -114,8 +114,8 @@ defmodule JustBash.Commands.Du do
       {:ok, %VFS.Stat{size: size}, _fs} ->
         calculate_file_size(size, display_path, opts, depth)
 
-      {:error, _} ->
-        {:error, "du: cannot access '#{display_path}': No such file or directory\n"}
+      {:error, error} ->
+        {:error, "du: cannot access '#{display_path}': #{FS.strerror(error)}\n"}
     end
   end
 

--- a/lib/just_bash/commands/expand.ex
+++ b/lib/just_bash/commands/expand.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Expand do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -26,8 +27,8 @@ defmodule JustBash.Commands.Expand do
 
   defp get_content(bash, %{files: []}, stdin), do: {:ok, stdin, bash.fs}
 
-  defp get_content(bash, %{files: files}, _stdin) do
-    read_files(bash, files)
+  defp get_content(bash, %{files: files}, stdin) do
+    read_files(bash, files, stdin)
   end
 
   defp process_and_return(bash, {:error, msg}, _opts), do: {Command.error(msg), bash}
@@ -76,6 +77,11 @@ defmodule JustBash.Commands.Expand do
     {:ok, %{opts | files: opts.files ++ rest}}
   end
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts) do
+    parse_args(rest, %{opts | files: opts.files ++ ["-"]})
+  end
+
   defp parse_args(["-" <> _ = arg | _rest], _opts) do
     {:error, "expand: invalid option '#{arg}'\n"}
   end
@@ -111,11 +117,9 @@ defmodule JustBash.Commands.Expand do
     end
   end
 
-  defp read_files(bash, files) do
+  defp read_files(bash, files, stdin) do
     Enum.reduce_while(files, {:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
-      resolved = FS.resolve_path(bash.cwd, file)
-
-      case FS.read_file(fs, resolved) do
+      case StdinOperand.read(fs, bash.cwd, file, stdin) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
         {:error, error} -> {:halt, {:error, "expand: #{file}: #{FS.strerror(error)}\n"}}
       end

--- a/lib/just_bash/commands/expand.ex
+++ b/lib/just_bash/commands/expand.ex
@@ -117,7 +117,7 @@ defmodule JustBash.Commands.Expand do
 
       case FS.read_file(fs, resolved) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
-        {:error, _} -> {:halt, {:error, "expand: #{file}: No such file or directory\n"}}
+        {:error, error} -> {:halt, {:error, "expand: #{file}: #{FS.strerror(error)}\n"}}
       end
     end)
   end

--- a/lib/just_bash/commands/file.ex
+++ b/lib/just_bash/commands/file.ex
@@ -65,13 +65,12 @@ defmodule JustBash.Commands.File do
     if opts.brief, do: "#{result}\n", else: "#{file}: #{result}\n"
   end
 
-  defp format_error_line(opts, file, error) do
-    if opts.brief do
-      "cannot open\n"
-    else
-      "#{file}: cannot open (#{FS.strerror(error)})\n"
-    end
-  end
+  # -b suppresses the filename prefix, not the reason the open failed.
+  defp format_error_line(%{brief: true}, _file, error),
+    do: "cannot open (#{FS.strerror(error)})\n"
+
+  defp format_error_line(_opts, file, error),
+    do: "#{file}: cannot open (#{FS.strerror(error)})\n"
 
   defp parse_args(args) do
     parse_args(args, %{brief: false, mime: false, files: []})

--- a/lib/just_bash/commands/file.ex
+++ b/lib/just_bash/commands/file.ex
@@ -46,8 +46,8 @@ defmodule JustBash.Commands.File do
         line = format_success_line(opts, file, type_info)
         {acc_out <> line, acc_code, fs}
 
-      {:error, _} ->
-        line = format_error_line(opts, file)
+      {:error, error} ->
+        line = format_error_line(opts, file, error)
         {acc_out <> line, 1, fs}
     end
   end
@@ -65,11 +65,11 @@ defmodule JustBash.Commands.File do
     if opts.brief, do: "#{result}\n", else: "#{file}: #{result}\n"
   end
 
-  defp format_error_line(opts, file) do
+  defp format_error_line(opts, file, error) do
     if opts.brief do
       "cannot open\n"
     else
-      "#{file}: cannot open (No such file or directory)\n"
+      "#{file}: cannot open (#{FS.strerror(error)})\n"
     end
   end
 
@@ -132,12 +132,12 @@ defmodule JustBash.Commands.File do
           {:ok, content, fs} ->
             {:ok, detect_content_type(content, filename), fs}
 
-          {:error, _} ->
-            {:error, :read_error}
+          {:error, error} ->
+            {:error, error}
         end
 
-      {:error, _} ->
-        {:error, :not_found}
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/lib/just_bash/commands/find.ex
+++ b/lib/just_bash/commands/find.ex
@@ -161,8 +161,8 @@ defmodule JustBash.Commands.Find do
         children = find_children(fs, full_path, display_path, stat, opts, depth)
         {:ok, current ++ children}
 
-      {:error, _} ->
-        {:error, "find: #{display_path}: No such file or directory\n"}
+      {:error, error} ->
+        {:error, "find: #{display_path}: #{FS.strerror(error)}\n"}
     end
   end
 

--- a/lib/just_bash/commands/fold.ex
+++ b/lib/just_bash/commands/fold.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Fold do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -26,8 +27,8 @@ defmodule JustBash.Commands.Fold do
 
   defp get_content(bash, %{files: []}, stdin), do: {:ok, stdin, bash.fs}
 
-  defp get_content(bash, %{files: files}, _stdin) do
-    read_files(bash, files)
+  defp get_content(bash, %{files: files}, stdin) do
+    read_files(bash, files, stdin)
   end
 
   defp process_and_return(bash, {:error, msg}, _opts), do: {Command.error(msg), bash}
@@ -79,6 +80,11 @@ defmodule JustBash.Commands.Fold do
     {:ok, %{opts | files: opts.files ++ rest}}
   end
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts) do
+    parse_args(rest, %{opts | files: opts.files ++ ["-"]})
+  end
+
   defp parse_args(["-" <> _ = arg | _rest], _opts) do
     {:error, "fold: invalid option '#{arg}'\n"}
   end
@@ -87,11 +93,9 @@ defmodule JustBash.Commands.Fold do
     parse_args(rest, %{opts | files: opts.files ++ [file]})
   end
 
-  defp read_files(bash, files) do
+  defp read_files(bash, files, stdin) do
     Enum.reduce_while(files, {:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
-      resolved = FS.resolve_path(bash.cwd, file)
-
-      case FS.read_file(fs, resolved) do
+      case StdinOperand.read(fs, bash.cwd, file, stdin) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
         {:error, error} -> {:halt, {:error, "fold: #{file}: #{FS.strerror(error)}\n"}}
       end

--- a/lib/just_bash/commands/fold.ex
+++ b/lib/just_bash/commands/fold.ex
@@ -93,7 +93,7 @@ defmodule JustBash.Commands.Fold do
 
       case FS.read_file(fs, resolved) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
-        {:error, _} -> {:halt, {:error, "fold: #{file}: No such file or directory\n"}}
+        {:error, error} -> {:halt, {:error, "fold: #{file}: #{FS.strerror(error)}\n"}}
       end
     end)
   end

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -98,12 +98,12 @@ defmodule JustBash.Commands.Grep do
     show_filename =
       flags.with_filename or (length(expanded_files) > 1 and not flags.no_filename)
 
-    {results, any_match, fs} =
-      Enum.reduce(expanded_files, {[], false, bash.fs}, fn file, {acc, had_match, fs} ->
-        process_file(bash, fs, file, regex, flags, show_filename, acc, had_match)
+    {results, any_match, errors, fs} =
+      Enum.reduce(expanded_files, {[], false, "", bash.fs}, fn file, acc ->
+        process_file(bash, file, regex, flags, show_filename, acc)
       end)
 
-    build_files_result(%{bash | fs: fs}, results, any_match, flags)
+    build_files_result(%{bash | fs: fs}, results, any_match, errors, flags)
   end
 
   # Expand files recursively when -r flag is set
@@ -163,7 +163,7 @@ defmodule JustBash.Commands.Grep do
   defp join_path("/", entry), do: "/#{entry}"
   defp join_path(path, entry), do: "#{path}/#{entry}"
 
-  defp process_file(bash, fs, file, regex, flags, show_filename, acc, had_match) do
+  defp process_file(bash, file, regex, flags, show_filename, {acc, had_match, errors, fs}) do
     resolved = FS.resolve_path(bash.cwd, file)
 
     case FS.read_file(fs, resolved) do
@@ -172,10 +172,10 @@ defmodule JustBash.Commands.Grep do
         lines = process_content(content, regex, flags, prefix)
         matched = lines != []
         result = format_file_result(file, prefix, lines, matched, flags)
-        {if(result, do: [result | acc], else: acc), had_match or matched, fs}
+        {if(result, do: [result | acc], else: acc), had_match or matched, errors, fs}
 
-      {:error, _} ->
-        {acc, had_match, fs}
+      {:error, error} ->
+        {acc, had_match, errors <> "grep: #{file}: #{FS.strerror(error)}\n", fs}
     end
   end
 
@@ -189,17 +189,25 @@ defmodule JustBash.Commands.Grep do
     end
   end
 
-  defp build_files_result(bash, results, any_match, flags) do
-    exit_code = if any_match, do: 0, else: 1
+  defp build_files_result(bash, results, any_match, errors, flags) do
+    exit_code = files_exit_code(any_match, errors != "", flags.q)
 
     if flags.q do
-      {Command.result("", "", exit_code), bash}
+      {Command.result("", errors, exit_code), bash}
     else
       output = results |> Enum.reverse() |> Enum.join("\n")
       output = if output != "", do: output <> "\n", else: ""
-      {Command.result(output, "", exit_code), bash}
+      {Command.result(output, errors, exit_code), bash}
     end
   end
+
+  # "the exit status is 0 if a line is selected, 1 if no lines were selected,
+  # and 2 if an error occurred. However, if -q is used and a line is selected,
+  # the exit status is 0 even if an error occurred."
+  defp files_exit_code(true, _errored, true), do: 0
+  defp files_exit_code(_any_match, true, _quiet), do: 2
+  defp files_exit_code(true, false, _quiet), do: 0
+  defp files_exit_code(false, false, _quiet), do: 1
 
   defp execute_with_stdin(bash, pattern, stdin, flags) do
     regex = compile_pattern(bash, pattern, flags)

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Grep do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FlagParser
   alias JustBash.FS
   alias JustBash.Limit
@@ -79,7 +80,7 @@ defmodule JustBash.Commands.Grep do
   defp grep(bash, flags, rest, stdin) do
     case rest do
       [pattern | files] when files != [] ->
-        execute_with_files(bash, pattern, files, flags)
+        execute_with_files(bash, pattern, files, stdin, flags)
 
       [pattern] ->
         execute_with_stdin(bash, pattern, stdin, flags)
@@ -89,7 +90,7 @@ defmodule JustBash.Commands.Grep do
     end
   end
 
-  defp execute_with_files(bash, pattern, files, flags) do
+  defp execute_with_files(bash, pattern, files, stdin, flags) do
     regex = compile_pattern(bash, pattern, flags)
 
     # Expand files recursively if -r flag is set
@@ -100,7 +101,7 @@ defmodule JustBash.Commands.Grep do
 
     {results, any_match, errors, fs} =
       Enum.reduce(expanded_files, {[], false, "", bash.fs}, fn file, acc ->
-        process_file(bash, file, regex, flags, show_filename, acc)
+        process_file(bash, file, stdin, regex, flags, show_filename, acc)
       end)
 
     build_files_result(%{bash | fs: fs}, results, any_match, errors, flags)
@@ -163,15 +164,15 @@ defmodule JustBash.Commands.Grep do
   defp join_path("/", entry), do: "/#{entry}"
   defp join_path(path, entry), do: "#{path}/#{entry}"
 
-  defp process_file(bash, file, regex, flags, show_filename, {acc, had_match, errors, fs}) do
-    resolved = FS.resolve_path(bash.cwd, file)
-
-    case FS.read_file(fs, resolved) do
+  defp process_file(bash, file, stdin, regex, flags, show_filename, {acc, had_match, errors, fs}) do
+    case StdinOperand.read(fs, bash.cwd, file, stdin) do
       {:ok, content, fs} ->
-        prefix = if show_filename, do: "#{file}:", else: ""
+        # GNU names the `-` operand "(standard input)" in the prefix, not "-".
+        name = if StdinOperand.stdin?(file), do: "(standard input)", else: file
+        prefix = if show_filename, do: "#{name}:", else: ""
         lines = process_content(content, regex, flags, prefix)
         matched = lines != []
-        result = format_file_result(file, prefix, lines, matched, flags)
+        result = format_file_result(name, prefix, lines, matched, flags)
         {if(result, do: [result | acc], else: acc), had_match or matched, errors, fs}
 
       {:error, error} ->

--- a/lib/just_bash/commands/head.ex
+++ b/lib/just_bash/commands/head.ex
@@ -83,8 +83,8 @@ defmodule JustBash.Commands.Head do
 
   # GNU head `open(2)`s a directory successfully and only fails at `read(2)`,
   # so EISDIR gets a template of its own rather than the open-failure one.
-  defp read_error(file, %VFS.Error{kind: :eisdir}),
-    do: "head: error reading '#{file}': Is a directory\n"
+  defp read_error(file, %VFS.Error{kind: :eisdir} = error),
+    do: "head: error reading '#{file}': #{FS.strerror(error)}\n"
 
   defp read_error(file, error),
     do: "head: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"

--- a/lib/just_bash/commands/head.ex
+++ b/lib/just_bash/commands/head.ex
@@ -56,8 +56,7 @@ defmodule JustBash.Commands.Head do
             {[header <> body | out_acc], err_acc, code, fs}
 
           {:error, error} ->
-            err = "head: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"
-            {out_acc, [err | err_acc], 1, fs}
+            {out_acc, [read_error(file, error) | err_acc], 1, fs}
         end
       end)
 
@@ -76,9 +75,17 @@ defmodule JustBash.Commands.Head do
         {Command.ok(output), %{bash | fs: fs}}
 
       {:error, error} ->
-        {Command.error("head: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"), bash}
+        {Command.error(read_error(file, error)), bash}
     end
   end
+
+  # GNU head `open(2)`s a directory successfully and only fails at `read(2)`,
+  # so EISDIR gets a template of its own rather than the open-failure one.
+  defp read_error(file, %VFS.Error{kind: :eisdir}),
+    do: "head: error reading '#{file}': Is a directory\n"
+
+  defp read_error(file, error),
+    do: "head: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"
 
   defp head_stdin(bash, stdin, mode) do
     output = take_content(stdin, mode)

--- a/lib/just_bash/commands/head.ex
+++ b/lib/just_bash/commands/head.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Head do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FlagParser
   alias JustBash.FS
 
@@ -39,19 +40,17 @@ defmodule JustBash.Commands.Head do
 
     case files do
       [] -> head_stdin(bash, stdin, mode)
-      [file] -> head_file(bash, file, mode)
-      multiple -> head_multiple(bash, multiple, mode)
+      [file] -> head_file(bash, file, stdin, mode)
+      multiple -> head_multiple(bash, multiple, stdin, mode)
     end
   end
 
-  defp head_multiple(bash, files, mode) do
+  defp head_multiple(bash, files, stdin, mode) do
     {outputs, errors, exit_code, fs} =
       Enum.reduce(files, {[], [], 0, bash.fs}, fn file, {out_acc, err_acc, code, fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
-
-        case FS.read_file(fs, resolved) do
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
           {:ok, content, fs} ->
-            header = "==> #{file} <==\n"
+            header = "==> #{display_name(file)} <==\n"
             body = take_content(content, mode)
             {[header <> body | out_acc], err_acc, code, fs}
 
@@ -66,10 +65,8 @@ defmodule JustBash.Commands.Head do
     {%{stdout: stdout, stderr: stderr, exit_code: exit_code}, %{bash | fs: fs}}
   end
 
-  defp head_file(bash, file, mode) do
-    resolved = FS.resolve_path(bash.cwd, file)
-
-    case FS.read_file(bash.fs, resolved) do
+  defp head_file(bash, file, stdin, mode) do
+    case StdinOperand.read(bash.fs, bash.cwd, file, stdin) do
       {:ok, content, fs} ->
         output = take_content(content, mode)
         {Command.ok(output), %{bash | fs: fs}}
@@ -77,6 +74,11 @@ defmodule JustBash.Commands.Head do
       {:error, error} ->
         {Command.error(read_error(file, error)), bash}
     end
+  end
+
+  # GNU labels the `-` operand "standard input" in the multi-file header.
+  defp display_name(file) do
+    if StdinOperand.stdin?(file), do: "standard input", else: file
   end
 
   # GNU head `open(2)`s a directory successfully and only fails at `read(2)`,

--- a/lib/just_bash/commands/head.ex
+++ b/lib/just_bash/commands/head.ex
@@ -55,8 +55,8 @@ defmodule JustBash.Commands.Head do
             body = take_content(content, mode)
             {[header <> body | out_acc], err_acc, code, fs}
 
-          {:error, _} ->
-            err = "head: cannot open '#{file}' for reading: No such file or directory\n"
+          {:error, error} ->
+            err = "head: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"
             {out_acc, [err | err_acc], 1, fs}
         end
       end)
@@ -75,9 +75,8 @@ defmodule JustBash.Commands.Head do
         output = take_content(content, mode)
         {Command.ok(output), %{bash | fs: fs}}
 
-      {:error, _} ->
-        {Command.error("head: cannot open '#{file}' for reading: No such file or directory\n"),
-         bash}
+      {:error, error} ->
+        {Command.error("head: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"), bash}
     end
   end
 

--- a/lib/just_bash/commands/jq.ex
+++ b/lib/just_bash/commands/jq.ex
@@ -24,6 +24,7 @@ defmodule JustBash.Commands.Jq do
 
   alias JustBash.Commands.Command
   alias JustBash.Commands.Jq.{Evaluator, Parser}
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -83,17 +84,15 @@ defmodule JustBash.Commands.Jq do
         {:ok, nil, bash}
 
       opts.file ->
-        read_file_input(bash, opts.file)
+        read_file_input(bash, opts.file, stdin)
 
       true ->
         {:ok, stdin, bash}
     end
   end
 
-  defp read_file_input(bash, file) do
-    resolved = FS.resolve_path(bash.cwd, file)
-
-    case FS.read_file(bash.fs, resolved) do
+  defp read_file_input(bash, file, stdin) do
+    case StdinOperand.read(bash.fs, bash.cwd, file, stdin) do
       {:ok, content, fs} -> {:ok, content, %{bash | fs: fs}}
       {:error, error} -> {:error, "jq: #{file}: #{FS.strerror(error)}\n"}
     end

--- a/lib/just_bash/commands/jq.ex
+++ b/lib/just_bash/commands/jq.ex
@@ -95,7 +95,7 @@ defmodule JustBash.Commands.Jq do
 
     case FS.read_file(bash.fs, resolved) do
       {:ok, content, fs} -> {:ok, content, %{bash | fs: fs}}
-      {:error, _} -> {:error, "jq: #{file}: No such file or directory\n"}
+      {:error, error} -> {:error, "jq: #{file}: #{FS.strerror(error)}\n"}
     end
   end
 

--- a/lib/just_bash/commands/ln.ex
+++ b/lib/just_bash/commands/ln.ex
@@ -187,11 +187,11 @@ defmodule JustBash.Commands.Ln do
   end
 
   defp handle_link_result(_bash, {:error, %VFS.Error{kind: :enoent}}, target, _link_name, _opts) do
-    {:error, "ln: failed to access '#{target}': No such file or directory\n"}
+    {:error, "ln: failed to access '#{target}': #{FS.strerror(:enoent)}\n"}
   end
 
   defp handle_link_result(_bash, {:error, :enoent}, target, _link_name, _opts) do
-    {:error, "ln: failed to access '#{target}': No such file or directory\n"}
+    {:error, "ln: failed to access '#{target}': #{FS.strerror(:enoent)}\n"}
   end
 
   defp handle_link_result(_bash, {:error, %VFS.Error{kind: :eacces}}, target, _link_name, _opts) do

--- a/lib/just_bash/commands/md5sum.ex
+++ b/lib/just_bash/commands/md5sum.ex
@@ -44,6 +44,11 @@ defmodule JustBash.Commands.Md5sum do
   defp parse_args(["--binary" | rest], opts), do: parse_args(rest, opts)
   defp parse_args(["--text" | rest], opts), do: parse_args(rest, opts)
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts) do
+    parse_args(rest, %{opts | files: opts.files ++ ["-"]})
+  end
+
   defp parse_args(["-" <> _ = arg | _rest], _opts) do
     {:error, "md5sum: invalid option '#{arg}'\n"}
   end

--- a/lib/just_bash/commands/md5sum.ex
+++ b/lib/just_bash/commands/md5sum.ex
@@ -52,31 +52,35 @@ defmodule JustBash.Commands.Md5sum do
     parse_args(rest, %{opts | files: opts.files ++ [file]})
   end
 
+  # stdout carries the checksum lines and nothing else: `md5sum a b > sums.txt`
+  # has to produce a checksum file, not one with a diagnostic wedged into it.
   defp compute_hashes(bash, files, stdin) do
-    {output, exit_code} =
-      Enum.reduce(files, {"", 0}, fn file, {acc_out, acc_code} ->
+    {output, errors, exit_code} =
+      Enum.reduce(files, {"", "", 0}, fn file, {acc_out, acc_err, acc_code} ->
         case read_file(bash, file, stdin) do
           {:ok, content} ->
-            hash = md5(content)
-            {acc_out <> "#{hash}  #{file}\n", acc_code}
+            {acc_out <> "#{md5(content)}  #{file}\n", acc_err, acc_code}
 
           {:error, error} ->
-            {acc_out <> "md5sum: #{file}: #{FS.strerror(error)}\n", 1}
+            {acc_out, acc_err <> "md5sum: #{file}: #{FS.strerror(error)}\n", 1}
         end
       end)
 
-    {%{stdout: output, stderr: "", exit_code: exit_code}, bash}
+    {%{stdout: output, stderr: errors, exit_code: exit_code}, bash}
   end
 
+  # A checksum file we cannot read is a diagnostic and a non-zero exit, but it
+  # is not a checksum that did not match, so it does not feed the WARNING line.
   defp check_files(bash, files, stdin) do
-    {output, failed} =
-      Enum.reduce(files, {"", 0}, fn file, {acc_out, acc_failed} ->
+    {output, errors, failed} =
+      Enum.reduce(files, {"", "", 0}, fn file, {acc_out, acc_err, acc_failed} ->
         case read_file(bash, file, stdin) do
           {:ok, content} ->
-            check_content(bash, content, stdin, acc_out, acc_failed)
+            {out, failed} = check_content(bash, content, stdin, acc_out, acc_failed)
+            {out, acc_err, failed}
 
-          {:error, _} ->
-            {acc_out, acc_failed}
+          {:error, error} ->
+            {acc_out, acc_err <> "md5sum: #{file}: #{FS.strerror(error)}\n", acc_failed}
         end
       end)
 
@@ -88,8 +92,8 @@ defmodule JustBash.Commands.Md5sum do
         output
       end
 
-    exit_code = if failed > 0, do: 1, else: 0
-    {%{stdout: output, stderr: "", exit_code: exit_code}, bash}
+    exit_code = if failed > 0 or errors != "", do: 1, else: 0
+    {%{stdout: output, stderr: errors, exit_code: exit_code}, bash}
   end
 
   defp check_content(bash, content, stdin, acc_out, acc_failed) do

--- a/lib/just_bash/commands/md5sum.ex
+++ b/lib/just_bash/commands/md5sum.ex
@@ -60,8 +60,8 @@ defmodule JustBash.Commands.Md5sum do
             hash = md5(content)
             {acc_out <> "#{hash}  #{file}\n", acc_code}
 
-          {:error, _} ->
-            {acc_out <> "md5sum: #{file}: No such file or directory\n", 1}
+          {:error, error} ->
+            {acc_out <> "md5sum: #{file}: #{FS.strerror(error)}\n", 1}
         end
       end)
 

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -109,7 +109,7 @@ defmodule JustBash.Commands.Mv do
         {Command.ok(), %{bash | fs: new_fs}}
 
       {:error, %VFS.Error{kind: :enoent}} ->
-        {Command.error("mv: cannot stat '#{src}': No such file or directory\n"), bash}
+        {Command.error("mv: cannot stat '#{src}': #{FS.strerror(:enoent)}\n"), bash}
 
       {:error, %VFS.Error{kind: :eisdir}} ->
         {Command.error("mv: cannot overwrite directory '#{dest}' with non-directory\n"), bash}

--- a/lib/just_bash/commands/nl.ex
+++ b/lib/just_bash/commands/nl.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Nl do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -26,8 +27,8 @@ defmodule JustBash.Commands.Nl do
 
   defp get_content(bash, %{files: []}, stdin), do: {:ok, stdin, bash.fs}
 
-  defp get_content(bash, %{files: files}, _stdin) do
-    read_files(bash, files)
+  defp get_content(bash, %{files: files}, stdin) do
+    read_files(bash, files, stdin)
   end
 
   defp process_and_return(bash, {:error, msg}, _opts), do: {Command.error(msg), bash}
@@ -137,6 +138,11 @@ defmodule JustBash.Commands.Nl do
     {:error, "nl: unrecognized option '#{arg}'\n"}
   end
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts) do
+    parse_args(rest, %{opts | files: opts.files ++ ["-"]})
+  end
+
   defp parse_args(["-" <> _ = arg | _rest], _opts) do
     {:error, "nl: invalid option -- '#{arg}'\n"}
   end
@@ -155,11 +161,9 @@ defmodule JustBash.Commands.Nl do
   defp parse_number_format("rz"), do: {:ok, :rz}
   defp parse_number_format(f), do: {:error, "nl: invalid line numbering format: '#{f}'\n"}
 
-  defp read_files(bash, files) do
+  defp read_files(bash, files, stdin) do
     Enum.reduce_while(files, {:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
-      resolved = FS.resolve_path(bash.cwd, file)
-
-      case FS.read_file(fs, resolved) do
+      case StdinOperand.read(fs, bash.cwd, file, stdin) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
         {:error, error} -> {:halt, {:error, "nl: #{file}: #{FS.strerror(error)}\n"}}
       end

--- a/lib/just_bash/commands/nl.ex
+++ b/lib/just_bash/commands/nl.ex
@@ -161,7 +161,7 @@ defmodule JustBash.Commands.Nl do
 
       case FS.read_file(fs, resolved) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
-        {:error, _} -> {:halt, {:error, "nl: #{file}: No such file or directory\n"}}
+        {:error, error} -> {:halt, {:error, "nl: #{file}: #{FS.strerror(error)}\n"}}
       end
     end)
   end

--- a/lib/just_bash/commands/od.ex
+++ b/lib/just_bash/commands/od.ex
@@ -30,6 +30,9 @@ defmodule JustBash.Commands.Od do
   defp parse_args(["-A", _ | rest], opts), do: parse_args(rest, opts)
   defp parse_args(["-t", _ | rest], opts), do: parse_args(rest, opts)
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts), do: parse_args(rest, %{opts | file: "-"})
+
   defp parse_args(["-" <> _ = flag | _], _opts),
     do: {:error, "od: unknown option: #{flag}\n"}
 

--- a/lib/just_bash/commands/od.ex
+++ b/lib/just_bash/commands/od.ex
@@ -43,7 +43,7 @@ defmodule JustBash.Commands.Od do
 
     case FS.read_file(bash.fs, resolved) do
       {:ok, c, fs} -> {:ok, c, %{bash | fs: fs}}
-      {:error, _} -> {:error, "od: #{file}: No such file or directory\n"}
+      {:error, error} -> {:error, "od: #{file}: #{FS.strerror(error)}\n"}
     end
   end
 

--- a/lib/just_bash/commands/paste.ex
+++ b/lib/just_bash/commands/paste.ex
@@ -122,8 +122,8 @@ defmodule JustBash.Commands.Paste do
       {:ok, content, fs} ->
         {:ok, split_lines(content), fs, stdin_idx}
 
-      {:error, _} ->
-        {:error, "paste: #{file}: No such file or directory\n"}
+      {:error, error} ->
+        {:error, "paste: #{file}: #{FS.strerror(error)}\n"}
     end
   end
 

--- a/lib/just_bash/commands/realpath.ex
+++ b/lib/just_bash/commands/realpath.ex
@@ -3,6 +3,14 @@ defmodule JustBash.Commands.Realpath do
   The `realpath` command - print the resolved absolute path.
 
   Resolves `.`, `..`, and symlinks in the virtual filesystem.
+
+  How much of the path has to exist depends on the mode, as in GNU realpath:
+
+    * default — every component *but the last* must resolve to a directory,
+      so `realpath /nope` canonicalises and exits 0 while
+      `realpath /nope/deep/x` does not
+    * `-e` — the whole path must exist
+    * `-m` — nothing has to exist
   """
 
   @behaviour JustBash.Commands.Command
@@ -15,7 +23,7 @@ defmodule JustBash.Commands.Realpath do
 
   @impl true
   def execute(bash, args, _stdin) do
-    {_opts, paths} = parse_args(args)
+    {opts, paths} = parse_args(args)
 
     case paths do
       [] ->
@@ -26,11 +34,11 @@ defmodule JustBash.Commands.Realpath do
           Enum.reduce(paths, {[], [], 0, bash.fs}, fn path, {out, err, code, fs} ->
             resolved = FS.resolve_path(bash.cwd, path)
 
-            case FS.stat(fs, resolved) do
-              {:ok, _stat, fs} ->
+            case check(fs, resolved, opts.mode) do
+              {:ok, fs} ->
                 {[out, resolved, "\n"], err, code, fs}
 
-              {:error, error} ->
+              {:error, error, fs} ->
                 {out, [err, "realpath: ", path, ": ", FS.strerror(error), "\n"], 1, fs}
             end
           end)
@@ -43,12 +51,41 @@ defmodule JustBash.Commands.Realpath do
     end
   end
 
+  defp check(fs, _resolved, :missing), do: {:ok, fs}
+
+  defp check(fs, resolved, :existing) do
+    case FS.stat(fs, resolved) do
+      {:ok, _stat, fs} -> {:ok, fs}
+      {:error, error} -> {:error, error, fs}
+    end
+  end
+
+  # The default mode names the operand in its diagnostic but only requires the
+  # parent to be a directory: `realpath /f/x` on a regular-file `/f` is ENOTDIR
+  # even though `/f` itself stats cleanly.
+  defp check(fs, resolved, :default) do
+    case FS.stat(fs, Path.dirname(resolved)) do
+      {:ok, %VFS.Stat{type: :directory}, fs} -> {:ok, fs}
+      {:ok, _not_a_directory, fs} -> {:error, :enotdir, fs}
+      {:error, error} -> {:error, error, fs}
+    end
+  end
+
   defp parse_args(args) do
-    parse_args(args, %{}, [])
+    parse_args(args, %{mode: :default}, [])
   end
 
   defp parse_args([], opts, paths), do: {opts, Enum.reverse(paths)}
-  # Skip flags like -e, -m, -s, --relative-to, etc.
+
+  defp parse_args([flag | rest], opts, paths)
+       when flag in ["-e", "--canonicalize-existing"],
+       do: parse_args(rest, %{opts | mode: :existing}, paths)
+
+  defp parse_args([flag | rest], opts, paths)
+       when flag in ["-m", "--canonicalize-missing"],
+       do: parse_args(rest, %{opts | mode: :missing}, paths)
+
+  # Skip the flags we do not model yet: -s, --relative-to, …
   defp parse_args(["--" <> _ | rest], opts, paths), do: parse_args(rest, opts, paths)
 
   defp parse_args(["-" <> _ | rest], opts, paths),

--- a/lib/just_bash/commands/realpath.ex
+++ b/lib/just_bash/commands/realpath.ex
@@ -30,8 +30,8 @@ defmodule JustBash.Commands.Realpath do
               {:ok, _stat, fs} ->
                 {[out, resolved, "\n"], err, code, fs}
 
-              {:error, _} ->
-                {out, [err, "realpath: ", path, ": No such file or directory\n"], 1, fs}
+              {:error, error} ->
+                {out, [err, "realpath: ", path, ": ", FS.strerror(error), "\n"], 1, fs}
             end
           end)
 

--- a/lib/just_bash/commands/rev.ex
+++ b/lib/just_bash/commands/rev.ex
@@ -35,7 +35,7 @@ defmodule JustBash.Commands.Rev do
 
       case FS.read_file(fs, resolved) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
-        {:error, _} -> {:halt, {:error, "rev: #{file}: No such file or directory\n"}}
+        {:error, error} -> {:halt, {:error, "rev: #{file}: #{FS.strerror(error)}\n"}}
       end
     end)
   end

--- a/lib/just_bash/commands/rev.ex
+++ b/lib/just_bash/commands/rev.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Rev do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -10,35 +11,31 @@ defmodule JustBash.Commands.Rev do
 
   @impl true
   def execute(bash, args, stdin) do
-    files = Enum.reject(args, &String.starts_with?(&1, "-"))
-
-    content =
-      if files == [] or files == ["-"] do
-        {:ok, stdin, bash.fs}
-      else
-        read_files(bash, files)
-      end
-
-    case content do
+    case read_operands(bash, StdinOperand.operands(args), stdin) do
       {:error, msg} ->
         {Command.error(msg), bash}
 
       {:ok, data, fs} ->
-        output = reverse_chars_per_line(data)
-        {Command.ok(output), %{bash | fs: fs}}
+        {Command.ok(reverse_chars_per_line(data)), %{bash | fs: fs}}
     end
   end
 
-  defp read_files(bash, files) do
-    Enum.reduce_while(files, {:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
-      resolved = FS.resolve_path(bash.cwd, file)
-
-      case FS.read_file(fs, resolved) do
+  # `rev` is line-local, so reading the operands in the order given is all it
+  # takes to put each one's lines where they belong — unlike `tac`, which has
+  # to reverse each operand on its own.
+  defp read_operands(bash, files, stdin) do
+    files
+    |> defaults_to_stdin()
+    |> Enum.reduce_while({:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
+      case StdinOperand.read(fs, bash.cwd, file, stdin) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
         {:error, error} -> {:halt, {:error, "rev: #{file}: #{FS.strerror(error)}\n"}}
       end
     end)
   end
+
+  defp defaults_to_stdin([]), do: ["-"]
+  defp defaults_to_stdin(files), do: files
 
   defp reverse_chars_per_line(content) do
     has_trailing_newline = String.ends_with?(content, "\n")

--- a/lib/just_bash/commands/rm.ex
+++ b/lib/just_bash/commands/rm.ex
@@ -23,9 +23,6 @@ defmodule JustBash.Commands.Rm do
           {:error, %VFS.Error{kind: :enoent}} when flags.f ->
             {err_acc, code_acc, fs_acc}
 
-          {:error, %VFS.Error{kind: :enoent}} ->
-            {err_acc <> "rm: cannot remove '#{path}': No such file or directory\n", 1, fs_acc}
-
           {:error, %VFS.Error{} = error} ->
             {err_acc <> "rm: cannot remove '#{path}': #{FS.strerror(error)}\n", 1, fs_acc}
         end

--- a/lib/just_bash/commands/sed.ex
+++ b/lib/just_bash/commands/sed.ex
@@ -14,6 +14,7 @@ defmodule JustBash.Commands.Sed do
 
   alias JustBash.Commands.Command
   alias JustBash.Commands.Sed.{Executor, Parser}
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -53,12 +54,12 @@ defmodule JustBash.Commands.Sed do
       output = Executor.execute(stdin, commands, opts.silent)
       {Command.ok(output), bash}
     else
-      execute_on_files(bash, commands, opts)
+      execute_on_files(bash, commands, opts, stdin)
     end
   end
 
-  defp execute_on_files(bash, commands, opts) do
-    case read_and_process_files(bash, opts.files, commands, opts) do
+  defp execute_on_files(bash, commands, opts, stdin) do
+    case read_and_process_files(bash, opts.files, commands, opts, stdin) do
       {:ok, output, new_bash} ->
         {Command.ok(output), new_bash}
 
@@ -158,20 +159,18 @@ defmodule JustBash.Commands.Sed do
   defp apply_single_flag("E", acc), do: %{acc | extended_regex: true}
   defp apply_single_flag("r", acc), do: %{acc | extended_regex: true}
 
-  defp read_and_process_files(bash, files, commands, opts) do
+  defp read_and_process_files(bash, files, commands, opts, stdin) do
     if opts.in_place do
       process_files_in_place(bash, files, commands, opts)
     else
-      process_files_to_output(bash, files, commands, opts)
+      process_files_to_output(bash, files, commands, opts, stdin)
     end
   end
 
-  defp process_files_to_output(bash, files, commands, opts) do
+  defp process_files_to_output(bash, files, commands, opts, stdin) do
     result =
       Enum.reduce_while(files, {:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
-
-        case FS.read_file(fs, resolved) do
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
           {:ok, content, fs} ->
             output = Executor.execute(content, commands, opts.silent)
             {:cont, {:ok, acc <> output, fs}}

--- a/lib/just_bash/commands/sed.ex
+++ b/lib/just_bash/commands/sed.ex
@@ -176,8 +176,8 @@ defmodule JustBash.Commands.Sed do
             output = Executor.execute(content, commands, opts.silent)
             {:cont, {:ok, acc <> output, fs}}
 
-          {:error, _} ->
-            {:halt, {:error, "sed: #{file}: No such file or directory\n"}}
+          {:error, error} ->
+            {:halt, {:error, "sed: #{file}: #{FS.strerror(error)}\n"}}
         end
       end)
 
@@ -221,8 +221,8 @@ defmodule JustBash.Commands.Sed do
       {:ok, content, fs} ->
         write_processed_content(%{bash | fs: fs}, resolved, file, content, commands, opts)
 
-      {:error, _} ->
-        {:halt, {:error, "sed: #{file}: No such file or directory\n"}}
+      {:error, error} ->
+        {:halt, {:error, "sed: #{file}: #{FS.strerror(error)}\n"}}
     end
   end
 

--- a/lib/just_bash/commands/sha256sum.ex
+++ b/lib/just_bash/commands/sha256sum.ex
@@ -8,6 +8,7 @@ defmodule JustBash.Commands.Sha256sum do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -17,18 +18,18 @@ defmodule JustBash.Commands.Sha256sum do
   def execute(bash, args, stdin) do
     {opts, files} = parse_args(args)
 
-    cond do
-      opts.check ->
-        check_checksums(bash, files)
-
-      files == [] or files == ["-"] ->
-        hash = :crypto.hash(:sha256, stdin) |> Base.encode16(case: :lower)
-        {Command.ok("#{hash}  -\n"), bash}
-
-      true ->
-        hash_files(bash, files)
+    if opts.check do
+      check_checksums(bash, files)
+    else
+      hash_files(bash, defaults_to_stdin(files), stdin)
     end
   end
+
+  # No operand at all is the same request as a lone `-`, and one `-` among
+  # several files is still that operand: `sha256sum - f` hashes both,
+  # labelling the first `-`.
+  defp defaults_to_stdin([]), do: ["-"]
+  defp defaults_to_stdin(files), do: files
 
   defp parse_args(args) do
     parse_args(args, %{check: false}, [])
@@ -42,12 +43,10 @@ defmodule JustBash.Commands.Sha256sum do
 
   defp parse_args([file | rest], opts, files), do: parse_args(rest, opts, [file | files])
 
-  defp hash_files(bash, files) do
+  defp hash_files(bash, files, stdin) do
     {stdout, stderr, exit_code, fs} =
       Enum.reduce(files, {"", "", 0, bash.fs}, fn file, {out, err, code, fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
-
-        case FS.read_file(fs, resolved) do
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
           {:ok, content, new_fs} ->
             hash = :crypto.hash(:sha256, content) |> Base.encode16(case: :lower)
             {out <> "#{hash}  #{file}\n", err, code, new_fs}

--- a/lib/just_bash/commands/sha256sum.ex
+++ b/lib/just_bash/commands/sha256sum.ex
@@ -52,8 +52,8 @@ defmodule JustBash.Commands.Sha256sum do
             hash = :crypto.hash(:sha256, content) |> Base.encode16(case: :lower)
             {out <> "#{hash}  #{file}\n", err, code, new_fs}
 
-          {:error, _} ->
-            {out, err <> "sha256sum: #{file}: No such file or directory\n", 1, fs}
+          {:error, error} ->
+            {out, err <> "sha256sum: #{file}: #{FS.strerror(error)}\n", 1, fs}
         end
       end)
 
@@ -69,8 +69,8 @@ defmodule JustBash.Commands.Sha256sum do
           {:ok, content, new_fs} ->
             verify_checksum_file(bash, content, out, err, code, new_fs)
 
-          {:error, _} ->
-            {out, err <> "sha256sum: #{file}: No such file or directory\n", 1, fs}
+          {:error, error} ->
+            {out, err <> "sha256sum: #{file}: #{FS.strerror(error)}\n", 1, fs}
         end
       end)
 
@@ -110,8 +110,8 @@ defmodule JustBash.Commands.Sha256sum do
           do: {o <> "#{trimmed}: OK\n", e, c, new_fs},
           else: {o <> "#{trimmed}: FAILED\n", e, 1, new_fs}
 
-      {:error, _} ->
-        {o, e <> "#{cmd_name}: #{trimmed}: No such file or directory\n", 1, f}
+      {:error, error} ->
+        {o, e <> "#{cmd_name}: #{trimmed}: #{FS.strerror(error)}\n", 1, f}
     end
   end
 end

--- a/lib/just_bash/commands/shasum.ex
+++ b/lib/just_bash/commands/shasum.ex
@@ -9,6 +9,7 @@ defmodule JustBash.Commands.Shasum do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -27,18 +28,18 @@ defmodule JustBash.Commands.Shasum do
         _ -> :sha
       end
 
-    cond do
-      opts.check ->
-        check_checksums(bash, algorithm, files)
-
-      files == [] or files == ["-"] ->
-        hash = :crypto.hash(algorithm, stdin) |> Base.encode16(case: :lower)
-        {Command.ok("#{hash}  -\n"), bash}
-
-      true ->
-        hash_files(bash, algorithm, files)
+    if opts.check do
+      check_checksums(bash, algorithm, files)
+    else
+      hash_files(bash, algorithm, defaults_to_stdin(files), stdin)
     end
   end
+
+  # No operand at all is the same request as a lone `-`, and one `-` among
+  # several files is still that operand: `shasum - f` hashes both, labelling
+  # the first `-`.
+  defp defaults_to_stdin([]), do: ["-"]
+  defp defaults_to_stdin(files), do: files
 
   defp parse_args(args) do
     parse_args(args, %{algorithm: "1", check: false}, [])
@@ -56,12 +57,10 @@ defmodule JustBash.Commands.Shasum do
 
   defp parse_args([file | rest], opts, files), do: parse_args(rest, opts, [file | files])
 
-  defp hash_files(bash, algorithm, files) do
+  defp hash_files(bash, algorithm, files, stdin) do
     {stdout, stderr, exit_code, fs} =
       Enum.reduce(files, {"", "", 0, bash.fs}, fn file, {out, err, code, fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
-
-        case FS.read_file(fs, resolved) do
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
           {:ok, content, new_fs} ->
             hash = :crypto.hash(algorithm, content) |> Base.encode16(case: :lower)
             {out <> "#{hash}  #{file}\n", err, code, new_fs}

--- a/lib/just_bash/commands/shasum.ex
+++ b/lib/just_bash/commands/shasum.ex
@@ -66,8 +66,8 @@ defmodule JustBash.Commands.Shasum do
             hash = :crypto.hash(algorithm, content) |> Base.encode16(case: :lower)
             {out <> "#{hash}  #{file}\n", err, code, new_fs}
 
-          {:error, _} ->
-            {out, err <> "shasum: #{file}: No such file or directory\n", 1, fs}
+          {:error, error} ->
+            {out, err <> "shasum: #{file}: #{FS.strerror(error)}\n", 1, fs}
         end
       end)
 
@@ -83,8 +83,8 @@ defmodule JustBash.Commands.Shasum do
           {:ok, content, new_fs} ->
             verify_checksum_file(bash, algorithm, content, out, err, code, new_fs)
 
-          {:error, _} ->
-            {out, err <> "shasum: #{file}: No such file or directory\n", 1, fs}
+          {:error, error} ->
+            {out, err <> "shasum: #{file}: #{FS.strerror(error)}\n", 1, fs}
         end
       end)
 
@@ -117,8 +117,8 @@ defmodule JustBash.Commands.Shasum do
           do: {o <> "#{trimmed}: OK\n", e, c, new_fs},
           else: {o <> "#{trimmed}: FAILED\n", e, 1, new_fs}
 
-      {:error, _} ->
-        {o, e <> "shasum: #{trimmed}: No such file or directory\n", 1, f}
+      {:error, error} ->
+        {o, e <> "shasum: #{trimmed}: #{FS.strerror(error)}\n", 1, f}
     end
   end
 end

--- a/lib/just_bash/commands/sort.ex
+++ b/lib/just_bash/commands/sort.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Sort do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FlagParser
   alias JustBash.FS
 
@@ -61,14 +62,12 @@ defmodule JustBash.Commands.Sort do
   end
 
   defp get_content(bash, [], stdin), do: {:ok, stdin, bash.fs}
-  defp get_content(bash, ["-" | _], stdin), do: {:ok, stdin, bash.fs}
 
   # A file sort cannot read is reported, not read as empty: swallowing the
-  # error is how `sort -- -Q` answered with nothing at exit 0.
-  defp get_content(bash, [file | _], _stdin) do
-    resolved = FS.resolve_path(bash.cwd, file)
-
-    case FS.read_file(bash.fs, resolved) do
+  # error is how `sort -- -Q` answered with nothing at exit 0. `-` is stdin,
+  # not a path, so it never reaches the filesystem to fail there.
+  defp get_content(bash, [file | _], stdin) do
+    case StdinOperand.read(bash.fs, bash.cwd, file, stdin) do
       {:ok, content, fs} -> {:ok, content, fs}
       {:error, error} -> {:error, read_error(file, error)}
     end

--- a/lib/just_bash/commands/source.ex
+++ b/lib/just_bash/commands/source.ex
@@ -28,20 +28,12 @@ defmodule JustBash.Commands.Source do
           {:ok, content, fs} ->
             execute_script_content(%{bash | fs: fs}, content)
 
-          {:error, %VFS.Error{kind: :enoent}} ->
+          {:error, error} ->
             {%{
                stdout: "",
-               stderr: "bash: source: #{filename}: No such file or directory\n",
+               stderr: "bash: source: #{filename}: #{FS.strerror(error)}\n",
                exit_code: 1
              }, bash}
-
-          {:error, %VFS.Error{kind: :eisdir}} ->
-            {%{stdout: "", stderr: "bash: source: #{filename}: Is a directory\n", exit_code: 1},
-             bash}
-
-          {:error, _reason} ->
-            {%{stdout: "", stderr: "bash: source: #{filename}: cannot read\n", exit_code: 1},
-             bash}
         end
     end
   end

--- a/lib/just_bash/commands/stat.ex
+++ b/lib/just_bash/commands/stat.ex
@@ -44,8 +44,13 @@ defmodule JustBash.Commands.Stat do
     {acc_out <> out, acc_err, acc_has_err, fs}
   end
 
-  defp accumulate_stat_result({:error, _}, file, _format, {acc_out, acc_err, _acc_has_err, fs}) do
-    err = "stat: cannot stat '#{file}': No such file or directory\n"
+  defp accumulate_stat_result(
+         {:error, error},
+         file,
+         _format,
+         {acc_out, acc_err, _acc_has_err, fs}
+       ) do
+    err = "stat: cannot stat '#{file}': #{FS.strerror(error)}\n"
     {acc_out, acc_err <> err, true, fs}
   end
 

--- a/lib/just_bash/commands/stdin_operand.ex
+++ b/lib/just_bash/commands/stdin_operand.ex
@@ -1,0 +1,36 @@
+defmodule JustBash.Commands.StdinOperand do
+  @moduledoc """
+  The `-` file operand.
+
+  POSIX gives every utility that takes a file operand the same reading of a
+  bare `-`: it names standard input, not a file called `-`. Resolving it as a
+  path instead reaches the filesystem, where it does not exist — harmless
+  while the read paths failed silently, and a hard error the moment #70 taught
+  them to report the read they could not do.
+
+  `sort -`, `uniq -` and `grep pat -` are the shapes that matter: they are how
+  a pipeline names its own input when it also wants to name a file, and under
+  `set -o pipefail` a diagnostic there kills the pipeline.
+  """
+
+  alias JustBash.FS
+
+  @dash "-"
+
+  @doc """
+  True when a file operand names standard input rather than a path.
+  """
+  @spec stdin?(String.t()) :: boolean()
+  def stdin?(@dash), do: true
+  def stdin?(_operand), do: false
+
+  @doc """
+  Read a file operand, taking `-` as `stdin` rather than resolving it as a
+  path. Mirrors `JustBash.FS.read_file/2`, so the error arm a caller already
+  has for a real path keeps working unchanged.
+  """
+  @spec read(FS.t(), String.t(), String.t(), String.t() | nil) ::
+          {:ok, binary(), FS.t()} | {:error, VFS.Error.t()}
+  def read(fs, _cwd, @dash, stdin), do: {:ok, stdin || "", fs}
+  def read(fs, cwd, operand, _stdin), do: FS.read_file(fs, FS.resolve_path(cwd, operand))
+end

--- a/lib/just_bash/commands/stdin_operand.ex
+++ b/lib/just_bash/commands/stdin_operand.ex
@@ -33,4 +33,22 @@ defmodule JustBash.Commands.StdinOperand do
           {:ok, binary(), FS.t()} | {:error, VFS.Error.t()}
   def read(fs, _cwd, @dash, stdin), do: {:ok, stdin || "", fs}
   def read(fs, cwd, operand, _stdin), do: FS.read_file(fs, FS.resolve_path(cwd, operand))
+
+  @doc """
+  Split a command's arguments into its file operands, honouring `--`.
+
+  `Enum.reject(args, &String.starts_with?(&1, "-"))` is not that split. It
+  deletes `-`, which is an operand naming stdin and never an option, and it
+  deletes every operand after `--`, which is the only way to name a file whose
+  name begins with a dash. Both deletions are silent: the command reads one
+  fewer input than it was given and still exits 0.
+  """
+  @spec operands([String.t()]) :: [String.t()]
+  def operands(args), do: do_operands(args, [])
+
+  defp do_operands([], acc), do: Enum.reverse(acc)
+  defp do_operands(["--" | rest], acc), do: Enum.reverse(acc, rest)
+  defp do_operands([@dash | rest], acc), do: do_operands(rest, [@dash | acc])
+  defp do_operands([@dash <> _ | rest], acc), do: do_operands(rest, acc)
+  defp do_operands([operand | rest], acc), do: do_operands(rest, [operand | acc])
 end

--- a/lib/just_bash/commands/tac.ex
+++ b/lib/just_bash/commands/tac.ex
@@ -35,10 +35,18 @@ defmodule JustBash.Commands.Tac do
 
       case FS.read_file(fs, resolved) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
-        {:error, error} -> {:halt, {:error, "tac: #{file}: #{FS.strerror(error)}\n"}}
+        {:error, error} -> {:halt, {:error, read_error(file, error)}}
       end
     end)
   end
+
+  # GNU tac `open(2)`s a directory successfully and only fails at `read(2)`,
+  # so EISDIR gets a template of its own rather than the open-failure one.
+  defp read_error(file, %VFS.Error{kind: :eisdir}),
+    do: "tac: #{file}: read error: Is a directory\n"
+
+  defp read_error(file, error),
+    do: "tac: failed to open '#{file}' for reading: #{FS.strerror(error)}\n"
 
   defp reverse_lines(content) do
     lines = String.split(content, "\n", trim: false)

--- a/lib/just_bash/commands/tac.ex
+++ b/lib/just_bash/commands/tac.ex
@@ -35,7 +35,7 @@ defmodule JustBash.Commands.Tac do
 
       case FS.read_file(fs, resolved) do
         {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
-        {:error, _} -> {:halt, {:error, "tac: #{file}: No such file or directory\n"}}
+        {:error, error} -> {:halt, {:error, "tac: #{file}: #{FS.strerror(error)}\n"}}
       end
     end)
   end

--- a/lib/just_bash/commands/tac.ex
+++ b/lib/just_bash/commands/tac.ex
@@ -42,8 +42,8 @@ defmodule JustBash.Commands.Tac do
 
   # GNU tac `open(2)`s a directory successfully and only fails at `read(2)`,
   # so EISDIR gets a template of its own rather than the open-failure one.
-  defp read_error(file, %VFS.Error{kind: :eisdir}),
-    do: "tac: #{file}: read error: Is a directory\n"
+  defp read_error(file, %VFS.Error{kind: :eisdir} = error),
+    do: "tac: #{file}: read error: #{FS.strerror(error)}\n"
 
   defp read_error(file, error),
     do: "tac: failed to open '#{file}' for reading: #{FS.strerror(error)}\n"

--- a/lib/just_bash/commands/tac.ex
+++ b/lib/just_bash/commands/tac.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Tac do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -10,35 +11,34 @@ defmodule JustBash.Commands.Tac do
 
   @impl true
   def execute(bash, args, stdin) do
-    files = Enum.reject(args, &String.starts_with?(&1, "-"))
-
-    content =
-      if files == [] or files == ["-"] do
-        {:ok, stdin, bash.fs}
-      else
-        read_files(bash, files)
-      end
-
-    case content do
-      {:error, msg} ->
-        {Command.error(msg), bash}
-
-      {:ok, data, fs} ->
-        output = reverse_lines(data)
-        {Command.ok(output), %{bash | fs: fs}}
+    case read_operands(bash, StdinOperand.operands(args), stdin) do
+      {:error, msg} -> {Command.error(msg), bash}
+      {:ok, output, fs} -> {Command.ok(output), %{bash | fs: fs}}
     end
   end
 
-  defp read_files(bash, files) do
-    Enum.reduce_while(files, {:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
-      resolved = FS.resolve_path(bash.cwd, file)
-
-      case FS.read_file(fs, resolved) do
-        {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
+  # `tac a b` is `tac a; tac b`: GNU reverses each operand's lines on its own
+  # and writes the operands in the order given, so it is not `cat a b | tac`,
+  # which would also reverse the operands against each other.
+  defp read_operands(bash, files, stdin) do
+    files
+    |> defaults_to_stdin()
+    |> Enum.reduce_while({:ok, [], bash.fs}, fn file, {:ok, acc, fs} ->
+      case StdinOperand.read(fs, bash.cwd, file, stdin) do
+        {:ok, data, fs} -> {:cont, {:ok, [reverse_lines(data) | acc], fs}}
         {:error, error} -> {:halt, {:error, read_error(file, error)}}
       end
     end)
+    |> collect()
   end
+
+  defp defaults_to_stdin([]), do: ["-"]
+  defp defaults_to_stdin(files), do: files
+
+  defp collect({:ok, reversed, fs}),
+    do: {:ok, reversed |> Enum.reverse() |> IO.iodata_to_binary(), fs}
+
+  defp collect({:error, _msg} = error), do: error
 
   # GNU tac `open(2)`s a directory successfully and only fails at `read(2)`,
   # so EISDIR gets a template of its own rather than the open-failure one.

--- a/lib/just_bash/commands/tail.ex
+++ b/lib/just_bash/commands/tail.ex
@@ -56,8 +56,7 @@ defmodule JustBash.Commands.Tail do
             {[header <> body | out_acc], err_acc, code, fs}
 
           {:error, error} ->
-            err = "tail: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"
-            {out_acc, [err | err_acc], 1, fs}
+            {out_acc, [read_error(file, error) | err_acc], 1, fs}
         end
       end)
 
@@ -76,9 +75,17 @@ defmodule JustBash.Commands.Tail do
         {Command.ok(output), %{bash | fs: fs}}
 
       {:error, error} ->
-        {Command.error("tail: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"), bash}
+        {Command.error(read_error(file, error)), bash}
     end
   end
+
+  # GNU tail `open(2)`s a directory successfully and only fails at `read(2)`,
+  # so EISDIR gets a template of its own rather than the open-failure one.
+  defp read_error(file, %VFS.Error{kind: :eisdir}),
+    do: "tail: error reading '#{file}': Is a directory\n"
+
+  defp read_error(file, error),
+    do: "tail: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"
 
   defp tail_stdin(bash, stdin, mode) do
     output = take_content(stdin, mode)

--- a/lib/just_bash/commands/tail.ex
+++ b/lib/just_bash/commands/tail.ex
@@ -55,8 +55,8 @@ defmodule JustBash.Commands.Tail do
             body = take_content(content, mode)
             {[header <> body | out_acc], err_acc, code, fs}
 
-          {:error, _} ->
-            err = "tail: cannot open '#{file}' for reading: No such file or directory\n"
+          {:error, error} ->
+            err = "tail: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"
             {out_acc, [err | err_acc], 1, fs}
         end
       end)
@@ -75,9 +75,8 @@ defmodule JustBash.Commands.Tail do
         output = take_content(content, mode)
         {Command.ok(output), %{bash | fs: fs}}
 
-      {:error, _} ->
-        {Command.error("tail: cannot open '#{file}' for reading: No such file or directory\n"),
-         bash}
+      {:error, error} ->
+        {Command.error("tail: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"), bash}
     end
   end
 

--- a/lib/just_bash/commands/tail.ex
+++ b/lib/just_bash/commands/tail.ex
@@ -83,8 +83,8 @@ defmodule JustBash.Commands.Tail do
 
   # GNU tail `open(2)`s a directory successfully and only fails at `read(2)`,
   # so EISDIR gets a template of its own rather than the open-failure one.
-  defp read_error(file, %VFS.Error{kind: :eisdir}),
-    do: "tail: error reading '#{file}': Is a directory\n"
+  defp read_error(file, %VFS.Error{kind: :eisdir} = error),
+    do: "tail: error reading '#{file}': #{FS.strerror(error)}\n"
 
   defp read_error(file, error),
     do: "tail: cannot open '#{file}' for reading: #{FS.strerror(error)}\n"

--- a/lib/just_bash/commands/tail.ex
+++ b/lib/just_bash/commands/tail.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Tail do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FlagParser
   alias JustBash.FS
 
@@ -39,19 +40,17 @@ defmodule JustBash.Commands.Tail do
 
     case files do
       [] -> tail_stdin(bash, stdin, mode)
-      [file] -> tail_file(bash, file, mode)
-      multiple -> tail_multiple(bash, multiple, mode)
+      [file] -> tail_file(bash, file, stdin, mode)
+      multiple -> tail_multiple(bash, multiple, stdin, mode)
     end
   end
 
-  defp tail_multiple(bash, files, mode) do
+  defp tail_multiple(bash, files, stdin, mode) do
     {outputs, errors, exit_code, fs} =
       Enum.reduce(files, {[], [], 0, bash.fs}, fn file, {out_acc, err_acc, code, fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
-
-        case FS.read_file(fs, resolved) do
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
           {:ok, content, fs} ->
-            header = "==> #{file} <==\n"
+            header = "==> #{display_name(file)} <==\n"
             body = take_content(content, mode)
             {[header <> body | out_acc], err_acc, code, fs}
 
@@ -66,10 +65,8 @@ defmodule JustBash.Commands.Tail do
     {%{stdout: stdout, stderr: stderr, exit_code: exit_code}, %{bash | fs: fs}}
   end
 
-  defp tail_file(bash, file, mode) do
-    resolved = FS.resolve_path(bash.cwd, file)
-
-    case FS.read_file(bash.fs, resolved) do
+  defp tail_file(bash, file, stdin, mode) do
+    case StdinOperand.read(bash.fs, bash.cwd, file, stdin) do
       {:ok, content, fs} ->
         output = take_content(content, mode)
         {Command.ok(output), %{bash | fs: fs}}
@@ -77,6 +74,11 @@ defmodule JustBash.Commands.Tail do
       {:error, error} ->
         {Command.error(read_error(file, error)), bash}
     end
+  end
+
+  # GNU labels the `-` operand "standard input" in the multi-file header.
+  defp display_name(file) do
+    if StdinOperand.stdin?(file), do: "standard input", else: file
   end
 
   # GNU tail `open(2)`s a directory successfully and only fails at `read(2)`,

--- a/lib/just_bash/commands/tree.ex
+++ b/lib/just_bash/commands/tree.ex
@@ -90,8 +90,8 @@ defmodule JustBash.Commands.Tree do
       {:ok, _stat, _fs} ->
         {:ok, "#{display_path}\n", 0, 1}
 
-      {:error, _} ->
-        {:error, "tree: #{display_path}: No such file or directory\n"}
+      {:error, error} ->
+        {:error, "tree: #{display_path}: #{FS.strerror(error)}\n"}
     end
   end
 

--- a/lib/just_bash/commands/uniq.ex
+++ b/lib/just_bash/commands/uniq.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Uniq do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FlagParser
   alias JustBash.FS
 
@@ -36,10 +37,8 @@ defmodule JustBash.Commands.Uniq do
 
   defp get_content(bash, [], stdin), do: {:ok, stdin, bash.fs}
 
-  defp get_content(bash, [file | _], _stdin) do
-    resolved = FS.resolve_path(bash.cwd, file)
-
-    case FS.read_file(bash.fs, resolved) do
+  defp get_content(bash, [file | _], stdin) do
+    case StdinOperand.read(bash.fs, bash.cwd, file, stdin) do
       {:ok, content, fs} -> {:ok, content, fs}
       {:error, error} -> {:error, read_error(file, error)}
     end

--- a/lib/just_bash/commands/uniq.ex
+++ b/lib/just_bash/commands/uniq.ex
@@ -28,20 +28,30 @@ defmodule JustBash.Commands.Uniq do
   end
 
   defp uniq(bash, flags, files, stdin) do
-    {content, fs} =
-      case files do
-        [] ->
-          {stdin, bash.fs}
+    case get_content(bash, files, stdin) do
+      {:error, message} -> {Command.error(message), bash}
+      {:ok, content, fs} -> uniq_content(bash, content, flags, fs)
+    end
+  end
 
-        [file | _] ->
-          resolved = FS.resolve_path(bash.cwd, file)
+  defp get_content(bash, [], stdin), do: {:ok, stdin, bash.fs}
 
-          case FS.read_file(bash.fs, resolved) do
-            {:ok, c, fs} -> {c, fs}
-            {:error, _} -> {"", bash.fs}
-          end
-      end
+  defp get_content(bash, [file | _], _stdin) do
+    resolved = FS.resolve_path(bash.cwd, file)
 
+    case FS.read_file(bash.fs, resolved) do
+      {:ok, content, fs} -> {:ok, content, fs}
+      {:error, error} -> {:error, read_error(file, error)}
+    end
+  end
+
+  # GNU uniq words the failure differently once the open has succeeded.
+  defp read_error(file, %VFS.Error{kind: :eisdir}),
+    do: "uniq: error reading '#{file}': Is a directory\n"
+
+  defp read_error(file, error), do: "uniq: #{file}: #{FS.strerror(error)}\n"
+
+  defp uniq_content(bash, content, flags, fs) do
     lines = String.split(content, "\n", trim: true)
 
     output =

--- a/lib/just_bash/commands/uniq.ex
+++ b/lib/just_bash/commands/uniq.ex
@@ -45,8 +45,8 @@ defmodule JustBash.Commands.Uniq do
   end
 
   # GNU uniq words the failure differently once the open has succeeded.
-  defp read_error(file, %VFS.Error{kind: :eisdir}),
-    do: "uniq: error reading '#{file}': Is a directory\n"
+  defp read_error(file, %VFS.Error{kind: :eisdir} = error),
+    do: "uniq: error reading '#{file}': #{FS.strerror(error)}\n"
 
   defp read_error(file, error), do: "uniq: #{file}: #{FS.strerror(error)}\n"
 

--- a/lib/just_bash/commands/wc.ex
+++ b/lib/just_bash/commands/wc.ex
@@ -35,8 +35,8 @@ defmodule JustBash.Commands.Wc do
         output = format_output(content, file, flags)
         {Command.ok(output), %{bash | fs: fs}}
 
-      {:error, _} ->
-        {Command.error("wc: #{file}: No such file or directory\n"), bash}
+      {:error, error} ->
+        {Command.error("wc: #{file}: #{FS.strerror(error)}\n"), bash}
     end
   end
 
@@ -62,8 +62,8 @@ defmodule JustBash.Commands.Wc do
             line = format_output(content, file, flags)
             {[line | out_acc], new_totals, err_acc, code, fs}
 
-          {:error, _} ->
-            err = "wc: #{file}: No such file or directory\n"
+          {:error, error} ->
+            err = "wc: #{file}: #{FS.strerror(error)}\n"
             {out_acc, totals, [err | err_acc], 1, fs}
         end
       end)

--- a/lib/just_bash/commands/wc.ex
+++ b/lib/just_bash/commands/wc.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Wc do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @short_flags %{?l => :l, ?w => :w, ?c => :c}
@@ -20,17 +21,15 @@ defmodule JustBash.Commands.Wc do
         {Command.ok(output), bash}
 
       [file] ->
-        wc_single_file(bash, file, flags)
+        wc_single_file(bash, file, stdin, flags)
 
       multiple ->
-        wc_multiple_files(bash, multiple, flags)
+        wc_multiple_files(bash, multiple, stdin, flags)
     end
   end
 
-  defp wc_single_file(bash, file, flags) do
-    resolved = FS.resolve_path(bash.cwd, file)
-
-    case FS.read_file(bash.fs, resolved) do
+  defp wc_single_file(bash, file, stdin, flags) do
+    case StdinOperand.read(bash.fs, bash.cwd, file, stdin) do
       {:ok, content, fs} ->
         output = format_output(content, file, flags)
         {Command.ok(output), %{bash | fs: fs}}
@@ -40,16 +39,14 @@ defmodule JustBash.Commands.Wc do
     end
   end
 
-  defp wc_multiple_files(bash, files, flags) do
+  defp wc_multiple_files(bash, files, stdin, flags) do
     {outputs, total_counts, err_acc, exit_code, fs} =
       Enum.reduce(files, {[], %{lines: 0, words: 0, bytes: 0}, [], 0, bash.fs}, fn file,
                                                                                    {out_acc,
                                                                                     totals,
                                                                                     err_acc, code,
                                                                                     fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
-
-        case FS.read_file(fs, resolved) do
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
           {:ok, content, fs} ->
             counts = count_content(content)
 

--- a/lib/just_bash/commands/xxd.ex
+++ b/lib/just_bash/commands/xxd.ex
@@ -34,6 +34,9 @@ defmodule JustBash.Commands.Xxd do
   defp parse_args(["-p" | rest], opts), do: parse_args(rest, %{opts | plain: true})
   defp parse_args(["-r" | _], _opts), do: {:error, "xxd: -r not supported\n"}
 
+  # A bare `-` is never a flag: POSIX reads it as the stdin operand.
+  defp parse_args(["-" | rest], opts), do: parse_args(rest, %{opts | file: "-"})
+
   defp parse_args(["-" <> _ = flag | _], _opts),
     do: {:error, "xxd: unknown option: #{flag}\n"}
 

--- a/lib/just_bash/commands/xxd.ex
+++ b/lib/just_bash/commands/xxd.ex
@@ -56,7 +56,7 @@ defmodule JustBash.Commands.Xxd do
 
     case FS.read_file(bash.fs, resolved) do
       {:ok, c, fs} -> {:ok, c, %{bash | fs: fs}}
-      {:error, _} -> {:error, "xxd: #{file}: No such file or directory\n"}
+      {:error, error} -> {:error, "xxd: #{file}: #{FS.strerror(error)}\n"}
     end
   end
 

--- a/lib/just_bash/interpreter/executor.ex
+++ b/lib/just_bash/interpreter/executor.ex
@@ -349,10 +349,10 @@ defmodule JustBash.Interpreter.Executor do
         %AST.For{variable: variable, words: words, body: body, redirections: redirs},
         _stdin
       ) do
-    {_redir_stdin, non_stdin_redirs} = Redirection.extract_heredoc_stdin(bash, redirs)
-
-    with_redirections(bash, non_stdin_redirs, fn bash ->
-      Loop.execute_for(bash, variable, words, body, &execute_body/2)
+    with_stdin(bash, redirs, fn _redir_stdin, non_stdin_redirs ->
+      with_redirections(bash, non_stdin_redirs, fn bash ->
+        Loop.execute_for(bash, variable, words, body, &execute_body/2)
+      end)
     end)
   end
 
@@ -361,11 +361,10 @@ defmodule JustBash.Interpreter.Executor do
         %AST.While{condition: condition, body: body, redirections: redirs},
         stdin
       ) do
-    {redir_stdin, non_stdin_redirs} = Redirection.extract_heredoc_stdin(bash, redirs)
-    effective_stdin = redir_stdin || stdin
-
-    with_redirections(bash, non_stdin_redirs, fn bash ->
-      Loop.execute_while(bash, condition, body, effective_stdin, &execute_body/2)
+    with_stdin(bash, redirs, fn redir_stdin, non_stdin_redirs ->
+      with_redirections(bash, non_stdin_redirs, fn bash ->
+        Loop.execute_while(bash, condition, body, redir_stdin || stdin, &execute_body/2)
+      end)
     end)
   end
 
@@ -374,11 +373,10 @@ defmodule JustBash.Interpreter.Executor do
         %AST.Until{condition: condition, body: body, redirections: redirs},
         stdin
       ) do
-    {redir_stdin, non_stdin_redirs} = Redirection.extract_heredoc_stdin(bash, redirs)
-    effective_stdin = redir_stdin || stdin
-
-    with_redirections(bash, non_stdin_redirs, fn bash ->
-      Loop.execute_until(bash, condition, body, effective_stdin, &execute_body/2)
+    with_stdin(bash, redirs, fn redir_stdin, non_stdin_redirs ->
+      with_redirections(bash, non_stdin_redirs, fn bash ->
+        Loop.execute_until(bash, condition, body, redir_stdin || stdin, &execute_body/2)
+      end)
     end)
   end
 
@@ -460,12 +458,11 @@ defmodule JustBash.Interpreter.Executor do
       |> Expansion.take_substitutions()
 
     # Extract heredoc content as stdin if present
-    {heredoc_stdin, non_heredoc_redirs} = Redirection.extract_heredoc_stdin(temp_bash, redirs)
-    effective_stdin = heredoc_stdin || stdin
-
     {result, new_bash} =
-      with_redirections(temp_bash, non_heredoc_redirs, fn temp_bash ->
-        invoke_command(temp_bash, cmd_name, expanded_args, effective_stdin)
+      with_stdin(temp_bash, redirs, fn heredoc_stdin, non_heredoc_redirs ->
+        with_redirections(temp_bash, non_heredoc_redirs, fn temp_bash ->
+          invoke_command(temp_bash, cmd_name, expanded_args, heredoc_stdin || stdin)
+        end)
       end)
 
     {%{result | stderr: expansion_stderr <> result.stderr}, new_bash}
@@ -573,6 +570,20 @@ defmodule JustBash.Interpreter.Executor do
 
       {:error, result, bash} ->
         {result, bash}
+    end
+  end
+
+  # `< file` is the read side of the same rule: the shell opens the target, so
+  # a target it cannot open is the shell's diagnostic and the body never runs.
+  @spec with_stdin(
+          JustBash.t(),
+          [AST.Redirection.t()],
+          (String.t() | nil, [AST.Redirection.t()] -> {result(), JustBash.t()})
+        ) :: {result(), JustBash.t()}
+  defp with_stdin(bash, redirections, fun) do
+    case Redirection.extract_heredoc_stdin(bash, redirections) do
+      {:ok, stdin, rest} -> fun.(stdin, rest)
+      {:error, result} -> {result, bash}
     end
   end
 

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -19,6 +19,13 @@ defmodule JustBash.Interpreter.Executor.Redirection do
 
   @type result :: %{stdout: String.t(), stderr: String.t(), exit_code: non_neg_integer()}
 
+  # The one path the shell services itself instead of opening in the
+  # filesystem. Both directions have to name the same set: `> /dev/null`
+  # discards, so `< /dev/null` reads empty. Otherwise `cmd < /dev/null` — the
+  # standard way to hand a command a closed stdin — reports a missing file for
+  # a target that was never meant to be one.
+  @null_device "/dev/null"
+
   @typedoc """
   A redirection whose target has already been expanded, resolved, and opened
   by `preflight/2`.
@@ -226,13 +233,13 @@ defmodule JustBash.Interpreter.Executor.Redirection do
 
   @spec classify_redirection(non_neg_integer(), atom(), String.t()) :: redir_type()
   # Combined redirection &> must be checked before /dev/null catch-all
-  defp classify_redirection(_fd, :"&>", "/dev/null"), do: :combined_dev_null
-  defp classify_redirection(_fd, :"&>>", "/dev/null"), do: :combined_dev_null
+  defp classify_redirection(_fd, :"&>", @null_device), do: :combined_dev_null
+  defp classify_redirection(_fd, :"&>>", @null_device), do: :combined_dev_null
   defp classify_redirection(_fd, :"&>", _target), do: :combined_write
   defp classify_redirection(_fd, :"&>>", _target), do: :combined_append
-  defp classify_redirection(2, :>, "/dev/null"), do: :stderr_dev_null
-  defp classify_redirection(2, :">>", "/dev/null"), do: :stderr_dev_null
-  defp classify_redirection(_fd, _operator, "/dev/null"), do: :stdout_dev_null
+  defp classify_redirection(2, :>, @null_device), do: :stderr_dev_null
+  defp classify_redirection(2, :">>", @null_device), do: :stderr_dev_null
+  defp classify_redirection(_fd, _operator, @null_device), do: :stdout_dev_null
   defp classify_redirection(2, :>, _target), do: :stderr_write
   defp classify_redirection(2, :">>", _target), do: :stderr_append
   defp classify_redirection(_fd, :>, _target), do: :stdout_write
@@ -409,22 +416,9 @@ defmodule JustBash.Interpreter.Executor.Redirection do
 
   # Input redirection: < file
   defp extract_stdin_content(bash, [%AST.Redirection{operator: :<, target: target} | _]) do
-    path = Expansion.expand_redirect_target(bash, target)
-    resolved = FS.resolve_path(bash.cwd, path)
-
-    case FS.read_file(bash.fs, resolved) do
-      {:ok, content, _fs} ->
-        content
-
-      # `open(2)` on a directory succeeds, so bash runs the command and the
-      # *command* fails on its own read — `cat: stdin: Is a directory`. That
-      # is not a shell-level diagnostic, and this model has no seam for it.
-      {:error, %VFS.Error{kind: :eisdir}} ->
-        ""
-
-      {:error, error} ->
-        {:error, path, error}
-    end
+    bash
+    |> Expansion.expand_redirect_target(target)
+    |> read_stdin_target(bash)
   end
 
   # Heredoc with content
@@ -444,5 +438,27 @@ defmodule JustBash.Interpreter.Executor.Redirection do
 
   defp extract_stdin_content(_bash, []) do
     nil
+  end
+
+  # `< /dev/null` is the read side of `> /dev/null`: the shell services it
+  # without touching the filesystem, and the command gets an empty stdin.
+  defp read_stdin_target(@null_device, _bash), do: ""
+
+  defp read_stdin_target(path, bash) do
+    resolved = FS.resolve_path(bash.cwd, path)
+
+    case FS.read_file(bash.fs, resolved) do
+      {:ok, content, _fs} ->
+        content
+
+      # `open(2)` on a directory succeeds, so bash runs the command and the
+      # *command* fails on its own read — `cat: stdin: Is a directory`. That
+      # is not a shell-level diagnostic, and this model has no seam for it.
+      {:error, %VFS.Error{kind: :eisdir}} ->
+        ""
+
+      {:error, error} ->
+        {:error, path, error}
+    end
   end
 end

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -85,23 +85,31 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   end
 
   @doc """
-  Extract heredoc or here-string content as stdin.
-  Returns `{stdin_content, non_heredoc_redirections}`.
+  Extract heredoc, here-string or `< file` content as stdin.
+
+  Returns `{:ok, stdin_content, non_heredoc_redirections}`, or `{:error,
+  result}` when a `< file` target cannot be opened. The shell opens that
+  target itself, so — like the write side in `preflight/2` — a failure is the
+  shell's to report and the command never runs.
   """
   @spec extract_heredoc_stdin(JustBash.t(), [AST.Redirection.t()]) ::
-          {String.t() | nil, [AST.Redirection.t()]}
+          {:ok, String.t() | nil, [AST.Redirection.t()]} | {:error, result()}
   def extract_heredoc_stdin(bash, redirections) do
-    stdin_content = extract_stdin_content(bash, redirections)
+    case extract_stdin_content(bash, redirections) do
+      {:error, path, error} ->
+        {:error, %{stdout: "", stderr: "bash: #{path}: #{FS.strerror(error)}\n", exit_code: 1}}
 
-    non_heredoc_redirs =
-      Enum.reject(redirections, fn
-        %AST.Redirection{operator: :<<<} -> true
-        %AST.Redirection{operator: :"<<", target: %AST.HereDoc{}} -> true
-        %AST.Redirection{operator: :<} -> true
-        _ -> false
-      end)
+      stdin_content ->
+        non_heredoc_redirs =
+          Enum.reject(redirections, fn
+            %AST.Redirection{operator: :<<<} -> true
+            %AST.Redirection{operator: :"<<", target: %AST.HereDoc{}} -> true
+            %AST.Redirection{operator: :<} -> true
+            _ -> false
+          end)
 
-    {stdin_content, non_heredoc_redirs}
+        {:ok, stdin_content, non_heredoc_redirs}
+    end
   end
 
   # --- Private Functions ---
@@ -405,8 +413,17 @@ defmodule JustBash.Interpreter.Executor.Redirection do
     resolved = FS.resolve_path(bash.cwd, path)
 
     case FS.read_file(bash.fs, resolved) do
-      {:ok, content, _fs} -> content
-      {:error, _} -> ""
+      {:ok, content, _fs} ->
+        content
+
+      # `open(2)` on a directory succeeds, so bash runs the command and the
+      # *command* fails on its own read — `cat: stdin: Is a directory`. That
+      # is not a shell-level diagnostic, and this model has no seam for it.
+      {:error, %VFS.Error{kind: :eisdir}} ->
+        ""
+
+      {:error, error} ->
+        {:error, path, error}
     end
   end
 

--- a/lib/just_bash/spec_test/parser.ex
+++ b/lib/just_bash/spec_test/parser.ex
@@ -9,16 +9,22 @@ defmodule JustBash.SpecTest.Parser do
 
   Directives:
 
-    * `## stdout: LINE` / `## stderr: LINE` — one expected line
+    * `## stdout: LINE` / `## stderr: LINE` — one expected line. The value may
+      be empty (`## stdout:` with nothing after the colon), which is how the
+      format spells "one empty line".
     * `## stdout-json: "…"` / `## stderr-json: "…"` — an escaped expectation,
       the only way to express output with no trailing newline
     * `## STDOUT:` … `## END` / `## STDERR:` … `## END` — multiline
     * `## status: N` — expected exit status (default 0)
     * `## SKIP (why): reason` — do not run this case
-    * `## N-I <shells> …`, `## BUG <shells> …`, `## OK <shells> …` — the
-      expectation for a shell that is not bash. Bash is the oracle here, so
-      these are dropped; a multiline one is consumed to `## END` so its body
-      does not fall through into the script.
+    * `## N-I <shells> KEY: …`, `## BUG <shells> KEY: …`,
+      `## OK <shells> KEY: …` (and the `-2`/`-3` numbered spellings) — what
+      those shells actually do, overriding the unannotated default for them
+      *per key*. The unannotated default records osh, so an annotation naming
+      `bash` is bash's recorded behaviour and is the expectation we want;
+      `just-bash` is this repo's own recorded behaviour and wins over `bash`.
+      An annotation naming neither is dropped, and a multiline one is consumed
+      to `## END` so its body does not fall through into the script.
     * `## compare_shells:`, `## oils_failures_allowed:`, `## tags:`, … —
       file- or case-level metadata we have no use for
 
@@ -94,9 +100,24 @@ defmodule JustBash.SpecTest.Parser do
   defp case_header?("#### " <> _), do: true
   defp case_header?(_), do: false
 
+  # The unannotated expectation is the weakest; `## OK bash …` overrides it and
+  # `## OK just-bash …` overrides that. Precedence is tracked per key, because
+  # the format overrides one key at a time: `append.test.sh` keeps the default
+  # `## stdout-json: ""` for stdout only until `## OK bash STDOUT:` replaces it,
+  # while `## OK bash status: 0` replaces the status on its own line.
+  @default_precedence 0
+  @shell_precedence %{"bash" => 1, "just-bash" => 2}
+
   defp build_test_case(name, line_num, body) do
-    {script_lines, expectations} =
-      collect(body, [], %{stdout: nil, stderr: nil, status: 0, skip: nil})
+    initial = %{
+      stdout: nil,
+      stderr: nil,
+      status: 0,
+      skip: nil,
+      precedence: %{stdout: 0, stderr: 0, status: 0}
+    }
+
+    {script_lines, expectations} = collect(body, [], initial)
 
     %TestCase{
       name: name,
@@ -113,56 +134,104 @@ defmodule JustBash.SpecTest.Parser do
   # expectation. Script lines and directives interleave freely.
   defp collect([], script, exp), do: {Enum.reverse(script), exp}
 
-  defp collect([{"## stdout: " <> value, _} | rest], script, exp),
-    do: collect(rest, script, %{exp | stdout: value <> "\n"})
-
-  defp collect([{"## stderr: " <> value, _} | rest], script, exp),
-    do: collect(rest, script, %{exp | stderr: value <> "\n"})
-
-  defp collect([{"## stdout-json: " <> json, _} | rest], script, exp),
-    do: collect(rest, script, %{exp | stdout: parse_json_string(json)})
-
-  defp collect([{"## stderr-json: " <> json, _} | rest], script, exp),
-    do: collect(rest, script, %{exp | stderr: parse_json_string(json)})
-
-  defp collect([{"## status: " <> value, _} | rest], script, exp),
-    do: collect(rest, script, %{exp | status: value |> String.trim() |> String.to_integer()})
-
   defp collect([{"## SKIP" <> reason, _} | rest], script, exp),
     do: collect(rest, script, %{exp | skip: skip_reason(reason)})
 
-  defp collect([{"## " <> _ = line, _} | rest], script, exp) do
-    case block_opener(line) do
-      :stdout ->
-        {stdout, rest} = collect_block(rest, [])
-        collect(rest, script, %{exp | stdout: stdout})
+  defp collect([{"## " <> body, _} | rest], script, exp) do
+    case directive(body) do
+      {:block, key, precedence} ->
+        {text, rest} = collect_block(rest, [])
+        collect(rest, script, put_expectation(exp, key, text, precedence))
 
-      :stderr ->
-        {stderr, rest} = collect_block(rest, [])
-        collect(rest, script, %{exp | stderr: stderr})
+      {:value, key, value, precedence} ->
+        collect(rest, script, put_expectation(exp, key, value, precedence))
 
       # Another shell's multiline expectation: drop it, body and all.
-      :other_shell ->
+      :drop_block ->
         {_ignored, rest} = collect_block(rest, [])
         collect(rest, script, exp)
 
-      nil ->
+      :ignore ->
         collect(rest, script, exp)
     end
   end
 
   defp collect([{line, _} | rest], script, exp), do: collect(rest, [line | script], exp)
 
-  # `## STDOUT:` and `## STDERR:` open a block; so does the same suffix behind a
-  # shell annotation (`## N-I dash STDOUT:`). Trailing spaces after the colon
-  # are common in the corpus and mean nothing.
-  defp block_opener(line) do
-    case String.trim_trailing(line) do
-      "## STDOUT:" -> :stdout
-      "## STDERR:" -> :stderr
-      trimmed -> if String.ends_with?(trimmed, ["STDOUT:", "STDERR:"]), do: :other_shell
+  defp put_expectation(exp, key, value, precedence) do
+    case Map.fetch!(exp.precedence, key) do
+      current when precedence >= current ->
+        %{exp | key => value, precedence: Map.put(exp.precedence, key, precedence)}
+
+      _higher ->
+        exp
     end
   end
+
+  # `OK`, `BUG` and `N-I` (optionally numbered, `## OK-2 mksh …`) introduce a
+  # `/`-separated shell list and then an ordinary `KEY: value`.
+  @annotation ~r{^(?:OK|BUG|N-I)(?:-\d+)?\s+(\S+)\s+(.*)$}
+
+  defp directive(body) do
+    case Regex.run(@annotation, body) do
+      [_line, shells, keyed] -> annotated(shells, keyed)
+      nil -> keyed_directive(body, @default_precedence)
+    end
+  end
+
+  defp annotated(shells, keyed) do
+    case shell_precedence(shells) do
+      nil -> if block_key(keyed), do: :drop_block, else: :ignore
+      precedence -> keyed_directive(keyed, precedence)
+    end
+  end
+
+  # `bash-2` is a *different* shell (bash 2.x), so membership is exact.
+  defp shell_precedence(shells) do
+    shells
+    |> String.split("/")
+    |> Enum.map(&Map.get(@shell_precedence, &1))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.max(fn -> nil end)
+  end
+
+  defp keyed_directive(keyed, precedence) do
+    case block_key(keyed) do
+      nil -> value_directive(keyed, precedence)
+      key -> {:block, key, precedence}
+    end
+  end
+
+  # Trailing spaces after the colon are common in the corpus and mean nothing.
+  defp block_key(keyed) do
+    case String.trim_trailing(keyed) do
+      "STDOUT:" -> :stdout
+      "STDERR:" -> :stderr
+      _other -> nil
+    end
+  end
+
+  defp value_directive("stdout-json:" <> json, precedence),
+    do: {:value, :stdout, parse_json_string(json), precedence}
+
+  defp value_directive("stderr-json:" <> json, precedence),
+    do: {:value, :stderr, parse_json_string(json), precedence}
+
+  defp value_directive("stdout:" <> value, precedence),
+    do: {:value, :stdout, expected_line(value), precedence}
+
+  defp value_directive("stderr:" <> value, precedence),
+    do: {:value, :stderr, expected_line(value), precedence}
+
+  defp value_directive("status:" <> value, precedence),
+    do: {:value, :status, value |> String.trim() |> String.to_integer(), precedence}
+
+  defp value_directive(_metadata, _precedence), do: :ignore
+
+  # One separating space belongs to the format, not to the expectation, and a
+  # bare `## stdout:` carries none — that spelling means a single empty line.
+  defp expected_line(" " <> value), do: value <> "\n"
+  defp expected_line(value), do: value <> "\n"
 
   # A block runs to `## END` (spelled `## END:` in a few upstream files). A
   # missing terminator ends it at the next directive rather than eating the

--- a/lib/just_bash/spec_test/parser.ex
+++ b/lib/just_bash/spec_test/parser.ex
@@ -2,16 +2,34 @@ defmodule JustBash.SpecTest.Parser do
   @moduledoc """
   Parser for Oils spec test format (.test.sh files).
 
-  The format is:
-  - Lines starting with `##` are metadata (compare_shells, oils_failures_allowed)
-  - Lines starting with `####` are test case names
-  - Following lines until the next `##` directive are the script
-  - `## stdout:` single line expected stdout
-  - `## STDOUT:` ... `## END` multiline expected stdout
-  - `## status:` expected exit status (default 0)
-  - `## N-I` (not implemented) and `## BUG` mark shell-specific behaviors
+  A file is a run of cases. Each case opens with `#### <name>`; every line
+  after that up to the next `####` is either a `##` directive or a line of the
+  script, in any order — Oils puts `## SKIP` *above* the script and the
+  expectations below it.
+
+  Directives:
+
+    * `## stdout: LINE` / `## stderr: LINE` — one expected line
+    * `## stdout-json: "…"` / `## stderr-json: "…"` — an escaped expectation,
+      the only way to express output with no trailing newline
+    * `## STDOUT:` … `## END` / `## STDERR:` … `## END` — multiline
+    * `## status: N` — expected exit status (default 0)
+    * `## SKIP (why): reason` — do not run this case
+    * `## N-I <shells> …`, `## BUG <shells> …`, `## OK <shells> …` — the
+      expectation for a shell that is not bash. Bash is the oracle here, so
+      these are dropped; a multiline one is consumed to `## END` so its body
+      does not fall through into the script.
+    * `## compare_shells:`, `## oils_failures_allowed:`, `## tags:`, … —
+      file- or case-level metadata we have no use for
+
+  The script is kept byte-for-byte between its first and last non-blank line.
+  Only whole blank lines at either end — the file's layout, not the case's —
+  are dropped: `$LINENO`, `set -x` traces and bash's own `line N` diagnostics
+  count from the first surviving line, and a trailing space on the last
+  command is part of what the case tests.
 
   Example:
+
       #### Add one to var
       i=1
       echo $(($i+1))
@@ -24,6 +42,7 @@ defmodule JustBash.SpecTest.Parser do
       :name,
       :script,
       :expected_stdout,
+      :expected_stderr,
       :expected_status,
       :skip_reason,
       :line_number
@@ -33,6 +52,7 @@ defmodule JustBash.SpecTest.Parser do
             name: String.t(),
             script: String.t(),
             expected_stdout: String.t() | nil,
+            expected_stderr: String.t() | nil,
             expected_status: non_neg_integer(),
             skip_reason: String.t() | nil,
             line_number: pos_integer()
@@ -55,9 +75,8 @@ defmodule JustBash.SpecTest.Parser do
   """
   @spec parse(String.t()) :: [TestCase.t()]
   def parse(content) do
-    lines = String.split(content, "\n")
-
-    lines
+    content
+    |> String.split("\n")
     |> Enum.with_index(1)
     |> extract_test_cases([])
     |> Enum.reverse()
@@ -65,121 +84,134 @@ defmodule JustBash.SpecTest.Parser do
 
   defp extract_test_cases([], acc), do: acc
 
-  defp extract_test_cases([{line, line_num} | rest], acc) do
-    if String.starts_with?(line, "#### ") do
-      name = String.trim_leading(line, "#### ")
-      {test_case, remaining} = parse_test_case(name, line_num, rest)
-      extract_test_cases(remaining, [test_case | acc])
-    else
-      extract_test_cases(rest, acc)
-    end
+  defp extract_test_cases([{"#### " <> name, line_num} | rest], acc) do
+    {body, remaining} = Enum.split_while(rest, fn {line, _} -> not case_header?(line) end)
+    extract_test_cases(remaining, [build_test_case(name, line_num, body) | acc])
   end
 
-  defp parse_test_case(name, line_num, lines) do
-    {script_lines, rest} = collect_script(lines, [])
-    {expectations, remaining} = collect_expectations(rest, %{stdout: nil, status: 0, skip: nil})
+  defp extract_test_cases([_line | rest], acc), do: extract_test_cases(rest, acc)
 
-    script = script_lines |> Enum.reverse() |> Enum.join("\n") |> String.trim()
+  defp case_header?("#### " <> _), do: true
+  defp case_header?(_), do: false
 
-    test_case = %TestCase{
+  defp build_test_case(name, line_num, body) do
+    {script_lines, expectations} =
+      collect(body, [], %{stdout: nil, stderr: nil, status: 0, skip: nil})
+
+    %TestCase{
       name: name,
-      script: script,
+      script: script(script_lines),
       expected_stdout: expectations.stdout,
+      expected_stderr: expectations.stderr,
       expected_status: expectations.status,
       skip_reason: expectations.skip,
       line_number: line_num
     }
-
-    {test_case, remaining}
   end
 
-  defp collect_script([], acc), do: {acc, []}
+  # One pass over a case body, sorting each line into the script or into an
+  # expectation. Script lines and directives interleave freely.
+  defp collect([], script, exp), do: {Enum.reverse(script), exp}
 
-  defp collect_script([{line, _} | rest] = lines, acc) do
-    cond do
-      String.starts_with?(line, "#### ") ->
-        {acc, lines}
+  defp collect([{"## stdout: " <> value, _} | rest], script, exp),
+    do: collect(rest, script, %{exp | stdout: value <> "\n"})
 
-      String.starts_with?(line, "## ") ->
-        {acc, lines}
+  defp collect([{"## stderr: " <> value, _} | rest], script, exp),
+    do: collect(rest, script, %{exp | stderr: value <> "\n"})
 
-      true ->
-        collect_script(rest, [line | acc])
+  defp collect([{"## stdout-json: " <> json, _} | rest], script, exp),
+    do: collect(rest, script, %{exp | stdout: parse_json_string(json)})
+
+  defp collect([{"## stderr-json: " <> json, _} | rest], script, exp),
+    do: collect(rest, script, %{exp | stderr: parse_json_string(json)})
+
+  defp collect([{"## status: " <> value, _} | rest], script, exp),
+    do: collect(rest, script, %{exp | status: value |> String.trim() |> String.to_integer()})
+
+  defp collect([{"## SKIP" <> reason, _} | rest], script, exp),
+    do: collect(rest, script, %{exp | skip: skip_reason(reason)})
+
+  defp collect([{"## " <> _ = line, _} | rest], script, exp) do
+    case block_opener(line) do
+      :stdout ->
+        {stdout, rest} = collect_block(rest, [])
+        collect(rest, script, %{exp | stdout: stdout})
+
+      :stderr ->
+        {stderr, rest} = collect_block(rest, [])
+        collect(rest, script, %{exp | stderr: stderr})
+
+      # Another shell's multiline expectation: drop it, body and all.
+      :other_shell ->
+        {_ignored, rest} = collect_block(rest, [])
+        collect(rest, script, exp)
+
+      nil ->
+        collect(rest, script, exp)
     end
   end
 
-  defp collect_expectations([], acc), do: {acc, []}
+  defp collect([{line, _} | rest], script, exp), do: collect(rest, [line | script], exp)
 
-  defp collect_expectations([{line, _} | rest] = lines, acc) do
-    cond do
-      String.starts_with?(line, "#### ") ->
-        {acc, lines}
-
-      String.starts_with?(line, "## stdout: ") ->
-        stdout = String.trim_leading(line, "## stdout: ")
-        collect_expectations(rest, %{acc | stdout: stdout <> "\n"})
-
-      String.starts_with?(line, "## stdout-json: ") ->
-        json = String.trim_leading(line, "## stdout-json: ")
-        stdout = parse_json_string(json)
-        collect_expectations(rest, %{acc | stdout: stdout})
-
-      String.starts_with?(line, "## STDOUT:") ->
-        {stdout, remaining} = collect_multiline_stdout(rest, [])
-        collect_expectations(remaining, %{acc | stdout: stdout})
-
-      String.starts_with?(line, "## status: ") ->
-        status = line |> String.trim_leading("## status: ") |> String.to_integer()
-        collect_expectations(rest, %{acc | status: status})
-
-      String.starts_with?(line, "## N-I ") ->
-        # Not implemented in some shells - we might skip or handle differently
-        collect_expectations(rest, acc)
-
-      String.starts_with?(line, "## BUG ") ->
-        # Bug in some shells - skip this expectation
-        collect_expectations(rest, acc)
-
-      String.starts_with?(line, "## OK ") ->
-        # OK for some shells - skip
-        collect_expectations(rest, acc)
-
-      String.starts_with?(line, "## ") ->
-        # Other directives we don't handle yet
-        collect_expectations(rest, acc)
-
-      true ->
-        # Comment or blank line, continue
-        collect_expectations(rest, acc)
+  # `## STDOUT:` and `## STDERR:` open a block; so does the same suffix behind a
+  # shell annotation (`## N-I dash STDOUT:`). Trailing spaces after the colon
+  # are common in the corpus and mean nothing.
+  defp block_opener(line) do
+    case String.trim_trailing(line) do
+      "## STDOUT:" -> :stdout
+      "## STDERR:" -> :stderr
+      trimmed -> if String.ends_with?(trimmed, ["STDOUT:", "STDERR:"]), do: :other_shell
     end
   end
 
-  defp collect_multiline_stdout([], acc) do
-    {acc |> Enum.reverse() |> Enum.join("\n"), []}
-  end
+  # A block runs to `## END` (spelled `## END:` in a few upstream files). A
+  # missing terminator ends it at the next directive rather than eating the
+  # rest of the case.
+  defp collect_block([], acc), do: {block_text(acc), []}
 
-  defp collect_multiline_stdout([{line, _} | rest], acc) do
-    cond do
-      line == "## END" ->
-        stdout = acc |> Enum.reverse() |> Enum.join("\n")
-        # Add trailing newline if content exists
-        stdout = if stdout != "", do: stdout <> "\n", else: stdout
-        {stdout, rest}
+  defp collect_block([{"## END" <> _, _} | rest], acc), do: {block_text(acc), rest}
 
-      String.starts_with?(line, "## ") ->
-        # Another directive, end multiline
-        stdout = acc |> Enum.reverse() |> Enum.join("\n")
-        stdout = if stdout != "", do: stdout <> "\n", else: stdout
-        {stdout, [{line, 0} | rest]}
+  defp collect_block([{"## " <> _, _} | _] = lines, acc), do: {block_text(acc), lines}
 
-      true ->
-        collect_multiline_stdout(rest, [line | acc])
+  defp collect_block([{"#### " <> _, _} | _] = lines, acc), do: {block_text(acc), lines}
+
+  defp collect_block([{line, _} | rest], acc), do: collect_block(rest, [line | acc])
+
+  defp block_text([]), do: ""
+  defp block_text(acc), do: acc |> Enum.reverse() |> Enum.join("\n") |> Kernel.<>("\n")
+
+  # `## SKIP (unimplementable): python2 not available` and the bare
+  # `## SKIP: reason` both carry their reason after the colon.
+  defp skip_reason(rest) do
+    case String.split(rest, ":", parts: 2) do
+      [_prefix, reason] -> String.trim(reason)
+      [_only] -> String.trim(rest)
     end
   end
+
+  # Trim at line granularity, not character granularity. The blank lines that
+  # frame a case belong to the file's layout; a trailing space on a command
+  # belongs to the case — `#### a && b ` in shell-grammar.test.sh is testing
+  # exactly that. `String.trim/1` cannot tell them apart and drops both.
+  #
+  # Interior blank lines stay: `$LINENO` and bash's `line N:` diagnostics are
+  # counted from the first surviving line, which is what the corpus's recorded
+  # expectations assume (`builtin-trap-err.test.sh` asserts `line=3`).
+  defp script(lines) do
+    lines
+    |> Enum.drop_while(&blank?/1)
+    |> Enum.reverse()
+    |> Enum.drop_while(&blank?/1)
+    |> Enum.reverse()
+    |> Enum.join("\n")
+  end
+
+  defp blank?(line), do: String.trim(line) == ""
 
   defp parse_json_string(json) do
     # Handle simple JSON string escapes
     json
+    |> String.trim()
     |> String.trim("\"")
     |> String.replace("\\n", "\n")
     |> String.replace("\\t", "\t")

--- a/lib/just_bash/spec_test/runner.ex
+++ b/lib/just_bash/spec_test/runner.ex
@@ -8,14 +8,24 @@ defmodule JustBash.SpecTest.Runner do
 
   defmodule Result do
     @moduledoc "Result of running a spec test"
-    defstruct [:test_case, :passed, :actual_stdout, :actual_status, :error]
+    defstruct [
+      :test_case,
+      :passed,
+      :actual_stdout,
+      :actual_stderr,
+      :actual_status,
+      :error,
+      skipped: false
+    ]
 
     @type t :: %__MODULE__{
             test_case: TestCase.t(),
             passed: boolean(),
             actual_stdout: String.t() | nil,
+            actual_stderr: String.t() | nil,
             actual_status: non_neg_integer() | nil,
-            error: String.t() | nil
+            error: String.t() | nil,
+            skipped: boolean()
           }
   end
 
@@ -46,7 +56,7 @@ defmodule JustBash.SpecTest.Runner do
   """
   @spec run_test_case(TestCase.t(), keyword()) :: Result.t()
   def run_test_case(%TestCase{skip_reason: reason} = tc, _opts) when not is_nil(reason) do
-    %Result{test_case: tc, passed: false, error: "Skipped: #{reason}"}
+    %Result{test_case: tc, passed: false, skipped: true, error: "Skipped: #{reason}"}
   end
 
   def run_test_case(%TestCase{} = tc, opts) do
@@ -55,13 +65,16 @@ defmodule JustBash.SpecTest.Runner do
     try do
       {result, _bash} = JustBash.exec(bash, tc.script)
 
-      stdout_matches = check_stdout(tc.expected_stdout, result.stdout)
-      status_matches = result.exit_code == tc.expected_status
+      matches? =
+        check_output(tc.expected_stdout, result.stdout) and
+          check_output(tc.expected_stderr, result.stderr) and
+          result.exit_code == tc.expected_status
 
       %Result{
         test_case: tc,
-        passed: stdout_matches and status_matches,
+        passed: matches?,
         actual_stdout: result.stdout,
+        actual_stderr: result.stderr,
         actual_status: result.exit_code,
         error: nil
       }
@@ -77,24 +90,29 @@ defmodule JustBash.SpecTest.Runner do
     end
   end
 
-  defp check_stdout(nil, _actual), do: true
-  defp check_stdout(expected, actual), do: expected == actual
+  # A case that asserts nothing about a stream passes on that stream.
+  defp check_output(nil, _actual), do: true
+  defp check_output(expected, actual), do: expected == actual
 
   @doc """
   Generate a summary of test results.
   """
   @spec summary([Result.t()]) :: map()
   def summary(results) do
-    passed = Enum.count(results, & &1.passed)
-    failed = Enum.count(results, &(not &1.passed and is_nil(&1.error)))
-    errored = Enum.count(results, &(not is_nil(&1.error)))
-    total = length(results)
+    # A skipped case is neither a pass nor a failure, and does not count
+    # against the rate — the corpus carries 247 of them.
+    {skipped, ran} = Enum.split_with(results, & &1.skipped)
+    passed = Enum.count(ran, & &1.passed)
+    failed = Enum.count(ran, &(not &1.passed and is_nil(&1.error)))
+    errored = Enum.count(ran, &(not is_nil(&1.error)))
+    total = length(ran)
 
     %{
       total: total,
       passed: passed,
       failed: failed,
       errored: errored,
+      skipped: length(skipped),
       pass_rate: if(total > 0, do: Float.round(passed / total * 100, 1), else: 0.0)
     }
   end
@@ -111,12 +129,13 @@ defmodule JustBash.SpecTest.Runner do
     IO.puts("Passed:  #{s.passed}")
     IO.puts("Failed:  #{s.failed}")
     IO.puts("Errors:  #{s.errored}")
+    IO.puts("Skipped: #{s.skipped}")
     IO.puts("Rate:    #{s.pass_rate}%")
 
     # Show first few failures
     failures =
       results
-      |> Enum.filter(&(not &1.passed))
+      |> Enum.filter(&(not &1.passed and not &1.skipped))
       |> Enum.take(10)
 
     if failures != [] do
@@ -131,6 +150,8 @@ defmodule JustBash.SpecTest.Runner do
         else
           IO.puts("Expected stdout: #{inspect(result.test_case.expected_stdout)}")
           IO.puts("Actual stdout:   #{inspect(result.actual_stdout)}")
+          IO.puts("Expected stderr: #{inspect(result.test_case.expected_stderr)}")
+          IO.puts("Actual stderr:   #{inspect(result.actual_stderr)}")
           IO.puts("Expected status: #{result.test_case.expected_status}")
           IO.puts("Actual status:   #{result.actual_status}")
         end

--- a/test/commands/error_message_test.exs
+++ b/test/commands/error_message_test.exs
@@ -94,7 +94,27 @@ defmodule JustBash.Commands.ErrorMessageTest do
     {"shasum -c PATH", @read_kinds, :stderr, "shasum: PATH: MSG\n"},
     {"echo '0  PATH' > /sums; sha256sum -c /sums", @read_kinds, :stderr,
      "sha256sum: PATH: MSG\n"},
-    {"echo '0  PATH' > /sums; shasum -c /sums", @read_kinds, :stderr, "shasum: PATH: MSG\n"}
+    {"echo '0  PATH' > /sums; shasum -c /sums", @read_kinds, :stderr, "shasum: PATH: MSG\n"},
+
+    # These five printed nothing at all, which is why grepping for the wrong
+    # message did not reach them. `sort report.txt | head -5` against a
+    # mistyped path is an empty exit-0 result an agent cannot tell from an
+    # empty file.
+    {"sort PATH", @stat_kinds, :stderr, "sort: cannot read: PATH: MSG\n"},
+    {"sort PATH", [:eisdir], :stderr, "sort: read failed: PATH: MSG\n"},
+    {"cut -f1 PATH", @read_kinds, :stderr, "cut: PATH: MSG\n"},
+    {"cut -f1 PATH /f", @read_kinds, :stderr, "cut: PATH: MSG\n"},
+    {"uniq PATH", @stat_kinds, :stderr, "uniq: PATH: MSG\n"},
+    {"uniq PATH", [:eisdir], :stderr, "uniq: error reading 'PATH': MSG\n"},
+    {"grep x PATH", @read_kinds, :stderr, "grep: PATH: MSG\n"},
+    {"grep hi PATH /f", @read_kinds, :stderr, "grep: PATH: MSG\n"},
+
+    # `<` is opened by the shell, so the shell reports it and the command
+    # never runs. :eisdir is absent because `open(2)` on a directory succeeds
+    # — bash runs the command and the command fails on read, with its own name
+    # in the message, which this model does not reach.
+    {"cat < PATH", @stat_kinds, :stderr, "bash: PATH: MSG\n"},
+    {"wc -l < PATH", @stat_kinds, :stderr, "bash: PATH: MSG\n"}
   ]
 
   @strerror %{
@@ -164,6 +184,62 @@ defmodule JustBash.Commands.ErrorMessageTest do
       assert result.stdout == ""
       assert result.stderr == "md5sum: /nope: No such file or directory\n"
       assert result.exit_code == 1
+    end
+  end
+
+  describe "a read that fails is never mistaken for an empty file" do
+    test "sort exits 2 the way GNU sort does" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "sort /nope")
+
+      assert result.exit_code == 2
+    end
+
+    test "cut keeps the files it could read and still exits 1" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "cut -f1 /f /nope")
+
+      assert result.stdout == "hi\n"
+      assert result.exit_code == 1
+    end
+
+    test "grep exits 2 on a read failure even when another file matched" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "grep hi /f /nope")
+
+      assert result.stdout == "/f:hi\n"
+      assert result.exit_code == 2
+    end
+
+    test "grep -q still exits 0 when a line was selected" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "grep -q hi /f /nope")
+
+      assert result.stdout == ""
+      assert result.stderr == "grep: /nope: No such file or directory\n"
+      assert result.exit_code == 0
+    end
+
+    test "a failed < redirect stops the command from running" do
+      # `wc -l < /nope` used to print a fabricated 0 — the sharpest form of the
+      # bug, because the number looks like an answer.
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "wc -l < /nope")
+
+      assert result.stdout == ""
+      assert result.stderr == "bash: /nope: No such file or directory\n"
+      assert result.exit_code == 1
+    end
+
+    test "a loop redirected from a file it cannot open does not run either" do
+      {result, _bash} =
+        JustBash.exec(sandbox(:enoent), "while read line; do echo ran; done < /nope")
+
+      assert result.stdout == ""
+      assert result.stderr == "bash: /nope: No such file or directory\n"
+      assert result.exit_code == 1
+    end
+
+    test "a heredoc is unaffected" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "cat <<< hello")
+
+      assert result.stdout == "hello\n"
+      assert result.exit_code == 0
     end
   end
 

--- a/test/commands/error_message_test.exs
+++ b/test/commands/error_message_test.exs
@@ -41,9 +41,7 @@ defmodule JustBash.Commands.ErrorMessageTest do
     {"shasum PATH", :stderr, "shasum: PATH: MSG\n"},
     {"diff PATH PATH", :stderr, "diff: PATH: MSG\n"},
     {"source PATH", :stderr, "bash: source: PATH: MSG\n"},
-    # md5sum writes its diagnostic to stdout. That is a separate bug from the
-    # message text, so it is recorded here rather than quietly corrected.
-    {"md5sum PATH", :stdout, "md5sum: PATH: MSG\n"}
+    {"md5sum PATH", :stderr, "md5sum: PATH: MSG\n"}
   ]
 
   # Commands that only inspect metadata. A directory is a perfectly good answer
@@ -114,6 +112,33 @@ defmodule JustBash.Commands.ErrorMessageTest do
         assert Map.fetch!(result, unquote(stream)) == fill(unquote(template), kind)
         assert result.exit_code != 0
       end
+    end
+  end
+
+  describe "a diagnostic never lands in a data stream" do
+    test "md5sum keeps the checksum stream free of its own error" do
+      # `md5sum a b > sums.txt` has to produce a checksum file, not a checksum
+      # file with a diagnostic wedged into it as a malformed line.
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "md5sum /f /nope")
+
+      assert result.stdout == "764efa883dda1e11db47671c4a3bbd9e  /f\n"
+      assert result.stderr == "md5sum: /nope: No such file or directory\n"
+      assert result.exit_code == 1
+    end
+
+    test "md5sum's error is silenced by 2>/dev/null" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "md5sum /nope 2>/dev/null")
+
+      assert result.stdout == ""
+      assert result.exit_code == 1
+    end
+
+    test "md5sum -c reports a checksum file it cannot read" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "md5sum -c /nope")
+
+      assert result.stdout == ""
+      assert result.stderr == "md5sum: /nope: No such file or directory\n"
+      assert result.exit_code == 1
     end
   end
 

--- a/test/commands/error_message_test.exs
+++ b/test/commands/error_message_test.exs
@@ -58,7 +58,10 @@ defmodule JustBash.Commands.ErrorMessageTest do
     {"stat PATH", @stat_kinds, :stderr, "stat: cannot stat 'PATH': MSG\n"},
     {"chmod 644 PATH", @stat_kinds, :stderr, "chmod: cannot access 'PATH': MSG\n"},
     {"chown u PATH", @stat_kinds, :stderr, "chown: cannot access 'PATH': MSG\n"},
-    {"realpath PATH", @stat_kinds, :stderr, "realpath: PATH: MSG\n"},
+    # Without -e, realpath only requires the *parent* components to exist, so
+    # :enoent on the final component is not an error at all — see below.
+    {"realpath PATH", [:enotdir, :eacces], :stderr, "realpath: PATH: MSG\n"},
+    {"realpath -e PATH", @stat_kinds, :stderr, "realpath: PATH: MSG\n"},
     {"du PATH", @stat_kinds, :stderr, "du: cannot access 'PATH': MSG\n"},
     {"find PATH", @stat_kinds, :stderr, "find: PATH: MSG\n"},
     {"tree PATH", @stat_kinds, :stderr, "tree: PATH: MSG\n"},
@@ -136,6 +139,47 @@ defmodule JustBash.Commands.ErrorMessageTest do
 
       assert result.stdout == ""
       assert result.stderr == "md5sum: /nope: No such file or directory\n"
+      assert result.exit_code == 1
+    end
+  end
+
+  # Verified against coreutils 9.x: `grealpath nope` -> rc=0 and the
+  # canonicalised path; `grealpath nope/deep/x` -> rc=1. The last component is
+  # allowed to be missing; everything before it has to be a directory.
+  describe "realpath without -e" do
+    test "canonicalises a missing final component and exits 0" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "realpath /nope")
+
+      assert result.stdout == "/nope\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "errors when an intermediate component is missing" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "realpath /nope/deep/x")
+
+      assert result.stderr == "realpath: /nope/deep/x: No such file or directory\n"
+      assert result.exit_code == 1
+    end
+
+    test "errors when the parent component is not a directory" do
+      {result, _bash} = JustBash.exec(sandbox(:enotdir), "realpath /f/x")
+
+      assert result.stderr == "realpath: /f/x: Not a directory\n"
+      assert result.exit_code == 1
+    end
+
+    test "-m accepts a missing intermediate component too" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "realpath -m /nope/deep/x")
+
+      assert result.stdout == "/nope/deep/x\n"
+      assert result.exit_code == 0
+    end
+
+    test "-e still requires the whole path to exist" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "realpath -e /nope")
+
+      assert result.stderr == "realpath: /nope: No such file or directory\n"
       assert result.exit_code == 1
     end
   end

--- a/test/commands/error_message_test.exs
+++ b/test/commands/error_message_test.exs
@@ -14,50 +14,58 @@ defmodule JustBash.Commands.ErrorMessageTest do
 
   alias JustBash.Test.FailingBackend
 
-  # Commands that read a file's *contents*. Every one of these can hit all four
-  # kinds, including :eisdir — reading a directory is an error.
-  #
-  # `PATH` is the operand under test; `MSG` is the strerror text for the kind.
-  @content_readers [
-    {"cat PATH", :stderr, "cat: PATH: MSG\n"},
-    {"wc PATH", :stderr, "wc: PATH: MSG\n"},
-    {"head PATH", :stderr, "head: cannot open 'PATH' for reading: MSG\n"},
-    {"tail PATH", :stderr, "tail: cannot open 'PATH' for reading: MSG\n"},
-    {"od PATH", :stderr, "od: PATH: MSG\n"},
-    {"xxd PATH", :stderr, "xxd: PATH: MSG\n"},
-    {"base64 PATH", :stderr, "base64: PATH: MSG\n"},
-    {"tac PATH", :stderr, "tac: PATH: MSG\n"},
-    {"rev PATH", :stderr, "rev: PATH: MSG\n"},
-    {"nl PATH", :stderr, "nl: PATH: MSG\n"},
-    {"fold PATH", :stderr, "fold: PATH: MSG\n"},
-    {"expand PATH", :stderr, "expand: PATH: MSG\n"},
-    {"paste PATH", :stderr, "paste: PATH: MSG\n"},
-    {"comm PATH PATH", :stderr, "comm: PATH: MSG\n"},
-    {"jq . PATH", :stderr, "jq: PATH: MSG\n"},
-    {"awk '{print}' PATH", :stderr, "awk: PATH: MSG\n"},
-    {"sed -n p PATH", :stderr, "sed: PATH: MSG\n"},
-    {"sed -i s/a/b/ PATH", :stderr, "sed: PATH: MSG\n"},
-    {"sha256sum PATH", :stderr, "sha256sum: PATH: MSG\n"},
-    {"shasum PATH", :stderr, "shasum: PATH: MSG\n"},
-    {"diff PATH PATH", :stderr, "diff: PATH: MSG\n"},
-    {"source PATH", :stderr, "bash: source: PATH: MSG\n"},
-    {"md5sum PATH", :stderr, "md5sum: PATH: MSG\n"}
-  ]
+  # Reading a file's *contents* can hit all four kinds, including :eisdir —
+  # reading a directory is an error.
+  @read_kinds [:enoent, :enotdir, :eisdir, :eacces]
 
-  # Commands that only inspect metadata. A directory is a perfectly good answer
-  # for these, so :eisdir is not among the kinds they can surface.
-  @metadata_readers [
-    {"stat PATH", :stderr, "stat: cannot stat 'PATH': MSG\n"},
-    {"chmod 644 PATH", :stderr, "chmod: cannot access 'PATH': MSG\n"},
-    {"chown u PATH", :stderr, "chown: cannot access 'PATH': MSG\n"},
-    {"realpath PATH", :stderr, "realpath: PATH: MSG\n"},
-    {"du PATH", :stderr, "du: cannot access 'PATH': MSG\n"},
-    {"find PATH", :stderr, "find: PATH: MSG\n"},
-    {"tree PATH", :stderr, "tree: PATH: MSG\n"},
-    {"ls PATH", :stderr, "ls: cannot access 'PATH': MSG\n"},
-    {"rm PATH", :stderr, "rm: cannot remove 'PATH': MSG\n"},
-    {"cp PATH /dest", :stderr, "cp: cannot stat 'PATH': MSG\n"},
-    {"file PATH", :stdout, "PATH: cannot open (MSG)\n"}
+  # A directory is a perfectly good answer for a command that only inspects
+  # metadata, so :eisdir is not among the kinds it can surface. It is also not
+  # among the kinds that can reach a template chosen at `open(2)` time — GNU
+  # head/tail/tac open a directory successfully and fail at `read(2)`, which
+  # gets its own wording.
+  @stat_kinds [:enoent, :enotdir, :eacces]
+
+  # Each row is an invocation, the kinds it covers, the stream the diagnostic
+  # belongs on, and the template. `PATH` is the operand under test; `MSG` is
+  # the strerror text for the kind.
+  @matrix [
+    {"cat PATH", @read_kinds, :stderr, "cat: PATH: MSG\n"},
+    {"wc PATH", @read_kinds, :stderr, "wc: PATH: MSG\n"},
+    {"head PATH", @stat_kinds, :stderr, "head: cannot open 'PATH' for reading: MSG\n"},
+    {"head PATH", [:eisdir], :stderr, "head: error reading 'PATH': MSG\n"},
+    {"tail PATH", @stat_kinds, :stderr, "tail: cannot open 'PATH' for reading: MSG\n"},
+    {"tail PATH", [:eisdir], :stderr, "tail: error reading 'PATH': MSG\n"},
+    {"od PATH", @read_kinds, :stderr, "od: PATH: MSG\n"},
+    {"xxd PATH", @read_kinds, :stderr, "xxd: PATH: MSG\n"},
+    {"base64 PATH", @read_kinds, :stderr, "base64: PATH: MSG\n"},
+    {"tac PATH", @stat_kinds, :stderr, "tac: failed to open 'PATH' for reading: MSG\n"},
+    {"tac PATH", [:eisdir], :stderr, "tac: PATH: read error: MSG\n"},
+    {"rev PATH", @read_kinds, :stderr, "rev: PATH: MSG\n"},
+    {"nl PATH", @read_kinds, :stderr, "nl: PATH: MSG\n"},
+    {"fold PATH", @read_kinds, :stderr, "fold: PATH: MSG\n"},
+    {"expand PATH", @read_kinds, :stderr, "expand: PATH: MSG\n"},
+    {"paste PATH", @read_kinds, :stderr, "paste: PATH: MSG\n"},
+    {"comm PATH PATH", @read_kinds, :stderr, "comm: PATH: MSG\n"},
+    {"jq . PATH", @read_kinds, :stderr, "jq: PATH: MSG\n"},
+    {"awk '{print}' PATH", @read_kinds, :stderr, "awk: PATH: MSG\n"},
+    {"sed -n p PATH", @read_kinds, :stderr, "sed: PATH: MSG\n"},
+    {"sed -i s/a/b/ PATH", @read_kinds, :stderr, "sed: PATH: MSG\n"},
+    {"sha256sum PATH", @read_kinds, :stderr, "sha256sum: PATH: MSG\n"},
+    {"shasum PATH", @read_kinds, :stderr, "shasum: PATH: MSG\n"},
+    {"diff PATH PATH", @read_kinds, :stderr, "diff: PATH: MSG\n"},
+    {"source PATH", @read_kinds, :stderr, "bash: source: PATH: MSG\n"},
+    {"md5sum PATH", @read_kinds, :stderr, "md5sum: PATH: MSG\n"},
+    {"stat PATH", @stat_kinds, :stderr, "stat: cannot stat 'PATH': MSG\n"},
+    {"chmod 644 PATH", @stat_kinds, :stderr, "chmod: cannot access 'PATH': MSG\n"},
+    {"chown u PATH", @stat_kinds, :stderr, "chown: cannot access 'PATH': MSG\n"},
+    {"realpath PATH", @stat_kinds, :stderr, "realpath: PATH: MSG\n"},
+    {"du PATH", @stat_kinds, :stderr, "du: cannot access 'PATH': MSG\n"},
+    {"find PATH", @stat_kinds, :stderr, "find: PATH: MSG\n"},
+    {"tree PATH", @stat_kinds, :stderr, "tree: PATH: MSG\n"},
+    {"ls PATH", @stat_kinds, :stderr, "ls: cannot access 'PATH': MSG\n"},
+    {"rm PATH", @stat_kinds, :stderr, "rm: cannot remove 'PATH': MSG\n"},
+    {"cp PATH /dest", @stat_kinds, :stderr, "cp: cannot stat 'PATH': MSG\n"},
+    {"file PATH", @stat_kinds, :stdout, "PATH: cannot open (MSG)\n"}
   ]
 
   @strerror %{
@@ -92,19 +100,7 @@ defmodule JustBash.Commands.ErrorMessageTest do
   end
 
   describe "the strerror matrix" do
-    for {script, stream, template} <- @content_readers,
-        kind <- [:enoent, :enotdir, :eisdir, :eacces] do
-      test "#{script} names #{kind} rather than guessing" do
-        kind = unquote(kind)
-        {result, _bash} = JustBash.exec(sandbox(kind), fill(unquote(script), kind))
-
-        assert Map.fetch!(result, unquote(stream)) == fill(unquote(template), kind)
-        assert result.exit_code != 0
-      end
-    end
-
-    for {script, stream, template} <- @metadata_readers,
-        kind <- [:enoent, :enotdir, :eacces] do
+    for {script, kinds, stream, template} <- @matrix, kind <- kinds do
       test "#{script} names #{kind} rather than guessing" do
         kind = unquote(kind)
         {result, _bash} = JustBash.exec(sandbox(kind), fill(unquote(script), kind))

--- a/test/commands/error_message_test.exs
+++ b/test/commands/error_message_test.exs
@@ -65,7 +65,9 @@ defmodule JustBash.Commands.ErrorMessageTest do
     {"ls PATH", @stat_kinds, :stderr, "ls: cannot access 'PATH': MSG\n"},
     {"rm PATH", @stat_kinds, :stderr, "rm: cannot remove 'PATH': MSG\n"},
     {"cp PATH /dest", @stat_kinds, :stderr, "cp: cannot stat 'PATH': MSG\n"},
-    {"file PATH", @stat_kinds, :stdout, "PATH: cannot open (MSG)\n"}
+    {"file PATH", @stat_kinds, :stdout, "PATH: cannot open (MSG)\n"},
+    # -b suppresses the filename prefix, not the reason.
+    {"file -b PATH", @stat_kinds, :stdout, "cannot open (MSG)\n"}
   ]
 
   @strerror %{

--- a/test/commands/error_message_test.exs
+++ b/test/commands/error_message_test.exs
@@ -1,0 +1,128 @@
+defmodule JustBash.Commands.ErrorMessageTest do
+  @moduledoc """
+  The strerror sweep from #70: 33 command modules spelled every filesystem
+  failure "No such file or directory", because they matched `{:error, _}` and
+  threw the kind away. `stat /f/x` on a regular-file `/f` claimed the path did
+  not exist when it exists and its parent is not a directory.
+
+  The cases below are the cross product of the commands that touch the
+  filesystem and the error kinds a path can fail with, enumerated rather than
+  written one at a time — the point of #70 is that a matrix nobody wrote by
+  hand is where the divergences hide.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.Test.FailingBackend
+
+  # Commands that read a file's *contents*. Every one of these can hit all four
+  # kinds, including :eisdir — reading a directory is an error.
+  #
+  # `PATH` is the operand under test; `MSG` is the strerror text for the kind.
+  @content_readers [
+    {"cat PATH", :stderr, "cat: PATH: MSG\n"},
+    {"wc PATH", :stderr, "wc: PATH: MSG\n"},
+    {"head PATH", :stderr, "head: cannot open 'PATH' for reading: MSG\n"},
+    {"tail PATH", :stderr, "tail: cannot open 'PATH' for reading: MSG\n"},
+    {"od PATH", :stderr, "od: PATH: MSG\n"},
+    {"xxd PATH", :stderr, "xxd: PATH: MSG\n"},
+    {"base64 PATH", :stderr, "base64: PATH: MSG\n"},
+    {"tac PATH", :stderr, "tac: PATH: MSG\n"},
+    {"rev PATH", :stderr, "rev: PATH: MSG\n"},
+    {"nl PATH", :stderr, "nl: PATH: MSG\n"},
+    {"fold PATH", :stderr, "fold: PATH: MSG\n"},
+    {"expand PATH", :stderr, "expand: PATH: MSG\n"},
+    {"paste PATH", :stderr, "paste: PATH: MSG\n"},
+    {"comm PATH PATH", :stderr, "comm: PATH: MSG\n"},
+    {"jq . PATH", :stderr, "jq: PATH: MSG\n"},
+    {"awk '{print}' PATH", :stderr, "awk: PATH: MSG\n"},
+    {"sed -n p PATH", :stderr, "sed: PATH: MSG\n"},
+    {"sed -i s/a/b/ PATH", :stderr, "sed: PATH: MSG\n"},
+    {"sha256sum PATH", :stderr, "sha256sum: PATH: MSG\n"},
+    {"shasum PATH", :stderr, "shasum: PATH: MSG\n"},
+    {"diff PATH PATH", :stderr, "diff: PATH: MSG\n"},
+    {"source PATH", :stderr, "bash: source: PATH: MSG\n"},
+    # md5sum writes its diagnostic to stdout. That is a separate bug from the
+    # message text, so it is recorded here rather than quietly corrected.
+    {"md5sum PATH", :stdout, "md5sum: PATH: MSG\n"}
+  ]
+
+  # Commands that only inspect metadata. A directory is a perfectly good answer
+  # for these, so :eisdir is not among the kinds they can surface.
+  @metadata_readers [
+    {"stat PATH", :stderr, "stat: cannot stat 'PATH': MSG\n"},
+    {"chmod 644 PATH", :stderr, "chmod: cannot access 'PATH': MSG\n"},
+    {"chown u PATH", :stderr, "chown: cannot access 'PATH': MSG\n"},
+    {"realpath PATH", :stderr, "realpath: PATH: MSG\n"},
+    {"du PATH", :stderr, "du: cannot access 'PATH': MSG\n"},
+    {"find PATH", :stderr, "find: PATH: MSG\n"},
+    {"tree PATH", :stderr, "tree: PATH: MSG\n"},
+    {"ls PATH", :stderr, "ls: cannot access 'PATH': MSG\n"},
+    {"rm PATH", :stderr, "rm: cannot remove 'PATH': MSG\n"},
+    {"cp PATH /dest", :stderr, "cp: cannot stat 'PATH': MSG\n"},
+    {"file PATH", :stdout, "PATH: cannot open (MSG)\n"}
+  ]
+
+  @strerror %{
+    enoent: "No such file or directory",
+    enotdir: "Not a directory",
+    eisdir: "Is a directory",
+    eacces: "Permission denied"
+  }
+
+  # /f is a regular file, so /f/x names a path whose parent component is not a
+  # directory; /d is a directory, so reading it is :eisdir. The in-memory
+  # backend has no permission model, so :eacces comes from a mount that refuses
+  # everything — the only way to reach the kind at all.
+  @files %{"/f" => "hi\n", "/d/inner" => "x\n"}
+
+  defp sandbox(:eacces) do
+    JustBash.new(files: @files)
+    |> JustBash.mount("/mnt", %FailingBackend{kind: :eacces})
+  end
+
+  defp sandbox(_kind), do: JustBash.new(files: @files)
+
+  defp path(:enoent), do: "/nope"
+  defp path(:enotdir), do: "/f/x"
+  defp path(:eisdir), do: "/d"
+  defp path(:eacces), do: "/mnt/f"
+
+  defp fill(template, kind) do
+    template
+    |> String.replace("PATH", path(kind))
+    |> String.replace("MSG", Map.fetch!(@strerror, kind))
+  end
+
+  describe "the strerror matrix" do
+    for {script, stream, template} <- @content_readers,
+        kind <- [:enoent, :enotdir, :eisdir, :eacces] do
+      test "#{script} names #{kind} rather than guessing" do
+        kind = unquote(kind)
+        {result, _bash} = JustBash.exec(sandbox(kind), fill(unquote(script), kind))
+
+        assert Map.fetch!(result, unquote(stream)) == fill(unquote(template), kind)
+        assert result.exit_code != 0
+      end
+    end
+
+    for {script, stream, template} <- @metadata_readers,
+        kind <- [:enoent, :enotdir, :eacces] do
+      test "#{script} names #{kind} rather than guessing" do
+        kind = unquote(kind)
+        {result, _bash} = JustBash.exec(sandbox(kind), fill(unquote(script), kind))
+
+        assert Map.fetch!(result, unquote(stream)) == fill(unquote(template), kind)
+        assert result.exit_code != 0
+      end
+    end
+  end
+
+  describe "JustBash.exec_file/2" do
+    test "names the kind when the script path is not readable" do
+      bash = JustBash.new(files: @files)
+
+      assert {%{stderr: "/f/x: Not a directory\n", exit_code: 1}, _bash} =
+               JustBash.exec_file(bash, "/f/x")
+    end
+  end
+end

--- a/test/commands/error_message_test.exs
+++ b/test/commands/error_message_test.exs
@@ -9,6 +9,13 @@ defmodule JustBash.Commands.ErrorMessageTest do
   filesystem and the error kinds a path can fail with, enumerated rather than
   written one at a time — the point of #70 is that a matrix nobody wrote by
   hand is where the divergences hide.
+
+  Operand arity is part of that cross product. `head`, `tail` and `wc` each
+  have a single-file arm and a reduce over several files, and `sha256sum` and
+  `shasum` have a third arm behind `-c`; with every row pinned to one operand,
+  five of the sites this sweep exists to fix could be reverted with the suite
+  still green. Rows that name two operands, or a checksum file, are there to
+  reach them.
   """
   use ExUnit.Case, async: true
 
@@ -70,7 +77,24 @@ defmodule JustBash.Commands.ErrorMessageTest do
     {"cp PATH /dest", @stat_kinds, :stderr, "cp: cannot stat 'PATH': MSG\n"},
     {"file PATH", @stat_kinds, :stdout, "PATH: cannot open (MSG)\n"},
     # -b suppresses the filename prefix, not the reason.
-    {"file -b PATH", @stat_kinds, :stdout, "cannot open (MSG)\n"}
+    {"file -b PATH", @stat_kinds, :stdout, "cannot open (MSG)\n"},
+
+    # Operand arity is an axis of this matrix, not a constant. head, tail and
+    # wc each have a single-file arm and a reduce over several files, and the
+    # sweep changed both; a one-operand invocation can never reach the second.
+    {"head PATH /f", @stat_kinds, :stderr, "head: cannot open 'PATH' for reading: MSG\n"},
+    {"head PATH /f", [:eisdir], :stderr, "head: error reading 'PATH': MSG\n"},
+    {"tail PATH /f", @stat_kinds, :stderr, "tail: cannot open 'PATH' for reading: MSG\n"},
+    {"tail PATH /f", [:eisdir], :stderr, "tail: error reading 'PATH': MSG\n"},
+    {"wc PATH /f", @read_kinds, :stderr, "wc: PATH: MSG\n"},
+
+    # -c is a third arm again: one site for the checksum file itself, another
+    # for each target it names.
+    {"sha256sum -c PATH", @read_kinds, :stderr, "sha256sum: PATH: MSG\n"},
+    {"shasum -c PATH", @read_kinds, :stderr, "shasum: PATH: MSG\n"},
+    {"echo '0  PATH' > /sums; sha256sum -c /sums", @read_kinds, :stderr,
+     "sha256sum: PATH: MSG\n"},
+    {"echo '0  PATH' > /sums; shasum -c /sums", @read_kinds, :stderr, "shasum: PATH: MSG\n"}
   ]
 
   @strerror %{

--- a/test/commands/file_info_test.exs
+++ b/test/commands/file_info_test.exs
@@ -485,7 +485,8 @@ defmodule JustBash.Commands.FileInfoTest do
       bash = JustBash.new()
       {result, _} = JustBash.exec(bash, "md5sum /nonexistent")
       assert result.exit_code == 1
-      assert result.stdout =~ "No such file"
+      assert result.stdout == ""
+      assert result.stderr =~ "No such file"
     end
   end
 

--- a/test/commands/stdin_operand_test.exs
+++ b/test/commands/stdin_operand_test.exs
@@ -26,23 +26,29 @@ defmodule JustBash.Commands.StdinOperandTest do
 
   @stdin "b\na\nb\n"
 
+  # The bytes of the *other* operand in the two-operand rows, distinct from
+  # `@stdin` so that dropping either one is visible.
+  @other "d\nc\nd\n"
+
   # `jq` is the one row whose input has to be a JSON document rather than
-  # arbitrary lines, so it names its own.
+  # arbitrary lines, so it names its own — both of them.
   @json "{\"k\":1}\n"
+  @json_other "{\"k\":2}\n"
 
   # Every command whose file operand GNU reads as stdin when it is `-`, with
   # the rest of the invocation it needs to do anything. FILE is the operand
-  # under test; a row may carry the stdin it needs, and the name the command
-  # shows for that operand when it is not the literal `-`.
+  # under test; a row may carry the stdin it needs, the name the command shows
+  # for that operand when it is not the literal `-`, and the bytes of the
+  # second operand in the two-operand runs.
   @dash_operand [
-    {"jq . FILE", @json, "-"},
-    {"file FILE", @stdin, "/dev/stdin"},
+    {"jq . FILE", @json, "-", @json_other},
+    {"file FILE", @stdin, "/dev/stdin", @other},
+    {"head FILE", @stdin, "standard input", @other},
+    {"tail FILE", @stdin, "standard input", @other},
+    {"grep b FILE", @stdin, "(standard input)", @other},
     "cat FILE",
     "tac FILE",
-    "head FILE",
-    "tail FILE",
     "wc -l FILE",
-    "grep b FILE",
     "sort FILE",
     "uniq FILE",
     "cut -c1 FILE",
@@ -77,13 +83,13 @@ defmodule JustBash.Commands.StdinOperandTest do
   )
 
   @rows Enum.map(@dash_operand, fn
-          {script, input, shown} -> {script, input, shown}
-          script -> {script, @stdin, "-"}
+          {script, input, shown, other} -> {script, input, shown, other}
+          script -> {script, @stdin, "-", @other}
         end)
 
   describe "the registry is fully classified" do
     test "every command is either a `-`-reads-stdin command or explicitly not" do
-      named = Enum.map(@rows, fn {script, _, _} -> script |> String.split(" ") |> hd() end)
+      named = Enum.map(@rows, fn {script, _, _, _} -> script |> String.split(" ") |> hd() end)
       classified = MapSet.new(named ++ @no_dash_operand)
 
       assert MapSet.new(Registry.list()) == classified
@@ -91,7 +97,7 @@ defmodule JustBash.Commands.StdinOperandTest do
   end
 
   describe "`-` names stdin, not a path" do
-    for {script, input, shown} <- @rows do
+    for {script, input, shown, _other} <- @rows do
       test "#{script} reads stdin" do
         {script, input, shown} = {unquote(script), unquote(input), unquote(shown)}
         dash = String.replace(script, "FILE", "-")
@@ -144,6 +150,60 @@ defmodule JustBash.Commands.StdinOperandTest do
     end
   end
 
+  describe "`-` is still stdin when it shares the command line with a file" do
+    # The rows above only ever build a single-operand invocation, and that is
+    # blind to the bug that mattered: a parser that deletes `-` from the
+    # operand list — `Enum.reject(args, &String.starts_with?(&1, "-"))` — still
+    # looks correct there, because deleting the only operand leaves the command
+    # falling back to stdin for a second reason. It is only with a file beside
+    # it that the deletion shows up, as a missing operand or as `-` reaching
+    # the filesystem.
+    #
+    # The reference run puts `/s` — a real file holding exactly the stdin bytes
+    # — in the `-` slot, so a command that reads only its first operand, or
+    # only its last, compares equal to itself. What is under test is the
+    # classification of `-`, not how many operands the command supports.
+    for {script, input, shown, other} <- @rows do
+      test "#{script}: `- FILE` and `FILE -` name stdin in either position" do
+        {script, input, shown, other} =
+          {unquote(script), unquote(input), unquote(shown), unquote(other)}
+
+        for {dash, ref} <- [{{"-", "/f"}, {"/s", "/f"}}, {{"/f", "-"}, {"/f", "/s"}}] do
+          {piped, _bash} = run(script, dash, input, other)
+          {from_file, _bash} = run(script, ref, input, other)
+
+          assert piped.exit_code == from_file.exit_code
+          assert piped.stderr == String.replace(from_file.stderr, "/s", shown)
+          assert piped.stdout == String.replace(from_file.stdout, "/s", shown)
+        end
+      end
+    end
+
+    # The matrix above compares `-` against a file and so cannot see this:
+    # `tac a b` is `tac a; tac b`, not `cat a b | tac`. GNU reverses each
+    # operand's lines on its own and writes the operands in the order given —
+    # `gtac - b` with `1\n2\n` on stdin prints `2 1 4 3`, not `4 3 2 1`.
+    test "tac reverses each operand on its own, in operand order" do
+      bash = JustBash.new(files: %{"/a" => "1\n2\n", "/b" => "3\n4\n"})
+      piped = "printf '1\\n2\\n' | "
+
+      assert {%{stdout: "2\n1\n4\n3\n"}, _} = JustBash.exec(bash, "tac /a /b")
+      assert {%{stdout: "4\n3\n2\n1\n"}, _} = JustBash.exec(bash, "tac /b /a")
+      assert {%{stdout: "2\n1\n4\n3\n"}, _} = JustBash.exec(bash, piped <> "tac - /b")
+      assert {%{stdout: "4\n3\n2\n1\n"}, _} = JustBash.exec(bash, piped <> "tac /b -")
+    end
+
+    test "an operand after `--` is a path, dash and all" do
+      bash = JustBash.new(files: %{"/-f" => "12\n34\n"})
+
+      assert {%{stdout: "34\n12\n", stderr: "", exit_code: 0}, _} =
+               JustBash.exec(bash, "cd /; tac -- -f")
+
+      assert {%{stdout: "21\n43\n", stderr: "", exit_code: 0}, _} =
+               JustBash.exec(bash, "cd /; rev -- -f")
+    end
+  end
+
   describe "`< /dev/null` closes stdin" do
     test "cat reads nothing and exits 0" do
       {result, _bash} = JustBash.exec(sandbox(), "cat < /dev/null; echo rc=$?")
@@ -189,4 +249,21 @@ defmodule JustBash.Commands.StdinOperandTest do
   # /f holds exactly the bytes the pipeline feeds in, so `cmd -` and `cmd /f`
   # differ only in where the command looked for them.
   defp sandbox(content \\ @stdin), do: JustBash.new(files: %{"/f" => content})
+
+  # In the two-operand runs the two operands hold different bytes, so dropping
+  # either one is visible, and /s holds the stdin bytes so that it stands in
+  # for `-`.
+  defp run(script, {first, second}, input, other) do
+    bash = JustBash.new(files: %{"/f" => other, "/s" => input})
+    JustBash.exec(bash, "printf #{inspect(input)} | " <> invocation(script, first, second))
+  end
+
+  # `comm FILE FILE` and `diff FILE FILE` already name two operands; every
+  # other row names one and gets a second appended.
+  defp invocation(script, first, second) do
+    case String.split(script, "FILE", parts: 3) do
+      [pre, post] -> pre <> first <> " " <> second <> post
+      [pre, mid, post] -> pre <> first <> mid <> second <> post
+    end
+  end
 end

--- a/test/commands/stdin_operand_test.exs
+++ b/test/commands/stdin_operand_test.exs
@@ -1,0 +1,192 @@
+defmodule JustBash.Commands.StdinOperandTest do
+  @moduledoc """
+  `-` as a file operand names stdin, and `/dev/null` reads as empty.
+
+  The #70 sweep taught the read paths to report the read they could not do.
+  That is only correct for operands that are really paths. Two classes of
+  operand are not:
+
+    * `-`, which POSIX and GNU read as standard input. `echo x | sort -` used
+      to exit 0 with nothing, which is the silent-success class #70 exists to
+      remove; the sweep turned it into `sort: cannot read: -` and a non-zero
+      exit, which is worse — a pipeline under `set -e` now dies.
+
+    * `/dev/null`, which the write side of redirection already special-cases
+      (`classify_redirection/3`) but the read side did not. `cmd < /dev/null`
+      is the standard way to close a command's stdin, and it started aborting
+      the command.
+
+  The `-` rows are checked against the same command reading a real file with
+  the same bytes, rather than against a literal transcript: the invariant is
+  that the operand names a source, not that `nl` pads to six columns.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.Commands.Registry
+
+  @stdin "b\na\nb\n"
+
+  # `jq` is the one row whose input has to be a JSON document rather than
+  # arbitrary lines, so it names its own.
+  @json "{\"k\":1}\n"
+
+  # Every command whose file operand GNU reads as stdin when it is `-`, with
+  # the rest of the invocation it needs to do anything. FILE is the operand
+  # under test; a row may carry the stdin it needs, and the name the command
+  # shows for that operand when it is not the literal `-`.
+  @dash_operand [
+    {"jq . FILE", @json, "-"},
+    {"file FILE", @stdin, "/dev/stdin"},
+    "cat FILE",
+    "tac FILE",
+    "head FILE",
+    "tail FILE",
+    "wc -l FILE",
+    "grep b FILE",
+    "sort FILE",
+    "uniq FILE",
+    "cut -c1 FILE",
+    "nl FILE",
+    "rev FILE",
+    "fold -w1 FILE",
+    "expand FILE",
+    "paste FILE",
+    "comm FILE FILE",
+    "base64 FILE",
+    "md5sum FILE",
+    "sha256sum FILE",
+    "shasum FILE",
+    "od -c FILE",
+    "xxd FILE",
+    "diff FILE FILE",
+    "sed -n p FILE",
+    "awk '{print}' FILE"
+  ]
+
+  # The rest of the registry. `-` is not stdin for these: either they take no
+  # file operand at all, or GNU treats `-` as an ordinary name (`tee -` writes
+  # a file called `-`; `rm -` removes one). Kept explicit so that a command
+  # added to the registry has to be classified rather than silently skipped.
+  @no_dash_operand ~w(
+    echo true : false pwd cd ls mkdir rm touch export unset test [ cp mv
+    printf basename dirname read seq tr date sleep exit tee env printenv
+    which ln readlink hostname stat du tree find xargs curl set source .
+    markdown md local declare typeset break continue shift return getopts
+    trap eval command uname chmod chown wget mktemp whoami id realpath
+    nproc arch yes type
+  )
+
+  @rows Enum.map(@dash_operand, fn
+          {script, input, shown} -> {script, input, shown}
+          script -> {script, @stdin, "-"}
+        end)
+
+  describe "the registry is fully classified" do
+    test "every command is either a `-`-reads-stdin command or explicitly not" do
+      named = Enum.map(@rows, fn {script, _, _} -> script |> String.split(" ") |> hd() end)
+      classified = MapSet.new(named ++ @no_dash_operand)
+
+      assert MapSet.new(Registry.list()) == classified
+    end
+  end
+
+  describe "`-` names stdin, not a path" do
+    for {script, input, shown} <- @rows do
+      test "#{script} reads stdin" do
+        {script, input, shown} = {unquote(script), unquote(input), unquote(shown)}
+        dash = String.replace(script, "FILE", "-")
+        file = String.replace(script, "FILE", "/f")
+
+        {piped, _bash} = JustBash.exec(sandbox(input), "printf #{inspect(input)} | " <> dash)
+        {from_file, _bash} = JustBash.exec(sandbox(input), file)
+
+        assert piped.stderr == ""
+        assert piped.exit_code == from_file.exit_code
+        assert piped.stdout == String.replace(from_file.stdout, "/f", shown)
+      end
+    end
+
+    # GNU does not agree with itself about what to call stdin in a per-operand
+    # label, so each of these is its own transcript.
+    test "grep labels the operand (standard input)" do
+      {result, _bash} = JustBash.exec(sandbox(), "printf 'b\\n' | grep b - /f")
+
+      assert result.stdout == "(standard input):b\n/f:b\n/f:b\n"
+      assert result.exit_code == 0
+    end
+
+    test "head labels the operand standard input" do
+      {result, _bash} = JustBash.exec(sandbox(), "printf 'z\\n' | head -1 - /f")
+
+      assert result.stdout =~ "==> standard input <==\nz\n"
+      assert result.stdout =~ "==> /f <==\nb\n"
+    end
+
+    test "wc labels the operand -" do
+      {result, _bash} = JustBash.exec(sandbox(), "printf 'z\\n' | wc -l - /f")
+
+      assert result.stdout == "      1 -\n      3 /f\n      4 total\n"
+    end
+
+    test "a pipeline into `sort -` under `set -e` survives" do
+      {result, _bash} = JustBash.exec(sandbox(), "set -e; printf 'b\\na\\n' | sort -; echo done")
+
+      assert result.stdout == "a\nb\ndone\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "a real path called -x is still a path" do
+      {result, _bash} = JustBash.exec(sandbox(), "sort -x")
+
+      assert result.stderr != ""
+      assert result.exit_code != 0
+    end
+  end
+
+  describe "`< /dev/null` closes stdin" do
+    test "cat reads nothing and exits 0" do
+      {result, _bash} = JustBash.exec(sandbox(), "cat < /dev/null; echo rc=$?")
+
+      assert result.stdout == "rc=0\n"
+      assert result.stderr == ""
+    end
+
+    test "read sees end of input and exits 1, with no diagnostic" do
+      {result, _bash} = JustBash.exec(sandbox(), "read x < /dev/null; echo rc=$?")
+
+      assert result.stdout == "rc=1\n"
+      assert result.stderr == ""
+    end
+
+    test "wc -l counts nothing" do
+      {result, _bash} = JustBash.exec(sandbox(), "wc -l < /dev/null")
+
+      assert result.stdout == "0\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "the read side agrees with the write side about which paths are special" do
+      # `> /dev/null` discards without touching the filesystem; `< /dev/null`
+      # has to be the same set of paths, or the two disagree about what a path
+      # even is.
+      {result, _bash} =
+        JustBash.exec(sandbox(), "echo hi > /dev/null; echo rc=$?; cat < /dev/null; echo rc=$?")
+
+      assert result.stdout == "rc=0\nrc=0\n"
+      assert result.stderr == ""
+    end
+
+    test "a path merely containing dev/null is still a path" do
+      {result, _bash} = JustBash.exec(sandbox(), "cat < /nope/dev/null")
+
+      assert result.stderr == "bash: /nope/dev/null: No such file or directory\n"
+      assert result.exit_code == 1
+    end
+  end
+
+  # /f holds exactly the bytes the pipeline feeds in, so `cmd -` and `cmd /f`
+  # differ only in where the command looked for them.
+  defp sandbox(content \\ @stdin), do: JustBash.new(files: %{"/f" => content})
+end

--- a/test/just_bash/spec_test_parser_test.exs
+++ b/test/just_bash/spec_test_parser_test.exs
@@ -17,6 +17,17 @@ defmodule JustBash.SpecTest.ParserTest do
     * `## STDERR` was never read, so the 65 cases carrying a stderr
       expectation asserted nothing about stderr.
 
+  Two more, found reviewing the first round of fixes:
+
+    * every `## OK bash …` / `## BUG bash …` / `## N-I bash …` annotation was
+      dropped as "another shell's expectation". It is the opposite: the
+      unannotated default records osh, and an annotation naming bash is
+      bash's own recorded behaviour. 440 such lines cover 323 of the 2728
+      cases, which were pinned to a shell we are not implementing.
+    * `## stdout:` with nothing after the colon — the format's spelling of
+      "one empty line" — was not recognised, so those cases asserted nothing
+      and passed whatever they printed.
+
   These run against the real corpus rather than hand-written fixtures — the
   parser's only job is to read those 136 files.
   """
@@ -200,10 +211,222 @@ defmodule JustBash.SpecTest.ParserTest do
     end
   end
 
+  describe "a shell annotation naming bash" do
+    test "a multiline STDOUT block overrides the unannotated expectation" do
+      # append.test.sh:134 records `## stdout-json: ""` / `## status: 2` for
+      # osh, then `## OK bash STDOUT:` -> `['1', '2 3']` with status 0. Bash is
+      # the oracle, so the annotation is the expectation.
+      case_ = fetch!("append.test.sh", "Try to append list to element")
+
+      assert case_.expected_stdout == "['1', '2 3']\n"
+      assert case_.expected_status == 0
+    end
+
+    test "overrides one key at a time, leaving the others at their default" do
+      # `## OK bash status: 0` is a single line with no stdout beside it, so
+      # the default `## stdout: hi` still stands.
+      case_ = fetch!("loop.test.sh", "bad arg to break")
+
+      assert case_.expected_stdout == "hi\n"
+      assert case_.expected_status == 128
+    end
+
+    test "just-bash wins over bash" do
+      # loop.test.sh:273 carries `## BUG bash STDOUT: a\n--` / status 0 and
+      # then this repo's own `## OK just-bash STDOUT: a` / status 1.
+      case_ = fetch!("loop.test.sh", "too many args to continue")
+
+      assert case_.expected_stdout == "a\n"
+      assert case_.expected_status == 1
+    end
+
+    test "just-bash wins over bash for a multiline block" do
+      case_ = fetch!("var-op-bash.test.sh", "Array expansion with nullary var op @Q")
+
+      # `## OK bash STDOUT:` records the associative array reversed; the
+      # `## OK just-bash STDOUT:` below it records our insertion order.
+      assert case_.expected_stdout =~ ~s(["'hello'", "'world'", "'osh'", "'ysh'"])
+      refute case_.expected_stdout =~ ~s(["'ysh'", "'osh'")
+    end
+
+    test "an annotation naming another shell is still dropped" do
+      [case_] =
+        Parser.parse("""
+        #### annotated
+        echo hi
+        ## stdout: hi
+        ## status: 0
+        ## OK dash stdout: bye
+        ## OK dash status: 3
+        """)
+
+      assert case_.expected_stdout == "hi\n"
+      assert case_.expected_status == 0
+    end
+
+    test "bash-2 is a different shell from bash" do
+      # assign-extended.test.sh carries both `## OK bash STDOUT:` and
+      # `## OK bash-2 STDOUT:`; bash-2 is bash 2.x, not our oracle.
+      case_ = fetch!("assign-extended.test.sh", "declare -p arr")
+
+      assert case_.expected_stdout =~ "declare -A test_arr6=([a]=\"1\" [b]=\"2\" [c]=\"3\" )"
+    end
+
+    test "a non-bash multiline annotation body still does not leak into the script" do
+      [case_] =
+        Parser.parse("""
+        #### annotated
+        echo hi
+        ## STDOUT:
+        hi
+        ## END
+        ## OK dash STDOUT:
+        not shell
+        ## END
+        """)
+
+      assert case_.script == "echo hi"
+      assert case_.expected_stdout == "hi\n"
+    end
+
+    test "every bash-keyed status annotation in the corpus is the case's status" do
+      annotated = bash_status_annotations()
+
+      # An independent read of the same 136 files: 124 cases spell bash's exit
+      # status as an annotation, and every one of them must survive parsing.
+      assert map_size(annotated) == 124
+
+      mismatched =
+        for {{file, name}, status} <- annotated,
+            case_ = fetch!(file, name),
+            case_.expected_status != status,
+            do: {file, name, case_.expected_status, status}
+
+      assert mismatched == []
+    end
+
+    test "the corpus's 440 bash-keyed annotations cover 323 cases in 89 files" do
+      by_case = bash_annotation_lines()
+
+      assert by_case |> Map.values() |> List.flatten() |> length() == 440
+      assert map_size(by_case) == 323
+      assert by_case |> Map.keys() |> Enum.map(&elem(&1, 0)) |> Enum.uniq() |> length() == 89
+    end
+  end
+
+  describe "a bare directive value" do
+    # `## stdout:` with nothing after the colon is how the format spells an
+    # expected single empty line — `echo $unset` prints one.
+    for {file, name} <- [
+          {"sh-func.test.sh", "Locals don't leak"},
+          {"var-op-strip.test.sh", "Remove const suffix from undefined"},
+          {"redirect-command.test.sh", "Redirect in command sub"},
+          {"assign.test.sh", "Empty env binding"}
+        ] do
+      test "#{file} #{inspect(name)} expects one empty line, not nothing" do
+        case_ = fetch!(unquote(file), unquote(name))
+
+        assert case_.expected_stdout == "\n"
+      end
+    end
+
+    test "a bare ## stderr: is read the same way" do
+      [case_] =
+        Parser.parse("""
+        #### bare stderr
+        echo x >&2
+        ## stderr:
+        """)
+
+      assert case_.expected_stderr == "\n"
+    end
+
+    test "Runner fails a case whose bare stdout expectation diverges" do
+      # Before the bare spelling was recognised, expected_stdout stayed nil and
+      # `check_output(nil, _)` passed the case whatever it printed.
+      [case_] =
+        Parser.parse("""
+        #### leaks
+        echo leaked
+        ## stdout:
+        """)
+
+      refute Runner.run_test_case(case_, []).passed
+    end
+  end
+
   describe "the whole corpus" do
     test "parses into 2728 cases across 136 files" do
       assert length(Path.wildcard(Path.join(@cases_dir, "*.test.sh"))) == 136
       assert length(all_cases()) == 2728
     end
+
+    test "2562 cases carry a stdout expectation and only 59 assert nothing" do
+      # These counts are the corpus-wide guard on every directive spelling the
+      # parser claims to read: drop one and they move. A case that asserts
+      # nothing at all passes vacuously, so the second number is the one that
+      # decides whether a ratchet built on this parser means anything.
+      cases = all_cases()
+
+      assert Enum.count(cases, & &1.expected_stdout) == 2562
+      assert Enum.count(cases, &(&1.expected_status != 0)) == 239
+      assert Enum.count(cases, &asserts_nothing?/1) == 59
+    end
+  end
+
+  defp asserts_nothing?(case_) do
+    is_nil(case_.expected_stdout) and is_nil(case_.expected_stderr) and
+      case_.expected_status == 0 and is_nil(case_.skip_reason)
+  end
+
+  # An independent reader of the corpus, deliberately not sharing code with the
+  # parser: split each file on its `#### ` headers and keep the annotation lines
+  # whose shell list names bash or just-bash.
+  @annotation ~r{^## (?:OK|BUG|N-I)(?:-\d+)?\s+(\S+)\s+(.*)$}
+
+  defp bash_annotation_lines do
+    for {file, name, body} <- raw_cases(),
+        lines = Enum.filter(body, &bash_keyed?/1),
+        lines != [],
+        into: %{},
+        do: {{file, name}, lines}
+  end
+
+  defp bash_status_annotations do
+    for {key, lines} <- bash_annotation_lines(),
+        statuses = Enum.flat_map(lines, &annotated_status/1),
+        statuses != [],
+        into: %{},
+        do: {key, List.last(statuses)}
+  end
+
+  defp annotated_status(line) do
+    case Regex.run(~r{^## (?:OK|BUG|N-I)(?:-\d+)?\s+\S+\s+status:\s*(\d+)\s*$}, line) do
+      [_line, status] -> [String.to_integer(status)]
+      nil -> []
+    end
+  end
+
+  defp bash_keyed?(line) do
+    case Regex.run(@annotation, line) do
+      [_line, shells, _keyed] -> Enum.any?(String.split(shells, "/"), &(&1 in ~w(bash just-bash)))
+      nil -> false
+    end
+  end
+
+  defp raw_cases do
+    Enum.flat_map(Path.wildcard(Path.join(@cases_dir, "*.test.sh")), fn path ->
+      file = Path.basename(path)
+
+      path
+      |> File.read!()
+      |> String.split("\n")
+      |> Enum.reduce([], fn
+        "#### " <> name, acc -> [{file, name, []} | acc]
+        _line, [] -> []
+        line, [{f, n, body} | rest] -> [{f, n, [line | body]} | rest]
+      end)
+      |> Enum.map(fn {f, n, body} -> {f, n, Enum.reverse(body)} end)
+    end)
   end
 end

--- a/test/just_bash/spec_test_parser_test.exs
+++ b/test/just_bash/spec_test_parser_test.exs
@@ -1,0 +1,209 @@
+defmodule JustBash.SpecTest.ParserTest do
+  @moduledoc """
+  #70 item 7 calls `lib/just_bash/spec_test/parser.ex` untrustworthy and lists
+  four defects. Nothing calls the parser, so nothing caught them:
+
+    * `:skip` was never assigned, so `Runner`'s skip guard was dead code and
+      all 247 SKIP-marked cases ran. Worse, Oils writes `## SKIP` *above* the
+      script, and the parser stopped collecting the script at the first `##`
+      line — so a SKIP-marked case ran with an empty script and "passed"
+      whatever it was asked.
+    * `String.trim_leading(line, "#### ")` strips the prefix *repeatedly*, so
+      a name that itself begins with the header prefix loses part of itself.
+    * `String.trim(script)` trimmed whitespace *characters*, so it silently
+      rewrote the last command of every case whose script ends in a space —
+      11 of them — while the format only means to drop the blank lines that
+      frame a case.
+    * `## STDERR` was never read, so the 65 cases carrying a stderr
+      expectation asserted nothing about stderr.
+
+  These run against the real corpus rather than hand-written fixtures — the
+  parser's only job is to read those 136 files.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.SpecTest.Parser
+  alias JustBash.SpecTest.Parser.TestCase
+  alias JustBash.SpecTest.Runner
+
+  @cases_dir "test/command_spec_cases/bash/cases"
+
+  defp parse!(file) do
+    assert {:ok, cases} = Parser.parse_file(Path.join(@cases_dir, file))
+    cases
+  end
+
+  defp fetch!(file, name) do
+    cases = parse!(file)
+
+    case Enum.find(cases, &(&1.name == name)) do
+      nil -> flunk("no case named #{inspect(name)} in #{file}")
+      %TestCase{} = test_case -> test_case
+    end
+  end
+
+  defp all_cases do
+    Enum.flat_map(Path.wildcard(Path.join(@cases_dir, "*.test.sh")), fn path ->
+      assert {:ok, cases} = Parser.parse_file(path)
+      cases
+    end)
+  end
+
+  describe "## SKIP" do
+    test "the marker sets skip_reason" do
+      case_ = fetch!("command-sub.test.sh", "Command Sub trailing newline removed")
+
+      assert case_.skip_reason == "python2 not available"
+    end
+
+    test "a marker above the script does not swallow the script" do
+      case_ = fetch!("command-sub.test.sh", "Command Sub trailing newline removed")
+
+      assert case_.script == ~s|s=$(python2 -c 'print("ab\\ncd\\n")')\nargv.py "$s"|
+    end
+
+    test "every SKIP marker in the corpus produces a skip_reason" do
+      markers =
+        @cases_dir
+        |> Path.join("*.test.sh")
+        |> Path.wildcard()
+        |> Enum.flat_map(&(&1 |> File.read!() |> String.split("\n")))
+        |> Enum.count(&String.starts_with?(&1, "## SKIP"))
+
+      assert markers == 247
+      assert Enum.count(all_cases(), & &1.skip_reason) == markers
+    end
+
+    test "Runner does not execute a skipped case" do
+      [case_] =
+        Parser.parse("""
+        #### skipped
+        ## SKIP (unimplementable): no reason to run this
+        echo ran
+        ## stdout: ran
+        """)
+
+      assert %Runner.Result{skipped: true, actual_stdout: nil} = Runner.run_test_case(case_, [])
+    end
+
+    test "a skipped case is neither a pass nor a failure in the summary" do
+      cases =
+        Parser.parse("""
+        #### skipped
+        ## SKIP (unimplementable): no reason to run this
+        echo ran
+        ## stdout: ran
+
+        #### runs
+        echo ran
+        ## stdout: ran
+        """)
+
+      summary = cases |> Runner.run_test_cases() |> Runner.summary()
+
+      assert %{total: 1, passed: 1, failed: 0, skipped: 1, pass_rate: 100.0} = summary
+    end
+  end
+
+  describe "the script" do
+    test "keeps interior blank lines, which $LINENO counts" do
+      case_ = fetch!("builtin-trap-err.test.sh", "trap can use original $LINENO")
+
+      # The blank line framing the case goes; the one inside it stays, which
+      # is what puts the two `false` commands on the lines the recorded
+      # expectation names.
+      assert case_.script == "trap 'echo line=$LINENO' ERR\n\nfalse\nfalse\necho ok"
+      assert case_.expected_stdout == "line=3\nline=4\nok\n"
+
+      lines = String.split(case_.script, "\n")
+      assert Enum.at(lines, 3 - 1) == "false"
+      assert Enum.at(lines, 4 - 1) == "false"
+    end
+
+    test "keeps trailing spaces on the last line" do
+      case_ = fetch!("shell-grammar.test.sh", "a && b ")
+
+      assert case_.script == "echo word_a && echo word_b "
+    end
+
+    test "String.trim/1 would rewrite the last command of 11 corpus cases" do
+      rewritten = Enum.count(all_cases(), &(String.trim(&1.script) != &1.script))
+
+      assert rewritten == 11
+    end
+
+    test "never contains a directive line" do
+      offenders =
+        Enum.filter(all_cases(), fn case_ ->
+          case_.script
+          |> String.split("\n")
+          |> Enum.any?(&String.starts_with?(&1, "## "))
+        end)
+
+      assert offenders == []
+    end
+
+    test "a multiline block for another shell does not leak into it" do
+      case_ = fetch!("redirect.test.sh", "Parsing of x={myvar} and related cases")
+
+      # The case is followed by `## BUG mksh/ash STDOUT:` and `## N-I dash
+      # STDOUT:` blocks whose bodies are lines of expected output, not shell.
+      refute case_.script =~ "x={myvar}\n0\nx={myvar}"
+      assert String.ends_with?(case_.script, "echo $((myvar-starting_fd))")
+    end
+  end
+
+  describe "## STDERR" do
+    test "a multiline block is read" do
+      case_ = fetch!("array-literal.test.sh", "non-index forms of element (BashAssoc)")
+
+      assert case_.expected_stderr ==
+               "bash: line 2: a: 2: must use subscript when assigning associative array\n" <>
+                 "bash: line 2: a: 3: must use subscript when assigning associative array\n" <>
+                 "bash: line 2: a: 4: must use subscript when assigning associative array\n"
+    end
+
+    test "a case may assert on stderr alone" do
+      case_ = fetch!("redirect.test.sh", ">& and <& are the same")
+
+      assert case_.expected_stderr == "one\ntwo\n"
+      assert case_.expected_stdout == nil
+    end
+
+    test "the corpus's 65 stderr expectations are all read" do
+      assert Enum.count(all_cases(), & &1.expected_stderr) == 65
+    end
+
+    test "Runner fails a case whose stderr diverges" do
+      [case_] =
+        Parser.parse("""
+        #### stderr
+        echo out
+        ## STDOUT:
+        out
+        ## END
+        ## STDERR:
+        expected
+        ## END
+        """)
+
+      refute Runner.run_test_case(case_, []).passed
+    end
+  end
+
+  describe "the case header" do
+    test "strips the prefix once, not repeatedly" do
+      # No corpus case is spelled this way today, which is why the repeated
+      # strip went unnoticed; `String.trim_leading/2` removes every leading
+      # occurrence of its argument, not just the first.
+      assert [%TestCase{name: "#### nested"}] = Parser.parse("#### #### nested\ntrue\n")
+    end
+  end
+
+  describe "the whole corpus" do
+    test "parses into 2728 cases across 136 files" do
+      assert length(Path.wildcard(Path.join(@cases_dir, "*.test.sh"))) == 136
+      assert length(all_cases()) == 2728
+    end
+  end
+end

--- a/test/support/failing_backend.ex
+++ b/test/support/failing_backend.ex
@@ -1,0 +1,27 @@
+# A mountable backend where every operation fails with one configured error
+# kind. The in-memory backend cannot produce :eacces, :erofs or :eio — it has
+# no permission model and no device to fail — so this is the only way to reach
+# those kinds from a shell command and check the message it renders.
+defmodule JustBash.Test.FailingBackend do
+  @moduledoc false
+  @enforce_keys [:kind]
+  defstruct [:kind]
+
+  @type t :: %__MODULE__{kind: atom()}
+end
+
+defimpl VFS.Mountable, for: JustBash.Test.FailingBackend do
+  use VFS.Skeleton
+
+  alias VFS.Error
+
+  def exists?(b, _path), do: {false, b}
+  def stat(b, path), do: {:error, Error.new(b.kind, path: path)}
+  def readdir(b, path), do: {:error, Error.new(b.kind, path: path)}
+  def stream_read(b, path, _opts), do: {:error, Error.new(b.kind, path: path)}
+  def write_file(b, path, _content, _opts), do: {:error, Error.new(b.kind, path: path)}
+  def mkdir(b, path, _opts), do: {:error, Error.new(b.kind, path: path)}
+  def rm(b, path, _opts), do: {:error, Error.new(b.kind, path: path)}
+
+  def capabilities(_), do: MapSet.new([:read, :write])
+end


### PR DESCRIPTION
Two independent pieces of the #70 roadmap. They touch disjoint files, so a
reviewer who wants them split can take either alone:

- `e42a3fd`, `6bf6b73`, `7eb7275`, `b15512a`, `63feb0b`, `82b54f1`, `6eaee65`,
  `da8250a`, `7e100b2`, `8c1fb52` — item 1's first bullet: the `FS.strerror/1`
  sweep, plus the commands the sweep's grep could not reach because they printed
  *nothing*
- `f863343`, `f522af8` — item 7's prerequisite: the Oils spec parser

Nothing else from the roadmap is here. No Docker oracle, no alphabet matrices,
no filesystem-shape matrix, and the spec suite is **not** activated in CI.

Review round two is folded in — six per-site conformance fixes, the coverage
hole in the matrix, and the parser's handling of bash-keyed annotations. The
finding-by-finding reply is
[here](https://github.com/elixir-ai-tools/just_bash/pull/74#issuecomment-5204908627).

Rebased onto `main` at `9aab27a`. #72 landed the `sort` half of this branch's
silent-read fix independently — `sort: cannot read:` / `sort: read failed:` and
the `strerror` behind them are main's now, not this branch's, and the claims
below have been trimmed to match. `sort.ex` here contributes only the `-`
operand.

---

## Piece A — the `strerror` sweep

### What was broken

33 command modules matched `{:error, _}`, threw the error kind away, and
spelled every filesystem failure `No such file or directory`. Only 13 called
`FS.strerror/1`. `stat.ex:50` was the representative case in the issue:

```elixir
defp accumulate_stat_result({:error, _}, file, _format, {acc_out, acc_err, _acc_has_err, fs}) do
  err = "stat: cannot stat '#{file}': No such file or directory\n"
```

Repro, with `/f` a regular file so `/f/x` is `ENOTDIR`:

```
$ stat /f/x
stat: cannot stat '/f/x': No such file or directory     # exists, wrong kind
$ wc /d                                                 # /d is a directory
wc: /d: No such file or directory                       # should be: Is a directory
$ cat /mnt/f                                            # unreadable mount
cat: /mnt/f: No such file or directory                  # should be: Permission denied
```

GNU coreutils prints the kind, not a guess. This is the issue's stated
prerequisite for the rest of the roadmap: it is estimated at 40–60% of all
divergences an enumerated matrix would report, and it is the same diff a
thousand times.

### The fix

Every one of them now renders `FS.strerror/1` on the error it was already
handed. The message template is untouched wherever GNU uses one template for
every kind, so the diff is one line per site. Two incidental cleanups fall out:
`rm`'s `:enoent` clause became identical to the general clause below it and is
gone, and `source`'s catch-all no longer says `cannot read` for every kind it
did not enumerate.

`JustBash.exec_file/2` in `lib/just_bash.ex` had the same defect and is fixed
with them — it is outside `commands/`, so it is the one site the issue's grep
did not name.

Where GNU does *not* use one template for every kind, the template branches:
`head`, `tail`, `tac` and `uniq` `open(2)` a directory successfully and only
fail at `read(2)`, so EISDIR gets its own wording.

```
ghead d   -> ghead: error reading 'd': Is a directory
gtac d    -> gtac: d: read error: Is a directory
gtac nope -> gtac: failed to open 'nope' for reading: No such file or directory
guniq d   -> guniq: error reading 'd': Is a directory
```

Those four branches render `FS.strerror/1` like every other site rather than
restating `Is a directory` in a literal, so a kind's spelling has exactly one
definition (`8c1fb52`, output-identical).

Two more per-site fixes: `file -b` names the reason instead of returning a bare
`cannot open`, and `realpath` without `-e` canonicalises a missing final
component and exits 0 the way GNU does — `-e` and `-m` were being parsed and
discarded, and all three modes are real now.

### The other half of the family: the commands that printed *nothing*

Grepping for the literal `"No such file or directory"` reaches every module
that printed a *wrong* message and none that printed no message at all. Those
are the worse members of the family, and every one is on #70 item 3's operand
list:

```
cut -f1 /nope rc=0 silent  ->  rc=1 cut: /nope: ...
uniq /nope    rc=0 silent  ->  rc=1 uniq: /nope: ...
uniq /d       rc=0 silent  ->  rc=1 uniq: error reading '/d': Is a directory
grep x /nope  rc=1 silent  ->  rc=2 grep: /nope: ...
cat < /nope   rc=0 silent  ->  rc=1 bash: /nope: ...
wc -l < /nope rc=0 and "0" ->  rc=1 bash: /nope: ..., no stdout
```

An agent writing `uniq report.txt | head -5` against a mistyped path got a
clean exit-0 empty result with nothing to distinguish it from an empty file.
`wc -l < /nope` printing a fabricated `0` is the sharpest one, because the
number looks like an answer.

`grep` keeps GNU's rule that `-q` with a line selected exits 0 even after an
error, and `cut` keeps the files it could read. `<` is the read side of
`025673c`: the shell opens the target, so the shell reports the failure and the
command never runs. EISDIR is deliberately excluded there — `open(2)` on a
directory succeeds, so bash runs the command and the *command's* own read fails
(`cat: stdin: Is a directory`), which is not a shell-level diagnostic and has
no seam here.

`md5sum` was writing its diagnostic to **stdout**, between checksum lines, so
`md5sum a b > sums.txt` wrote a malformed checksum line into the file and
`2>/dev/null` did not silence it; it writes to stderr now, and `md5sum -c` on
an unreadable checksum file reports instead of exiting 0. `file` writing to
stdout is *correct* — real `file(1)` does the same.

Teaching these paths to report turned two operands that are not paths from
harmless into hard errors: `echo x | sort -` and `cat < /dev/null` were being
resolved as filenames, and now had a failure to announce. `Commands.StdinOperand`
gives the read paths POSIX's reading of `-` — standard input, in any operand
position, so `cat - /f` and `cat /f -` both work — and `/dev/null`, previously
special-cased only on the write side, now shares one `@null_device` across both
directions, so `> /dev/null` discarding and `< /dev/null` reading empty agree.
Driving the audit off the registry rather than by hand reached nineteen more
commands with the same gap, ten of which had been rejecting a bare `-` as an
invalid option — which POSIX says it never is.

### The tests

`test/commands/error_message_test.exs` is the cross product of the
filesystem-touching commands and the kinds a path can fail with — 188 cases
generated from a table, not written one at a time. Each row is the invocation,
the kinds it covers, the stream the diagnostic belongs on, and its template,
with `PATH` and `MSG` filled per kind:

```elixir
{"head PATH", @stat_kinds, :stderr, "head: cannot open 'PATH' for reading: MSG\n"},
{"head PATH", [:eisdir], :stderr, "head: error reading 'PATH': MSG\n"},
```

Reading file *contents* can hit all four of
`:enoent`/`:enotdir`/`:eisdir`/`:eacces`; a command that only inspects metadata
is crossed with three, because a directory is a perfectly good answer for
`stat`, `find`, `du` and friends. A row carries its own kind list rather than
sitting in a "content reader" or "metadata reader" bucket, which is what lets
one command have two templates.

Operand arity is part of the cross product too. `head`, `tail` and `wc` each
have a single-file arm and a reduce over several files, and `sha256sum` and
`shasum` have a third arm behind `-c`; with every row pinned to one operand,
seven of the sites this sweep exists to fix could be reverted with the suite
still green — proven by mutation: replacing the rendered strerror with a
literal at `head.ex:58`, `tail.ex:58`, `wc.ex:63`, `sha256sum.ex:72`,
`sha256sum.ex:113`, `shasum.ex:86` and `shasum.ex:120` left **5248 tests, 0
failures**. Rows naming two operands, `-c FILE`, and a checksum file that
*lists* an unreadable target reach them — the same mutation now turns **28
tests red**.

`:eacces` is unreachable from the in-memory backend — it has no permission
model, and `chmod 000` is ignored on read. `test/support/failing_backend.ex`
is a `VFS.Mountable` whose every operation fails with one configured kind,
mounted at `/mnt`. That is also the only route to `:erofs`/`:eio`/`:enotsup`
when the roadmap gets to them.

**147 of the 204 fail on `main`:**

```
     left:  "wc: /f/x: No such file or directory\n"
     right: "wc: /f/x: Not a directory\n"
     left:  "wc: /mnt/f: No such file or directory\n"
     right: "wc: /mnt/f: Permission denied\n"
     left:  "head: cannot open '/d' for reading: No such file or directory\n"
     right: "head: error reading '/d': Is a directory\n"
     left:  "tail: cannot open '/f/x' for reading: No such file or directory\n"
     right: "tail: cannot open '/f/x' for reading: Not a directory\n"

204 tests, 147 failures
```

---

## Piece B — `lib/just_bash/spec_test/parser.ex`

### What was broken

Nothing calls the parser, so nothing caught any of it.

#### The four the issue lists

1. **`:skip` is never assigned.** `runner.ex:48`'s guard was dead code.
   Compounding it, Oils writes `## SKIP` *above* the script and
   `collect_script/2` stopped at the first `##` line — so a SKIP-marked case
   was parsed with an **empty script** and passed vacuously. All 247 of them:

   ```
   #### Command Sub trailing newline removed
   ## SKIP (unimplementable): python2 not available
   s=$(python2 -c 'print("ab\ncd\n")')
   argv.py "$s"
   ## stdout: ['ab\ncd']
   ```
   parsed as `script: "", skip_reason: nil`.

2. **`String.trim_leading(line, "#### ")`** removes *every* leading occurrence
   of its argument, not one. `#### #### nested` yields `nested`, not
   `#### nested`. No corpus case is spelled that way today, which is why it
   went unnoticed — so this one defect is tested on synthetic input while the
   others are tested on real files.

3. **`String.trim(script)`** trims whitespace *characters*. The format means
   to drop the blank lines that frame a case; trimming characters also rewrites
   the last command of every case whose script ends in a space.

   The corpus pins down the correct rule. `builtin-trap-err.test.sh`:

   ```
   #### trap can use original $LINENO

   trap 'echo line=$LINENO' ERR

   false
   false
   echo ok
   ## STDOUT:
   line=3
   line=4
   ```

   `line=3` only holds if the leading blank line is dropped and the interior
   one is kept. So the parser now trims at line granularity: whole blank lines
   at either end go, everything between the first and last non-blank line is
   preserved byte for byte.

4. **`## STDERR` is never read.** 65 of the 2728 cases carry a stderr
   expectation, and stderr is where the silently-ignored-flag class lives.

#### Two more, from review

5. **Every `## OK bash …` / `## BUG bash …` / `## N-I bash …` annotation was
   dropped** as "another shell's expectation". It is the opposite: the
   unannotated default records osh, and an annotation naming a shell is what
   *that shell* actually does. `append.test.sh` "Try to append list to
   element" records `## stdout-json: ""` / `## status: 2` and then
   `## OK bash status: 0` with `## OK bash STDOUT:` → `['1', '2 3']`; the
   parser produced the osh expectation, so a JustBash that reproduced bash
   exactly would have been scored a failure. **440 such lines cover 323 of the
   2728 cases across 89 files** — including two `## OK just-bash` markers
   written by this repo.

6. **A bare `## stdout:`** — the format's spelling of one expected empty line —
   was not recognised, because the clause required the separating space. Four
   cases parsed to `expected_stdout: nil`, and `Runner.check_output(nil, _)`
   passes a case whatever it printed. `sh-func.test.sh` "Locals don't leak"
   would have been scored `passed` if the local *had* leaked.

### The fix

A case body is now sorted line by line into script or directive, in either
order, rather than assuming directives only follow the script. A multiline
block keyed to another shell (`## N-I dash STDOUT:` … `## END`) is consumed
along with its body, so lines of *expected output* no longer fall through into
the script. `TestCase` gains `expected_stderr`; `Runner` reports a skipped case
as skipped instead of as an error, keeps skips out of the pass rate, and
compares stderr when the case names one.

Annotations are parsed into `{qualifier, shells, key: value}` and applied **per
key**, weakest first: unannotated default → `bash` → `just-bash`. The format
overrides one key at a time, which is why `append.test.sh` keeps its default
`stdout-json` until `## OK bash STDOUT:` replaces it while `## OK bash
status: 0` replaces the status on its own line. `bash-2` is bash 2.x and stays
foreign.

### The tests

`test/just_bash/spec_test_parser_test.exs`, against the real files in
`test/command_spec_cases/bash/cases/`. The corpus-wide counts independently
reproduce three numbers the issue states from the other side — 2728 cases,
247 SKIP markers, 65 stderr expectations:

```elixir
assert markers == 247
assert Enum.count(all_cases(), & &1.skip_reason) == markers
assert Enum.count(all_cases(), & &1.expected_stderr) == 65
assert length(all_cases()) == 2728
```

Those four are blind to a directive spelling the parser silently stops
recognising, so three more are pinned — **2562** cases with a stdout
expectation, **239** with a non-zero status, and only **59** that assert
nothing at all — and an independent reader re-derives the annotations straight
from the files without going through the parser: 440 bash-keyed lines, 323
cases, 89 files, and every one of the 124 cases carrying a bash-keyed
`status: N` must parse to that status.

Plus: no script contains a `## ` line; the `$LINENO` case above parses to the
script its expectation assumes; `Runner` does not execute a skipped case and
does not count it as a failure.

**25 of the 32 fail with the old parser** (`parser.ex` alone reverted to
main's):

```
  5) test a bare directive value assign.test.sh "Empty env binding" expects one empty line, not nothing
  9) test the script String.trim/1 would rewrite the last command of 11 corpus cases
 13) test ## STDERR a case may assert on stderr alone
 17) test a shell annotation naming bash just-bash wins over bash
 20) test a shell annotation naming bash every bash-keyed status annotation in the corpus is the case's status
 25) test ## SKIP Runner does not execute a skipped case

32 tests, 25 failures
```

The suite is still inert. Activating it — the curated subset, the re-recording
and the ratchet — is the rest of item 7.

---

## Gates

Run on the rebased branch.

```
$ mix compile --warnings-as-errors --force
Compiling 169 files (.ex)
Generated just_bash app

$ mix format --check-formatted

$ mix credo --strict
  Refactoring opportunities
| [F] Avoid `apply/2` and `apply/3` when the number of arguments is known.
|     test/support/banned_fixture_apply.ex:4:16 #(BannedCallTracer.Fixture.Apply.run)

Analysis took 1.9 seconds (0.1s to load, 1.8s running 68 checks on 237 files)
5393 mods/funs, found 1 refactoring opportunity.

$ mix test
Finished in 27.1 seconds (26.8s async, 0.3s sync)
2 doctests, 62 properties, 5313 tests, 0 failures (5 excluded)

$ mix dialyzer
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done (passed successfully)
```

The one credo finding is the pre-existing intentional test fixture, and the 13
dialyzer errors are the pre-existing entries in `.dialyzer_ignore.exs`. 5012
tests on `main`, 5313 here: +301.

Refs #70 (items 1 and the item-7 parser prerequisite; the rest of the roadmap stays open)
