### PR TITLE
fix: a trailing slash on a destination requires a directory instead of overwriting the file it names

### DIFF
--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -148,7 +148,18 @@ defmodule JustBash.Commands.Cp do
   # not what bash does with it.
   defp dest_kind(bash, ""), do: {:error, VFS.Error.new(:enoent, path: ""), bash}
 
+  # A destination is only a directory the copy may land inside once its
+  # spelling holds: `f/..` resolves to a directory but names nothing when `f`
+  # is a regular file, so it goes to `copy_one/4` as spelled and is reported
+  # there rather than gaining the source's basename.
   defp dest_kind(bash, dest) do
+    case FS.check_directory_spelling(bash.fs, bash.cwd, dest) do
+      {:ok, fs} -> stat_dest(%{bash | fs: fs}, dest)
+      {:error, %VFS.Error{} = error} -> {:error, error, bash}
+    end
+  end
+
+  defp stat_dest(bash, dest) do
     case FS.stat(bash.fs, FS.resolve_path(bash.cwd, dest)) do
       {:ok, %VFS.Stat{type: :directory}, fs} -> {:ok, :directory, %{bash | fs: fs}}
       {:ok, %VFS.Stat{}, fs} -> {:ok, :other, %{bash | fs: fs}}
@@ -194,8 +205,8 @@ defmodule JustBash.Commands.Cp do
 
   # A destination spelled as a directory that is not one names nothing to leave
   # alone, so `-n` does not get to keep it: the copy goes on to report it.
-  defp keep_or_copy(bash, src, {dest, dest_path} = dest_pair, %Options{clobber: :never} = opts) do
-    case FS.check_directory_spelling(bash.fs, dest, dest_path) do
+  defp keep_or_copy(bash, src, {dest, _dest_path} = dest_pair, %Options{clobber: :never} = opts) do
+    case FS.check_directory_spelling(bash.fs, bash.cwd, dest) do
       {:ok, fs} -> keep_or_clobber(%{bash | fs: fs}, src, dest_pair, opts)
       {:error, %VFS.Error{}} -> copy_resolved(bash, src, dest_pair, opts)
     end
@@ -236,7 +247,7 @@ defmodule JustBash.Commands.Cp do
   #     $ cp a.md f/     cp: cannot stat 'f/': Not a directory
   #     $ cp a.md nope/  cp: cannot create regular file 'nope/': No such file …
   defp copy_file(bash, {src, src_path}, {dest, dest_path}, opts) do
-    case FS.check_directory_spelling(bash.fs, dest, dest_path) do
+    case FS.check_directory_spelling(bash.fs, bash.cwd, dest) do
       {:ok, fs} ->
         fs
         |> FS.cp(src_path, dest_path)
@@ -297,8 +308,8 @@ defmodule JustBash.Commands.Cp do
   # A recursive copy creates the directory a trailing slash promises, so
   # `cp -r d nope/` is fine and only a destination that is already something
   # else is refused — which bash words as a failed stat of the operand.
-  defp copy_dir(bash, src, {dest, dest_path} = dest_pair, %Options{mode: :recursive} = opts) do
-    case FS.check_directory_spelling(bash.fs, dest, dest_path) do
+  defp copy_dir(bash, src, {dest, _dest_path} = dest_pair, %Options{mode: :recursive} = opts) do
+    case FS.check_directory_spelling(bash.fs, bash.cwd, dest) do
       {:ok, fs} ->
         copy_tree(%{bash | fs: fs}, src, dest_pair, opts)
 

--- a/lib/just_bash/commands/cp.ex
+++ b/lib/just_bash/commands/cp.ex
@@ -179,23 +179,38 @@ defmodule JustBash.Commands.Cp do
     src_path = FS.resolve_path(bash.cwd, src)
     dest_path = FS.resolve_path(bash.cwd, dest)
 
-    if src_path == dest_path do
+    if self_copy?(src_path, dest, dest_path) do
       {Command.error("cp: '#{src}' and '#{dest}' are the same file\n"), bash}
     else
       keep_or_copy(bash, {src, src_path}, {dest, dest_path}, opts)
     end
   end
 
-  # `-n` leaves an existing destination alone, and says nothing about it.
-  defp keep_or_copy(bash, src, {_dest, dest_path} = dest, %Options{clobber: :never} = opts) do
-    case FS.exists?(bash.fs, dest_path) do
-      {true, fs} -> {Command.ok(), %{bash | fs: fs}}
-      {false, fs} -> copy_resolved(%{bash | fs: fs}, src, dest, opts)
+  # `a.md/` names no file at all when `a.md` is a regular file, so it is not a
+  # second spelling of the source: the copy goes on to fail on the destination
+  # instead, as bash does.
+  defp self_copy?(src_path, dest, dest_path),
+    do: src_path == dest_path and not FS.directory_spelling?(dest)
+
+  # A destination spelled as a directory that is not one names nothing to leave
+  # alone, so `-n` does not get to keep it: the copy goes on to report it.
+  defp keep_or_copy(bash, src, {dest, dest_path} = dest_pair, %Options{clobber: :never} = opts) do
+    case FS.check_directory_spelling(bash.fs, dest, dest_path) do
+      {:ok, fs} -> keep_or_clobber(%{bash | fs: fs}, src, dest_pair, opts)
+      {:error, %VFS.Error{}} -> copy_resolved(bash, src, dest_pair, opts)
     end
   end
 
   defp keep_or_copy(bash, src, dest, %Options{clobber: :always} = opts),
     do: copy_resolved(bash, src, dest, opts)
+
+  # `-n` leaves an existing destination alone, and says nothing about it.
+  defp keep_or_clobber(bash, src, {_dest, dest_path} = dest, opts) do
+    case FS.exists?(bash.fs, dest_path) do
+      {true, fs} -> {Command.ok(), %{bash | fs: fs}}
+      {false, fs} -> copy_resolved(%{bash | fs: fs}, src, dest, opts)
+    end
+  end
 
   defp copy_resolved(bash, {src, src_path}, {dest, dest_path}, opts) do
     case FS.lstat(bash.fs, src_path) do
@@ -206,21 +221,38 @@ defmodule JustBash.Commands.Cp do
         copy_link(%{bash | fs: fs}, {src, src_path}, {dest, dest_path}, opts)
 
       {:ok, %VFS.Stat{}, fs} ->
-        fs
-        |> FS.cp(src_path, dest_path)
-        |> file_result(%{bash | fs: fs}, {src, src_path}, dest, opts)
+        copy_file(%{bash | fs: fs}, {src, src_path}, {dest, dest_path}, opts)
 
       {:error, %VFS.Error{} = error} ->
         {Command.error("cp: cannot stat '#{src}': #{FS.strerror(error)}\n"), bash}
     end
   end
 
-  # A preserved link is copied as a link — dangling or not, directory or not.
-  defp copy_link(bash, {src, src_path}, {dest, dest_path}, %Options{links: :preserve} = opts) do
-    bash.fs
-    |> FS.cp(src_path, dest_path)
-    |> file_result(bash, {src, src_path}, dest, opts)
+  # What lands at the destination is a file (or a preserved link), so a
+  # destination spelled as a directory is refused before anything is written:
+  # POSIX reads the trailing slash in `cp a.md f/` as an assertion that `f` is
+  # a directory. Wording checked against GNU coreutils 9.11:
+  #
+  #     $ cp a.md f/     cp: cannot stat 'f/': Not a directory
+  #     $ cp a.md nope/  cp: cannot create regular file 'nope/': No such file …
+  defp copy_file(bash, {src, src_path}, {dest, dest_path}, opts) do
+    case FS.check_directory_spelling(bash.fs, dest, dest_path) do
+      {:ok, fs} ->
+        fs
+        |> FS.cp(src_path, dest_path)
+        |> file_result(%{bash | fs: fs}, {src, src_path}, dest, opts)
+
+      {:error, %VFS.Error{kind: :enoent} = error} ->
+        {Command.error("cp: cannot create regular file '#{dest}': #{FS.strerror(error)}\n"), bash}
+
+      {:error, %VFS.Error{} = error} ->
+        {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(error)}\n"), bash}
+    end
   end
+
+  # A preserved link is copied as a link — dangling or not, directory or not.
+  defp copy_link(bash, src, dest, %Options{links: :preserve} = opts),
+    do: copy_file(bash, src, dest, opts)
 
   # A followed link copies whatever it names, under the link's own name: a link
   # to a directory therefore needs `-r`, exactly like a directory does.
@@ -262,7 +294,23 @@ defmodule JustBash.Commands.Cp do
   defp copy_dir(bash, {src, _src_path}, {_dest, _dest_path}, %Options{mode: :shallow}),
     do: {Command.error("cp: -r not specified; omitting directory '#{src}'\n"), bash}
 
-  defp copy_dir(bash, {src, src_path}, {dest, dest_path}, %Options{mode: :recursive} = opts) do
+  # A recursive copy creates the directory a trailing slash promises, so
+  # `cp -r d nope/` is fine and only a destination that is already something
+  # else is refused — which bash words as a failed stat of the operand.
+  defp copy_dir(bash, src, {dest, dest_path} = dest_pair, %Options{mode: :recursive} = opts) do
+    case FS.check_directory_spelling(bash.fs, dest, dest_path) do
+      {:ok, fs} ->
+        copy_tree(%{bash | fs: fs}, src, dest_pair, opts)
+
+      {:error, %VFS.Error{kind: :enotdir} = error} ->
+        {Command.error("cp: cannot stat '#{dest}': #{FS.strerror(error)}\n"), bash}
+
+      {:error, %VFS.Error{}} ->
+        copy_tree(bash, src, dest_pair, opts)
+    end
+  end
+
+  defp copy_tree(bash, {src, src_path}, {dest, dest_path}, opts) do
     case FS.cp(bash.fs, src_path, dest_path, recursive: true) do
       {:ok, fs} ->
         report(%{bash | fs: fs}, {src, src_path}, dest, opts)

--- a/lib/just_bash/commands/ln.ex
+++ b/lib/just_bash/commands/ln.ex
@@ -31,7 +31,7 @@ defmodule JustBash.Commands.Ln do
     # against GNU coreutils 9.11:
     #
     #     $ ln -s a.md f/  ln: failed to create symbolic link 'f/': Not a directory
-    case FS.check_directory_spelling(bash.fs, link_name, link_path) do
+    case FS.check_directory_spelling(bash.fs, bash.cwd, link_name) do
       {:ok, fs} ->
         linked(%{bash | fs: fs}, target, link_path, link_name, opts)
 

--- a/lib/just_bash/commands/ln.ex
+++ b/lib/just_bash/commands/ln.ex
@@ -36,9 +36,24 @@ defmodule JustBash.Commands.Ln do
         linked(%{bash | fs: fs}, target, link_path, link_name, opts)
 
       {:error, %VFS.Error{} = error} ->
-        {Command.error(create_failed(link_name, error, opts)), bash}
+        {Command.error(spelling_failed(link_name, error, opts)), bash}
     end
   end
+
+  # `--force` lstats the destination before unlinking it, and reports *that*
+  # failure rather than the create it never attempts. `:enoent` is not a
+  # failed lstat — there is simply nothing to unlink — so the create goes
+  # ahead and fails under its own wording. GNU coreutils 9.11:
+  #
+  #     $ ln -s  a.md f/     ln: failed to create symbolic link 'f/': Not a directory
+  #     $ ln -sf a.md f/     ln: failed to access 'f/': Not a directory
+  #     $ ln -f  a.md f/     ln: failed to access 'f/': Not a directory
+  #     $ ln -sf a.md nope/  ln: failed to create symbolic link 'nope/': No such file …
+  defp spelling_failed(link_name, %VFS.Error{kind: kind} = error, %{force: true})
+       when kind != :enoent,
+       do: "ln: failed to access '#{link_name}': #{FS.strerror(error)}\n"
+
+  defp spelling_failed(link_name, error, opts), do: create_failed(link_name, error, opts)
 
   defp linked(bash, target, link_path, link_name, opts) do
     case create_link(bash, target, link_path, link_name, opts) do

--- a/lib/just_bash/commands/ln.ex
+++ b/lib/just_bash/commands/ln.ex
@@ -15,17 +15,35 @@ defmodule JustBash.Commands.Ln do
     if opts.files == [] or length(opts.files) < 2 do
       {Command.error("ln: missing file operand\n"), bash}
     else
-      [target | rest] = opts.files
-      link_name = List.last(rest)
-      link_path = FS.resolve_path(bash.cwd, link_name)
+      link(bash, opts)
+    end
+  end
 
-      case create_link(bash, target, link_path, link_name, opts) do
-        {:ok, new_bash, output} ->
-          {Command.ok(output), new_bash}
+  defp link(bash, opts) do
+    [target | rest] = opts.files
+    link_name = List.last(rest)
+    link_path = FS.resolve_path(bash.cwd, link_name)
 
-        {:error, msg} ->
-          {Command.error(msg), bash}
-      end
+    # POSIX reads the trailing slash in `ln -s a.md f/` as an assertion that
+    # `f` is a directory, and `FS.resolve_path/2` normalizes it away. The check
+    # comes before anything else because `-f` unlinks the destination first: a
+    # link that may not be created must not take the file with it. Checked
+    # against GNU coreutils 9.11:
+    #
+    #     $ ln -s a.md f/  ln: failed to create symbolic link 'f/': Not a directory
+    case FS.check_directory_spelling(bash.fs, link_name, link_path) do
+      {:ok, fs} ->
+        linked(%{bash | fs: fs}, target, link_path, link_name, opts)
+
+      {:error, %VFS.Error{} = error} ->
+        {Command.error(create_failed(link_name, error, opts)), bash}
+    end
+  end
+
+  defp linked(bash, target, link_path, link_name, opts) do
+    case create_link(bash, target, link_path, link_name, opts) do
+      {:ok, new_bash, output} -> {Command.ok(output), new_bash}
+      {:error, msg} -> {Command.error(msg), bash}
     end
   end
 
@@ -143,9 +161,14 @@ defmodule JustBash.Commands.Ln do
     {:ok, %{bash | fs: new_fs}, output}
   end
 
-  defp handle_link_result(_bash, {:error, %VFS.Error{kind: :eexist}}, _target, link_name, opts) do
-    link_type = if opts.symbolic, do: "symbolic ", else: ""
-    {:error, "ln: failed to create #{link_type}link '#{link_name}': File exists\n"}
+  defp handle_link_result(
+         _bash,
+         {:error, %VFS.Error{kind: :eexist} = err},
+         _target,
+         link_name,
+         opts
+       ) do
+    {:error, create_failed(link_name, err, opts)}
   end
 
   defp handle_link_result(_bash, {:error, %VFS.Error{kind: :enoent}}, target, _link_name, _opts) do
@@ -166,7 +189,11 @@ defmodule JustBash.Commands.Ln do
 
   # Foreign mounts can refuse links entirely (:enotsup, :erofs, :exdev, ...).
   defp handle_link_result(_bash, {:error, %VFS.Error{} = err}, _target, link_name, opts) do
+    {:error, create_failed(link_name, err, opts)}
+  end
+
+  defp create_failed(link_name, error, opts) do
     link_type = if opts.symbolic, do: "symbolic ", else: ""
-    {:error, "ln: failed to create #{link_type}link '#{link_name}': #{FS.strerror(err)}\n"}
+    "ln: failed to create #{link_type}link '#{link_name}': #{FS.strerror(error)}\n"
   end
 end

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -27,7 +27,7 @@ defmodule JustBash.Commands.Mv do
     # anything the destination is wrong about.
     with :ok <- distinct(src_resolved, dest, dest_final),
          {:ok, src_type} <- source_type(bash, src, src_resolved),
-         :ok <- destination_directory(bash, {src, src_type}, dest, dest_resolved) do
+         :ok <- destination_directory(bash, {src, src_type}, dest) do
       rename(bash, {src, src_resolved}, {dest, dest_shown, dest_final})
     else
       {:error, message} -> {Command.error(message), bash}
@@ -82,8 +82,8 @@ defmodule JustBash.Commands.Mv do
   #     $ mv a.md f/     mv: cannot stat 'f/': Not a directory
   #     $ mv a.md nope/  mv: cannot move 'a.md' to 'nope/': No such file …
   #     $ mv src nope/   (renames the directory)
-  defp destination_directory(bash, {src, src_type}, dest, dest_resolved) do
-    case FS.check_directory_spelling(bash.fs, dest, dest_resolved) do
+  defp destination_directory(bash, {src, src_type}, dest) do
+    case FS.check_directory_spelling(bash.fs, bash.cwd, dest) do
       {:ok, _fs} -> :ok
       {:error, %VFS.Error{kind: :enoent}} when src_type == :directory -> :ok
       {:error, %VFS.Error{} = error} -> {:error, dest_error(src, dest, error)}

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -24,10 +24,12 @@ defmodule JustBash.Commands.Mv do
 
     # bash stats the source, then the destination, and only then asks whether
     # the two name the same file — so a missing source is reported ahead of
-    # anything the destination is wrong about.
-    with :ok <- distinct(src_resolved, dest, dest_final),
-         {:ok, src_type} <- source_type(bash, src, src_resolved),
-         :ok <- destination_directory(bash, {src, src_type}, dest) do
+    # anything the destination is wrong about, and a destination whose
+    # spelling does not hold is reported ahead of the comparison it would
+    # otherwise take part in.
+    with {:ok, src_type} <- source_type(bash, src, src_resolved),
+         :ok <- destination_directory(bash, {src, src_type}, dest),
+         :ok <- distinct(src_resolved, dest_final) do
       rename(bash, {src, src_resolved}, {dest, dest_shown, dest_final})
     else
       {:error, message} -> {Command.error(message), bash}
@@ -52,12 +54,17 @@ defmodule JustBash.Commands.Mv do
     end
   end
 
-  # `a.md/` names no file at all when `a.md` is a regular file, so a trailing
-  # slash keeps the destination from being a second spelling of the source:
-  # `destination_directory/4` reports it instead.
-  defp distinct(src_resolved, dest, dest_final) do
-    if FS.normalize_path(src_resolved) == FS.normalize_path(dest_final) and
-         not FS.directory_spelling?(dest) do
+  # Once the destination's spelling has been held to its promise, a
+  # destination that lands back on the source *is* the source, however it was
+  # spelled: `d/`, `d/.` and `d/../d/` all name the directory the source
+  # already sits in. Checked against GNU coreutils 9.11:
+  #
+  #     $ mv d/keep d/   mv: 'd/keep' and 'd/keep' are the same file
+  #
+  # (`a.md/` never reaches here — `destination_directory/3` reports it, which
+  # is why this asks nothing about the spelling.)
+  defp distinct(src_resolved, dest_final) do
+    if FS.normalize_path(src_resolved) == FS.normalize_path(dest_final) do
       {:error, "mv: '#{src_resolved}' and '#{dest_final}' are the same file\n"}
     else
       :ok

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -9,63 +9,113 @@ defmodule JustBash.Commands.Mv do
   def names, do: ["mv"]
 
   @impl true
-  def execute(bash, args, _stdin) do
-    case args do
-      [src, dest] ->
-        src_resolved = FS.resolve_path(bash.cwd, src)
-        dest_resolved = FS.resolve_path(bash.cwd, dest)
+  def execute(bash, [src, dest], _stdin), do: move(bash, src, dest)
+  def execute(bash, _args, _stdin), do: {Command.error("mv: missing file operand\n"), bash}
 
-        # `dest_final` is where the move lands; `dest_shown` is the same place
-        # spelled the way the operand was, which is how bash names it in
-        # messages ("a/b/a", not "/tmp/x/a/b/a").
-        {dest_final, dest_shown, fs} =
-          case FS.stat(bash.fs, dest_resolved) do
-            {:ok, %VFS.Stat{type: :directory}, fs} ->
-              basename = FS.basename(src_resolved)
+  defp move(bash, src, dest) do
+    src_resolved = FS.resolve_path(bash.cwd, src)
+    dest_resolved = FS.resolve_path(bash.cwd, dest)
 
-              {FS.normalize_path(dest_resolved <> "/" <> basename),
-               String.trim_trailing(dest, "/") <> "/" <> basename, fs}
+    # `dest_final` is where the move lands; `dest_shown` is the same place
+    # spelled the way the operand was, which is how bash names it in
+    # messages ("a/b/a", not "/tmp/x/a/b/a").
+    {dest_final, dest_shown, fs} = destination(bash.fs, src_resolved, dest, dest_resolved)
+    bash = %{bash | fs: fs}
 
-            {:ok, _stat, fs} ->
-              {dest_resolved, dest, fs}
+    # bash stats the source, then the destination, and only then asks whether
+    # the two name the same file — so a missing source is reported ahead of
+    # anything the destination is wrong about.
+    with :ok <- distinct(src_resolved, dest, dest_final),
+         {:ok, src_type} <- source_type(bash, src, src_resolved),
+         :ok <- destination_directory(bash, {src, src_type}, dest, dest_resolved) do
+      rename(bash, {src, src_resolved}, {dest, dest_shown, dest_final})
+    else
+      {:error, message} -> {Command.error(message), bash}
+    end
+  end
 
-            {:error, _} ->
-              {dest_resolved, dest, bash.fs}
-          end
+  # A destination that already exists as a directory receives the source under
+  # its own basename; anything else is the name the move lands under.
+  defp destination(fs, src_resolved, dest, dest_resolved) do
+    case FS.stat(fs, dest_resolved) do
+      {:ok, %VFS.Stat{type: :directory}, fs} ->
+        basename = FS.basename(src_resolved)
 
-        bash = %{bash | fs: fs}
+        {FS.normalize_path(dest_resolved <> "/" <> basename),
+         String.trim_trailing(dest, "/") <> "/" <> basename, fs}
 
-        if FS.normalize_path(src_resolved) == FS.normalize_path(dest_final) do
-          {Command.result("", "mv: '#{src_resolved}' and '#{dest_final}' are the same file\n", 1),
-           bash}
-        else
-          case FS.mv(bash.fs, src_resolved, dest_final) do
-            {:ok, new_fs} ->
-              {Command.ok(), %{bash | fs: new_fs}}
+      {:ok, _stat, fs} ->
+        {dest_resolved, dest, fs}
 
-            {:error, %VFS.Error{kind: :enoent}} ->
-              {Command.error("mv: cannot stat '#{src}': No such file or directory\n"), bash}
+      {:error, _} ->
+        {dest_resolved, dest, fs}
+    end
+  end
 
-            {:error, %VFS.Error{kind: :eisdir}} ->
-              {Command.error("mv: cannot overwrite directory '#{dest}' with non-directory\n"),
-               bash}
+  # `a.md/` names no file at all when `a.md` is a regular file, so a trailing
+  # slash keeps the destination from being a second spelling of the source:
+  # `destination_directory/4` reports it instead.
+  defp distinct(src_resolved, dest, dest_final) do
+    if FS.normalize_path(src_resolved) == FS.normalize_path(dest_final) and
+         not FS.directory_spelling?(dest) do
+      {:error, "mv: '#{src_resolved}' and '#{dest_final}' are the same file\n"}
+    else
+      :ok
+    end
+  end
 
-            {:error, %VFS.Error{kind: :einval}} ->
-              {Command.error(
-                 "mv: cannot move '#{src}' to a subdirectory of itself, '#{dest_shown}'\n"
-               ), bash}
+  defp source_type(bash, src, src_resolved) do
+    case FS.lstat(bash.fs, src_resolved) do
+      {:ok, %VFS.Stat{type: type}, _fs} ->
+        {:ok, type}
 
-            # :enotdir needs no clause of its own — the catch-all below already
-            # spells it "cannot move 'src' to 'dest': Not a directory", which is
-            # why #56 removed the explicit one.
-            {:error, %VFS.Error{} = error} ->
-              {Command.error("mv: cannot move '#{src}' to '#{dest}': #{FS.strerror(error)}\n"),
-               bash}
-          end
-        end
+      {:error, %VFS.Error{} = error} ->
+        {:error, "mv: cannot stat '#{src}': #{FS.strerror(error)}\n"}
+    end
+  end
 
-      _ ->
-        {Command.error("mv: missing file operand\n"), bash}
+  # POSIX reads the trailing slash in `mv a.md f/` as an assertion that `f` is
+  # a directory, and `resolve_path/2` normalizes it away. Only a directory
+  # arriving at a destination that does not exist yet makes the assertion true
+  # by itself. Wording checked against GNU coreutils 9.11:
+  #
+  #     $ mv a.md f/     mv: cannot stat 'f/': Not a directory
+  #     $ mv a.md nope/  mv: cannot move 'a.md' to 'nope/': No such file …
+  #     $ mv src nope/   (renames the directory)
+  defp destination_directory(bash, {src, src_type}, dest, dest_resolved) do
+    case FS.check_directory_spelling(bash.fs, dest, dest_resolved) do
+      {:ok, _fs} -> :ok
+      {:error, %VFS.Error{kind: :enoent}} when src_type == :directory -> :ok
+      {:error, %VFS.Error{} = error} -> {:error, dest_error(src, dest, error)}
+    end
+  end
+
+  defp dest_error(_src, dest, %VFS.Error{kind: :enotdir} = error),
+    do: "mv: cannot stat '#{dest}': #{FS.strerror(error)}\n"
+
+  defp dest_error(src, dest, %VFS.Error{} = error),
+    do: "mv: cannot move '#{src}' to '#{dest}': #{FS.strerror(error)}\n"
+
+  defp rename(bash, {src, src_resolved}, {dest, dest_shown, dest_final}) do
+    case FS.mv(bash.fs, src_resolved, dest_final) do
+      {:ok, new_fs} ->
+        {Command.ok(), %{bash | fs: new_fs}}
+
+      {:error, %VFS.Error{kind: :enoent}} ->
+        {Command.error("mv: cannot stat '#{src}': No such file or directory\n"), bash}
+
+      {:error, %VFS.Error{kind: :eisdir}} ->
+        {Command.error("mv: cannot overwrite directory '#{dest}' with non-directory\n"), bash}
+
+      {:error, %VFS.Error{kind: :einval}} ->
+        {Command.error("mv: cannot move '#{src}' to a subdirectory of itself, '#{dest_shown}'\n"),
+         bash}
+
+      # :enotdir needs no clause of its own — the catch-all below already
+      # spells it "cannot move 'src' to 'dest': Not a directory", which is
+      # why #56 removed the explicit one.
+      {:error, %VFS.Error{} = error} ->
+        {Command.error("mv: cannot move '#{src}' to '#{dest}': #{FS.strerror(error)}\n"), bash}
     end
   end
 end

--- a/lib/just_bash/commands/sed.ex
+++ b/lib/just_bash/commands/sed.ex
@@ -199,7 +199,22 @@ defmodule JustBash.Commands.Sed do
     end
   end
 
+  # POSIX reads the trailing slash in `sed -i s/x/y/ f/` as an assertion that
+  # `f` is a directory, and `FS.resolve_path/2` normalizes it away — so an
+  # in-place edit spelled that way would rewrite the regular file `f`. Real
+  # sed never gets that far: `open("f/")` fails with ENOTDIR before any
+  # editing, leaving the file alone.
   defp process_single_file_in_place(bash, file, commands, opts) do
+    case FS.check_directory_spelling(bash.fs, bash.cwd, file) do
+      {:ok, fs} ->
+        read_and_edit(%{bash | fs: fs}, file, commands, opts)
+
+      {:error, %VFS.Error{} = error} ->
+        {:halt, {:error, "sed: #{file}: #{FS.strerror(error)}\n"}}
+    end
+  end
+
+  defp read_and_edit(bash, file, commands, opts) do
     resolved = FS.resolve_path(bash.cwd, file)
 
     case FS.read_file(bash.fs, resolved) do

--- a/lib/just_bash/commands/tee.ex
+++ b/lib/just_bash/commands/tee.ex
@@ -64,10 +64,27 @@ defmodule JustBash.Commands.Tee do
     end)
   end
 
+  # POSIX reads the trailing slash in `tee f/` as an assertion that `f` is a
+  # directory, and `FS.resolve_path/2` normalizes it away — so a file spelled
+  # that way is checked against what is really there before anything is
+  # written. Checked against GNU coreutils 9.11:
+  #
+  #     $ echo x | tee f/     tee: f/: Not a directory
+  #     $ echo x | tee nope/  tee: nope/: No such file or directory
+  defp write_single_file(fs, resolved, file, content, append, acc_stderr, acc_code) do
+    case FS.check_directory_spelling(fs, file, resolved) do
+      {:ok, fs} ->
+        write_below_parent(fs, resolved, file, content, append, acc_stderr, acc_code)
+
+      {:error, %VFS.Error{} = error} ->
+        {fs, acc_stderr <> "tee: #{file}: #{FS.strerror(error)}\n", 1}
+    end
+  end
+
   # tee does not create missing parent directories, so an absent parent is
   # reported instead of being conjured up; a parent that exists but is not
   # a directory is ENOTDIR, as the kernel would report it.
-  defp write_single_file(fs, resolved, file, content, append, acc_stderr, acc_code) do
+  defp write_below_parent(fs, resolved, file, content, append, acc_stderr, acc_code) do
     parent = Path.dirname(resolved)
 
     case FS.stat(fs, parent) do

--- a/lib/just_bash/commands/tee.ex
+++ b/lib/just_bash/commands/tee.ex
@@ -59,7 +59,7 @@ defmodule JustBash.Commands.Tee do
         {acc_fs, acc_stderr, acc_code}
       else
         resolved = FS.resolve_path(cwd, file)
-        write_single_file(acc_fs, resolved, file, content, append, acc_stderr, acc_code)
+        write_single_file(acc_fs, {cwd, resolved}, file, content, append, acc_stderr, acc_code)
       end
     end)
   end
@@ -71,8 +71,8 @@ defmodule JustBash.Commands.Tee do
   #
   #     $ echo x | tee f/     tee: f/: Not a directory
   #     $ echo x | tee nope/  tee: nope/: No such file or directory
-  defp write_single_file(fs, resolved, file, content, append, acc_stderr, acc_code) do
-    case FS.check_directory_spelling(fs, file, resolved) do
+  defp write_single_file(fs, {cwd, resolved}, file, content, append, acc_stderr, acc_code) do
+    case FS.check_directory_spelling(fs, cwd, file) do
       {:ok, fs} ->
         write_below_parent(fs, resolved, file, content, append, acc_stderr, acc_code)
 

--- a/lib/just_bash/commands/touch.ex
+++ b/lib/just_bash/commands/touch.ex
@@ -29,7 +29,7 @@ defmodule JustBash.Commands.Touch do
   defp touch_file(cwd, path, {fs_acc, err_acc, code_acc}) do
     resolved = FS.resolve_path(cwd, path)
 
-    case FS.check_directory_spelling(fs_acc, path, resolved) do
+    case FS.check_directory_spelling(fs_acc, cwd, path) do
       {:ok, fs_acc} -> touch_resolved(fs_acc, resolved, path, err_acc, code_acc)
       {:error, %VFS.Error{} = error} -> {fs_acc, err_acc <> touch_failed(path, error), 1}
     end

--- a/lib/just_bash/commands/touch.ex
+++ b/lib/just_bash/commands/touch.ex
@@ -18,8 +18,24 @@ defmodule JustBash.Commands.Touch do
     {Command.result("", stderr, exit_code), %{bash | fs: new_fs}}
   end
 
+  # POSIX reads the trailing slash in `touch f/` as an assertion that `f` is a
+  # directory, and `FS.resolve_path/2` normalizes it away — so `touch f/` over
+  # a regular file is an error, not the no-op that touching `f` would be.
+  # Checked against GNU coreutils 9.11:
+  #
+  #     $ touch f/     touch: cannot touch 'f/': Not a directory
+  #     $ touch nope/  touch: cannot touch 'nope/': No such file or directory
+  #     $ touch d/     (exits 0)
   defp touch_file(cwd, path, {fs_acc, err_acc, code_acc}) do
     resolved = FS.resolve_path(cwd, path)
+
+    case FS.check_directory_spelling(fs_acc, path, resolved) do
+      {:ok, fs_acc} -> touch_resolved(fs_acc, resolved, path, err_acc, code_acc)
+      {:error, %VFS.Error{} = error} -> {fs_acc, err_acc <> touch_failed(path, error), 1}
+    end
+  end
+
+  defp touch_resolved(fs_acc, resolved, path, err_acc, code_acc) do
     {exists, fs_acc} = FS.exists?(fs_acc, resolved)
 
     if exists do
@@ -35,7 +51,9 @@ defmodule JustBash.Commands.Touch do
         {new_fs, err_acc, code_acc}
 
       {:error, %VFS.Error{} = error} ->
-        {fs, err_acc <> "touch: cannot touch '#{path}': #{FS.strerror(error)}\n", 1}
+        {fs, err_acc <> touch_failed(path, error), 1}
     end
   end
+
+  defp touch_failed(path, error), do: "touch: cannot touch '#{path}': #{FS.strerror(error)}\n"
 end

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -110,18 +110,25 @@ defmodule JustBash.FS do
 
   An empty operand names nothing at all, which is a different complaint.
   """
+  @directory_components ["", ".", ".."]
+
   @spec directory_spelling?(String.t()) :: boolean()
   def directory_spelling?(""), do: false
 
   def directory_spelling?(path) do
     last = path |> String.split("/") |> List.last()
-    last in ["", ".", ".."]
+    last in @directory_components
   end
 
   @doc """
-  Hold a path to what its spelling promised: `{:ok, fs}` unless `spelling`
-  demands a directory (see `directory_spelling?/1`) and `resolved` — the path
-  it resolved to — is not one.
+  Hold `spelling` — a path as an operand wrote it, read relative to `base` —
+  to what its spelling promised: `{:ok, fs}` unless it demands a directory
+  (see `directory_spelling?/1`) and what it demands it of is not one.
+
+  What it demands it of is the last component the spelling names outright, not
+  where `resolve_path/2` says the whole thing lands: `..` is collapsed
+  lexically, so `/f/..` resolves to `/` — a directory whatever `/f` is — while
+  the kernel cannot walk up out of the regular file `/f` at all.
 
   The error is the one `stat("f/")` itself gives: `:enotdir` when something
   that is not a directory is already there, naming the operand as the caller
@@ -130,11 +137,30 @@ defmodule JustBash.FS do
   — a recursive copy, say — can ignore.
   """
   @spec check_directory_spelling(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
-  def check_directory_spelling(fs, spelling, resolved) do
+  def check_directory_spelling(fs, base, spelling) do
     if directory_spelling?(spelling) do
-      require_directory(fs, spelling, resolved)
+      require_directory(fs, spelling, asserted_directory(base, spelling))
     else
       {:ok, fs}
+    end
+  end
+
+  # The path `spelling` asserts is a directory: everything before the run of
+  # `/`, `.` and `..` components trailing it. Holding that one path is enough
+  # — every component the run walks through afterwards is an ancestor of it,
+  # and an ancestor of a directory is a directory. A spelling that names
+  # nothing else (`/`, `.`, `..`) asserts only about where it resolved.
+  defp asserted_directory(base, spelling) do
+    named =
+      spelling
+      |> String.split("/")
+      |> Enum.reverse()
+      |> Enum.drop_while(&(&1 in @directory_components))
+      |> Enum.reverse()
+
+    case named do
+      [] -> resolve_path(base, spelling)
+      components -> resolve_path(base, Enum.join(components, "/"))
     end
   end
 

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -98,6 +98,46 @@ defmodule JustBash.FS do
   def resolve_path(_base, "/" <> _ = path), do: normalize_path(path)
   def resolve_path(base, path), do: VPath.join(normalize_path(base), path)
 
+  @doc """
+  Does the way `path` is spelled require it to name a directory?
+
+  POSIX resolves a trailing slash as a trailing `/.`, so `f/` is not another
+  spelling of the regular file `f` — it is an assertion that `f` is a
+  directory. The `.` and `..` components the slash stands for say the same
+  thing. `resolve_path/2` normalizes all of them away, so a caller that writes
+  through a user-supplied path asks this of the operand before trusting where
+  it resolved to.
+
+  An empty operand names nothing at all, which is a different complaint.
+  """
+  @spec directory_spelling?(String.t()) :: boolean()
+  def directory_spelling?(""), do: false
+
+  def directory_spelling?(path) do
+    last = path |> String.split("/") |> List.last()
+    last in ["", ".", ".."]
+  end
+
+  @doc """
+  Hold a path to what its spelling promised: `{:ok, fs}` unless `spelling`
+  demands a directory (see `directory_spelling?/1`) and `resolved` — the path
+  it resolved to — is not one.
+
+  The error is the one `stat("f/")` itself gives: `:enotdir` when something
+  that is not a directory is already there, naming the operand as the caller
+  spelled it, and whatever `stat/2` reported otherwise. `:enoent` means the
+  destination does not exist yet, which a caller about to create the directory
+  — a recursive copy, say — can ignore.
+  """
+  @spec check_directory_spelling(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
+  def check_directory_spelling(fs, spelling, resolved) do
+    if directory_spelling?(spelling) do
+      require_directory(fs, spelling, resolved)
+    else
+      {:ok, fs}
+    end
+  end
+
   # ── core operations (delegated to VFS) ───────────────────────────────────
 
   @doc "See `VFS.read_file/2`."
@@ -281,6 +321,16 @@ defmodule JustBash.FS do
   def strerror(kind) when is_atom(kind), do: to_string(kind)
 
   # ── private ──────────────────────────────────────────────────────────────
+
+  # The stat behind `check_directory_spelling/3`. The error names the operand
+  # as it was spelled, since that spelling is what the caller reports.
+  defp require_directory(fs, spelling, resolved) do
+    case stat(fs, resolved) do
+      {:ok, %VFS.Stat{type: :directory}, fs} -> {:ok, fs}
+      {:ok, %VFS.Stat{}, _fs} -> {:error, Error.new(:enotdir, path: spelling)}
+      {:error, %Error{} = error} -> {:error, error}
+    end
+  end
 
   # Is `dest` the same path as `src`, or nested inside it? Everything is
   # inside the root, so a recursive copy of "/" never has a safe destination.

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -146,6 +146,14 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   #     $ echo hi > f/     bash: f/: Not a directory
   #     $ echo hi > d/     bash: d/: Is a directory
   #     $ echo hi > nope/  bash: nope/: No such file or directory
+  #
+  # An empty target names nothing at all — `open("")` is ENOENT, not a write
+  # to the working directory that resolving it would produce:
+  #
+  #     $ echo hi > ''     bash: : No such file or directory
+  defp open_file(bash, _mode, "" = target_path, _resolved),
+    do: {:error, target_path, VFS.Error.new(:enoent, path: target_path), bash}
+
   defp open_file(bash, mode, target_path, resolved) do
     if FS.directory_spelling?(target_path) do
       {:error, target_path, directory_target(bash, target_path, resolved), bash}

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -148,16 +148,17 @@ defmodule JustBash.Interpreter.Executor.Redirection do
   #     $ echo hi > nope/  bash: nope/: No such file or directory
   defp open_file(bash, mode, target_path, resolved) do
     if FS.directory_spelling?(target_path) do
-      {:error, target_path, directory_target(bash, resolved), bash}
+      {:error, target_path, directory_target(bash, target_path, resolved), bash}
     else
       open_resolved(bash, mode, target_path, resolved)
     end
   end
 
-  defp directory_target(bash, resolved) do
-    case FS.stat(bash.fs, resolved) do
-      {:ok, %VFS.Stat{type: :directory}, _fs} -> VFS.Error.new(:eisdir, path: resolved)
-      {:ok, %VFS.Stat{}, _fs} -> VFS.Error.new(:enotdir, path: resolved)
+  # A spelling that holds is a directory, which is the one thing a redirection
+  # may not open; a spelling that does not says why it does not.
+  defp directory_target(bash, target_path, resolved) do
+    case FS.check_directory_spelling(bash.fs, bash.cwd, target_path) do
+      {:ok, _fs} -> VFS.Error.new(:eisdir, path: resolved)
       {:error, %VFS.Error{} = error} -> error
     end
   end

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -115,12 +115,12 @@ defmodule JustBash.Interpreter.Executor.Redirection do
     redir_type = classify_redirection(fd, operator, target_path)
     resolved = FS.resolve_path(bash.cwd, target_path)
 
-    case open_target(bash, redir_type, resolved) do
+    case open_target(bash, redir_type, target_path, resolved) do
       {:ok, bash} ->
         do_preflight(bash, rest, [{redir_type, resolved} | prepared])
 
-      {:error, error, bash} ->
-        {:error, open_failed(resolved, error), bash}
+      {:error, path, error, bash} ->
+        {:error, open_failed(path, error), bash}
     end
   end
 
@@ -130,13 +130,46 @@ defmodule JustBash.Interpreter.Executor.Redirection do
     %{stdout: "", stderr: "bash: #{path}: #{FS.strerror(error)}\n", exit_code: 1}
   end
 
-  defp open_target(bash, redir_type, path) do
+  defp open_target(bash, redir_type, target_path, resolved) do
     case open_mode(redir_type) do
-      :truncate -> create_or_truncate(bash, path)
-      :append -> open_for_append(bash, path)
       :none -> {:ok, bash}
+      mode -> open_file(bash, mode, target_path, resolved)
     end
   end
+
+  # A redirection writes a file, never a directory, so a target spelled as one
+  # — POSIX reads the trailing slash in `> f/` as an assertion that `f` is a
+  # directory — cannot be opened whatever is there. `resolve_path/2`
+  # normalizes the slash away, so the check needs the target as it was
+  # written, which is also how bash names it. Checked against bash 5:
+  #
+  #     $ echo hi > f/     bash: f/: Not a directory
+  #     $ echo hi > d/     bash: d/: Is a directory
+  #     $ echo hi > nope/  bash: nope/: No such file or directory
+  defp open_file(bash, mode, target_path, resolved) do
+    if FS.directory_spelling?(target_path) do
+      {:error, target_path, directory_target(bash, resolved), bash}
+    else
+      open_resolved(bash, mode, target_path, resolved)
+    end
+  end
+
+  defp directory_target(bash, resolved) do
+    case FS.stat(bash.fs, resolved) do
+      {:ok, %VFS.Stat{type: :directory}, _fs} -> VFS.Error.new(:eisdir, path: resolved)
+      {:ok, %VFS.Stat{}, _fs} -> VFS.Error.new(:enotdir, path: resolved)
+      {:error, %VFS.Error{} = error} -> error
+    end
+  end
+
+  defp open_resolved(bash, :truncate, target_path, resolved),
+    do: opened(create_or_truncate(bash, resolved), target_path)
+
+  defp open_resolved(bash, :append, target_path, resolved),
+    do: opened(open_for_append(bash, resolved), target_path)
+
+  defp opened({:ok, bash}, _target_path), do: {:ok, bash}
+  defp opened({:error, error, bash}, target_path), do: {:error, target_path, error, bash}
 
   @spec open_mode(redir_type()) :: :truncate | :append | :none
   defp open_mode(:stdout_write), do: :truncate

--- a/test/just_bash/trailing_slash_test.exs
+++ b/test/just_bash/trailing_slash_test.exs
@@ -225,6 +225,63 @@ defmodule JustBash.TrailingSlashTest do
     end
   end
 
+  # A `..` component makes the same demand a trailing slash does: the kernel
+  # can only walk up out of a directory. `FS.resolve_path/2` collapses it
+  # lexically — `/f/..` becomes `/`, a directory whatever `/f` is — so the
+  # demand is made about the last component the operand names outright.
+  # GNU coreutils 9.11 / bash 5:
+  #
+  #     $ touch f/..         touch: cannot touch 'f/..': Not a directory
+  #     $ touch nope/..      touch: cannot touch 'nope/..': No such file or directory
+  #     $ touch f/x/..       touch: cannot touch 'f/x/..': Not a directory
+  #     $ cp a.md f/..       cp: cannot stat 'f/..': Not a directory
+  #     $ cp a.md nope/..    cp: cannot create regular file 'nope/..': No such file …
+  #     $ mv a.md f/..       mv: cannot stat 'f/..': Not a directory
+  #     $ mv d f/..          mv: cannot stat 'f/..': Not a directory
+  #     $ echo hi > f/..     bash: f/..: Not a directory
+  #     $ echo x | tee f/..  tee: f/..: Not a directory
+  #     $ ln -s a.md f/..    ln: failed to create symbolic link 'f/..': Not a directory
+  describe "a .. component demands a directory the way a trailing slash does" do
+    for {command, message} <- [
+          {"touch /f/..", "touch: cannot touch '/f/..': Not a directory\n"},
+          {"touch /nope/..", "touch: cannot touch '/nope/..': No such file or directory\n"},
+          {"touch /f/x/..", "touch: cannot touch '/f/x/..': Not a directory\n"},
+          {"cp /a.md /f/..", "cp: cannot stat '/f/..': Not a directory\n"},
+          {"cp /a.md /nope/..",
+           "cp: cannot create regular file '/nope/..': No such file or directory\n"},
+          {"mv /a.md /f/..", "mv: cannot stat '/f/..': Not a directory\n"},
+          {"mv /d /f/..", "mv: cannot stat '/f/..': Not a directory\n"},
+          {"echo hi > /f/..", "bash: /f/..: Not a directory\n"},
+          {"echo hi | tee /f/..", "tee: /f/..: Not a directory\n"},
+          {"ln -s /a.md /f/..", "ln: failed to create symbolic link '/f/..': Not a directory\n"}
+        ] do
+      test "`#{command}` is refused" do
+        {result, bash} = JustBash.exec(bash(), unquote(command))
+
+        assert result.exit_code == 1
+        assert result.stderr == unquote(message)
+        assert {:ok, "F\n", _fs} = read(bash, "/f")
+        assert {:ok, "A\n", _fs} = read(bash, "/a.md")
+        assert {:ok, "K\n", _fs} = read(bash, "/d/keep")
+      end
+    end
+
+    # $ touch d/..   (exits 0: `d` really is a directory)
+    test "a .. hanging off a real directory is accepted" do
+      {result, _bash} = JustBash.exec(bash(), "touch /d/..")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+    end
+
+    test "a bare .. is accepted: the cwd is a directory" do
+      {result, _bash} = JustBash.exec(bash(), "cd /d && touch ..")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+    end
+  end
+
   describe "output redirection to a target spelled as a directory" do
     # $ cat a.md > f/
     # bash: f/: Not a directory
@@ -397,21 +454,43 @@ defmodule JustBash.TrailingSlashTest do
 
   describe "FS.check_directory_spelling/3" do
     test "passes a path that makes no demand" do
-      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/f", "/f")
+      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/", "/f")
     end
 
     test "passes a directory" do
-      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/d/", "/d")
+      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/", "/d/")
     end
 
     test "returns :enotdir for a non-directory, naming the operand as spelled" do
       assert {:error, %VFS.Error{kind: :enotdir, path: "/f/"}} =
-               FS.check_directory_spelling(fs(), "/f/", "/f")
+               FS.check_directory_spelling(fs(), "/", "/f/")
     end
 
     test "returns the error stat gave for a path that is not there" do
       assert {:error, %VFS.Error{kind: :enoent}} =
-               FS.check_directory_spelling(fs(), "/nope/", "/nope")
+               FS.check_directory_spelling(fs(), "/", "/nope/")
+    end
+
+    test "resolves a relative spelling against the base" do
+      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/d", "../d/")
+
+      assert {:error, %VFS.Error{kind: :enotdir, path: "../f/"}} =
+               FS.check_directory_spelling(fs(), "/d", "../f/")
+    end
+
+    # `resolve_path/2` collapses `..` lexically, so the demand is made about
+    # the last component the spelling names outright — `/f` for `/f/..`, not
+    # the `/` that `/f/..` resolves to.
+    test "a trailing .. demands the component it hangs off, not where it lands" do
+      assert {:error, %VFS.Error{kind: :enotdir, path: "/f/.."}} =
+               FS.check_directory_spelling(fs(), "/", "/f/..")
+
+      assert {:error, %VFS.Error{kind: :enoent}} =
+               FS.check_directory_spelling(fs(), "/", "/nope/..")
+
+      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/", "/d/..")
+      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/d", "..")
+      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/d", ".")
     end
   end
 end

--- a/test/just_bash/trailing_slash_test.exs
+++ b/test/just_bash/trailing_slash_test.exs
@@ -225,6 +225,55 @@ defmodule JustBash.TrailingSlashTest do
     end
   end
 
+  # A destination that resolves back to the source is the source, however the
+  # directory holding it was spelled — the slash does not turn the refusal
+  # into a silent exit-0 no-op. GNU coreutils 9.11, in a scratch directory:
+  #
+  #     $ mv d/keep d        mv: 'd/keep' and 'd/keep' are the same file
+  #     $ mv d/keep d/       mv: 'd/keep' and 'd/keep' are the same file
+  #     $ mv d/keep d/.      mv: 'd/keep' and 'd/./keep' are the same file
+  #     $ mv d/keep d/../d/  mv: 'd/keep' and 'd/../d/keep' are the same file
+  #     $ cd d && mv keep .  mv: 'keep' and './keep' are the same file
+  #     $ cd d && mv keep ./ mv: 'keep' and './keep' are the same file
+  #
+  # GNU names each side the way the operand was written; we name both by where
+  # they resolved, which is what `mv` did before this rule existed. The
+  # refusal — and the untouched file — is what #58 is about.
+  describe "mv onto a destination that resolves back to the source" do
+    for {command, same} <- [
+          {"mv /d/keep /d", "/d/keep"},
+          {"mv /d/keep /d/", "/d/keep"},
+          {"mv /d/keep /d/.", "/d/keep"},
+          {"mv /d/keep /d/../d/", "/d/keep"},
+          {"cd /d && mv keep .", "/d/keep"},
+          {"cd /d && mv keep ./", "/d/keep"},
+          {"mv /a.md /", "/a.md"},
+          {"mv /a.md //", "/a.md"}
+        ] do
+      test "`#{command}` is refused rather than doing nothing quietly" do
+        {result, bash} = JustBash.exec(bash(), unquote(command))
+
+        assert result.exit_code == 1
+        assert result.stdout == ""
+
+        assert result.stderr ==
+                 "mv: '#{unquote(same)}' and '#{unquote(same)}' are the same file\n"
+
+        assert {:ok, "K\n", _fs} = read(bash, "/d/keep")
+        assert {:ok, "A\n", _fs} = read(bash, "/a.md")
+      end
+    end
+
+    # $ mv nope.md nope.md
+    # mv: cannot stat 'nope.md': No such file or directory
+    test "a missing source is reported before the two names are compared" do
+      {result, _bash} = JustBash.exec(bash(), "mv /nope.md /nope.md")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot stat '/nope.md': No such file or directory\n"
+    end
+  end
+
   # A `..` component makes the same demand a trailing slash does: the kernel
   # can only walk up out of a directory. `FS.resolve_path/2` collapses it
   # lexically — `/f/..` becomes `/`, a directory whatever `/f` is — so the

--- a/test/just_bash/trailing_slash_test.exs
+++ b/test/just_bash/trailing_slash_test.exs
@@ -1,0 +1,417 @@
+defmodule JustBash.TrailingSlashTest do
+  @moduledoc """
+  Regression tests for issue #58: a trailing slash used to be stripped from a
+  destination operand, so `cp /a.md /f/` overwrote the regular file `/f`.
+
+  POSIX resolves `f/` as `f/.`, which requires `f` to be a directory.
+  `FS.resolve_path/2` normalizes the slash away, so every command that writes
+  through a destination asks `FS.directory_spelling?/1` about the operand
+  before trusting the resolved path.
+
+  Every wording here was checked against GNU coreutils 9.11 and bash 5 —
+  the shell transcript is quoted next to the case it came from.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.FS
+
+  # /f is a regular file, /d a directory, and the two symlinks reach one of
+  # each: a trailing slash is about what the path *lands on*, not how it is
+  # spelled on the way there.
+  defp bash do
+    JustBash.new(files: %{"/a.md" => "A\n", "/b.md" => "B\n", "/f" => "F\n", "/d/keep" => "K\n"})
+  end
+
+  defp bash_with_links do
+    {result, bash} = JustBash.exec(bash(), "ln -s /f /lf && ln -s /d /ld")
+    assert result.exit_code == 0
+    bash
+  end
+
+  defp fs, do: FS.new(%{"/f" => "F\n", "/d/keep" => "K\n"})
+
+  defp read(bash, path), do: FS.read_file(bash.fs, path)
+
+  defp exists?(bash, path), do: bash.fs |> FS.exists?(path) |> elem(0)
+
+  describe "cp with a destination spelled as a directory" do
+    # $ cp a.md f/
+    # cp: cannot stat 'f/': Not a directory
+    test "refuses to overwrite a regular file and leaves it alone" do
+      {result, bash} = JustBash.exec(bash(), "cp /a.md /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ cp a.md f/.
+    # cp: cannot stat 'f/.': Not a directory
+    test "refuses a trailing dot component too" do
+      {result, bash} = JustBash.exec(bash(), "cp /a.md /f/.")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/f/.': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ cp -r src f/
+    # cp: cannot stat 'f/': Not a directory
+    test "refuses a recursive copy onto a regular file" do
+      {result, bash} = JustBash.exec(bash(), "cp -r /d /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ cp a.md a.md/
+    # cp: cannot stat 'a.md/': Not a directory
+    test "is not a self-copy: the source is not spelled as a directory" do
+      {result, bash} = JustBash.exec(bash(), "cp /a.md /a.md/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/a.md/': Not a directory\n"
+      assert {:ok, "A\n", _fs} = read(bash, "/a.md")
+    end
+
+    # $ cp a.md nope/
+    # cp: cannot create regular file 'nope/': No such file or directory
+    test "will not create the file a slash promised would be a directory" do
+      {result, bash} = JustBash.exec(bash(), "cp /a.md /nope/")
+
+      assert result.exit_code == 1
+
+      assert result.stderr ==
+               "cp: cannot create regular file '/nope/': No such file or directory\n"
+
+      refute exists?(bash, "/nope")
+    end
+
+    # $ cp -r src nope/  (creates the directory: the copy makes the promise true)
+    test "a recursive copy creates the missing directory" do
+      {result, bash} = JustBash.exec(bash(), "cp -r /d /nope/")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert {:ok, "K\n", _fs} = read(bash, "/nope/keep")
+    end
+
+    test "copying into a directory still works" do
+      {result, bash} = JustBash.exec(bash(), "cp /a.md /d/")
+
+      assert result.exit_code == 0
+      assert {:ok, "A\n", _fs} = read(bash, "/d/a.md")
+    end
+
+    # $ cp a.md lfile/
+    # cp: cannot stat 'lfile/': Not a directory
+    test "follows a symlink before judging it: a link to a file is not a directory" do
+      {result, bash} = JustBash.exec(bash_with_links(), "cp /a.md /lf/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/lf/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    test "a symlink to a directory accepts the slash" do
+      {result, bash} = JustBash.exec(bash_with_links(), "cp /a.md /ld/")
+
+      assert result.exit_code == 0
+      assert {:ok, "A\n", _fs} = read(bash, "/d/a.md")
+    end
+
+    # $ cp -n a.md f/
+    # cp: cannot stat 'f/': Not a directory
+    #
+    # `-n` keeps an existing destination, but `f/` is not a name that file
+    # has, so there is nothing for it to keep.
+    test "-n does not quietly keep a destination that is not a directory" do
+      {result, bash} = JustBash.exec(bash(), "cp -n /a.md /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ cp -P l f/
+    # cp: cannot stat 'f/': Not a directory
+    test "-P refuses the destination before copying the link itself" do
+      {result, bash} = JustBash.exec(bash_with_links(), "cp -P /lf /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: cannot stat '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ cp a.md b.md f/
+    # cp: target 'f/': Not a directory
+    test "several sources still name the target that is not a directory" do
+      {result, bash} = JustBash.exec(bash(), "cp /a.md /b.md /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cp: target '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+  end
+
+  describe "mv with a destination spelled as a directory" do
+    # $ mv a.md f/
+    # mv: cannot stat 'f/': Not a directory
+    test "refuses to overwrite a regular file and keeps the source" do
+      {result, bash} = JustBash.exec(bash(), "mv /a.md /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot stat '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+      assert {:ok, "A\n", _fs} = read(bash, "/a.md")
+    end
+
+    test "refuses a trailing dot component too" do
+      {result, bash} = JustBash.exec(bash(), "mv /a.md /f/.")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot stat '/f/.': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ mv src f/
+    # mv: cannot stat 'f/': Not a directory
+    test "refuses to move a directory onto a regular file" do
+      {result, bash} = JustBash.exec(bash(), "mv /d /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot stat '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+      assert {:ok, "K\n", _fs} = read(bash, "/d/keep")
+    end
+
+    # $ mv a.md nope/
+    # mv: cannot move 'a.md' to 'nope/': No such file or directory
+    test "will not create the file a slash promised would be a directory" do
+      {result, bash} = JustBash.exec(bash(), "mv /a.md /nope/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot move '/a.md' to '/nope/': No such file or directory\n"
+      assert {:ok, "A\n", _fs} = read(bash, "/a.md")
+      refute exists?(bash, "/nope")
+    end
+
+    # $ mv src nope/  (a directory move makes the promise true)
+    test "moving a directory to a missing destination renames it" do
+      {result, bash} = JustBash.exec(bash(), "mv /d /nope/")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert {:ok, "K\n", _fs} = read(bash, "/nope/keep")
+      refute exists?(bash, "/d")
+    end
+
+    test "moving into a directory still works" do
+      {result, bash} = JustBash.exec(bash(), "mv /a.md /d/")
+
+      assert result.exit_code == 0
+      assert {:ok, "A\n", _fs} = read(bash, "/d/a.md")
+      refute exists?(bash, "/a.md")
+    end
+
+    # $ mv missing.md f/
+    # mv: cannot stat 'missing.md': No such file or directory
+    test "reports a missing source before judging the destination" do
+      {result, _bash} = JustBash.exec(bash(), "mv /missing.md /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "mv: cannot stat '/missing.md': No such file or directory\n"
+    end
+  end
+
+  describe "output redirection to a target spelled as a directory" do
+    # $ cat a.md > f/
+    # bash: f/: Not a directory
+    test "refuses to truncate a regular file" do
+      {result, bash} = JustBash.exec(bash(), "cat /a.md > /f/")
+
+      assert result.exit_code == 1
+      assert result.stdout == ""
+      assert result.stderr == "bash: /f/: Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ echo hi >> f/
+    # bash: f/: Not a directory
+    test "refuses to append to a regular file" do
+      {result, bash} = JustBash.exec(bash(), "echo hi >> /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /f/: Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    test "refuses a trailing dot component too" do
+      {result, bash} = JustBash.exec(bash(), "echo hi > /f/.")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /f/.: Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ echo hi > nope/
+    # bash: nope/: No such file or directory
+    test "will not create the file a slash promised would be a directory" do
+      {result, bash} = JustBash.exec(bash(), "echo hi > /nope/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /nope/: No such file or directory\n"
+      refute exists?(bash, "/nope")
+    end
+
+    # $ echo hi > d/
+    # bash: d/: Is a directory
+    test "a directory is still a directory when spelled with the slash" do
+      {result, _bash} = JustBash.exec(bash(), "echo hi > /d/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: /d/: Is a directory\n"
+    end
+
+    # $ echo hi 2> f/
+    # bash: f/: Not a directory
+    test "the stderr and combined forms are refused as well" do
+      {stderr_redirect, bash} = JustBash.exec(bash(), "echo hi 2> /f/")
+      assert stderr_redirect.exit_code == 1
+      assert stderr_redirect.stderr == "bash: /f/: Not a directory\n"
+
+      {combined, bash} = JustBash.exec(bash, "echo hi &> /f/")
+      assert combined.exit_code == 1
+      assert combined.stderr == "bash: /f/: Not a directory\n"
+
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # A target that cannot be opened means the command never runs, so its
+    # side effects never happen either.
+    test "the command body does not run" do
+      {result, bash} = JustBash.exec(bash(), "touch /made.md > /f/")
+
+      assert result.exit_code == 1
+      refute exists?(bash, "/made.md")
+    end
+  end
+
+  describe "other commands that write to a named destination" do
+    # $ echo hi | tee f/
+    # tee: f/: Not a directory
+    test "tee refuses the target but still passes stdin through" do
+      {result, bash} = JustBash.exec(bash(), "echo hi | tee /f/")
+
+      assert result.exit_code == 1
+      assert result.stdout == "hi\n"
+      assert result.stderr == "tee: /f/: Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ echo hi | tee nope/
+    # tee: nope/: No such file or directory
+    test "tee will not create the file a slash promised would be a directory" do
+      {result, bash} = JustBash.exec(bash(), "echo hi | tee /nope/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "tee: /nope/: No such file or directory\n"
+      refute exists?(bash, "/nope")
+    end
+
+    # $ ln -s a.md f/
+    # ln: failed to create symbolic link 'f/': Not a directory
+    test "ln refuses to create a link at a non-directory" do
+      {result, bash} = JustBash.exec(bash(), "ln -s /a.md /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "ln: failed to create symbolic link '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # `-f` unlinks the destination before linking, so the check has to come
+    # first: GNU words this one "failed to access 'f/'", but the file it must
+    # not delete is the point.
+    test "ln -sf does not remove the file it may not link over" do
+      {result, bash} = JustBash.exec(bash(), "ln -sf /a.md /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "Not a directory"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ touch f/
+    # touch: cannot touch 'f/': Not a directory
+    test "touch refuses a non-directory spelled as one" do
+      {result, _bash} = JustBash.exec(bash(), "touch /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "touch: cannot touch '/f/': Not a directory\n"
+    end
+
+    # $ touch nope/
+    # touch: cannot touch 'nope/': No such file or directory
+    test "touch will not create the file a slash promised would be a directory" do
+      {result, bash} = JustBash.exec(bash(), "touch /nope/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "touch: cannot touch '/nope/': No such file or directory\n"
+      refute exists?(bash, "/nope")
+    end
+
+    # $ touch d/   (exit 0: the promise holds)
+    test "touch accepts a real directory" do
+      {result, _bash} = JustBash.exec(bash(), "touch /d/")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+    end
+  end
+
+  describe "FS.directory_spelling?/1" do
+    test "a trailing slash and the dot components it implies demand a directory" do
+      assert FS.directory_spelling?("/f/")
+      assert FS.directory_spelling?("f/")
+      assert FS.directory_spelling?("/f/.")
+      assert FS.directory_spelling?("/f/..")
+      assert FS.directory_spelling?(".")
+      assert FS.directory_spelling?("..")
+      assert FS.directory_spelling?("/")
+    end
+
+    test "a plain path demands nothing" do
+      refute FS.directory_spelling?("/f")
+      refute FS.directory_spelling?("f")
+      refute FS.directory_spelling?("/a/b.md")
+      refute FS.directory_spelling?("..f")
+      refute FS.directory_spelling?("/f/...")
+    end
+
+    # An empty operand names nothing at all, which is a different complaint
+    # from the one this rule makes.
+    test "an empty path demands nothing" do
+      refute FS.directory_spelling?("")
+    end
+  end
+
+  describe "FS.check_directory_spelling/3" do
+    test "passes a path that makes no demand" do
+      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/f", "/f")
+    end
+
+    test "passes a directory" do
+      assert {:ok, _fs} = FS.check_directory_spelling(fs(), "/d/", "/d")
+    end
+
+    test "returns :enotdir for a non-directory, naming the operand as spelled" do
+      assert {:error, %VFS.Error{kind: :enotdir, path: "/f/"}} =
+               FS.check_directory_spelling(fs(), "/f/", "/f")
+    end
+
+    test "returns the error stat gave for a path that is not there" do
+      assert {:error, %VFS.Error{kind: :enoent}} =
+               FS.check_directory_spelling(fs(), "/nope/", "/nope")
+    end
+  end
+end

--- a/test/just_bash/trailing_slash_test.exs
+++ b/test/just_bash/trailing_slash_test.exs
@@ -437,14 +437,41 @@ defmodule JustBash.TrailingSlashTest do
     end
 
     # `-f` unlinks the destination before linking, so the check has to come
-    # first: GNU words this one "failed to access 'f/'", but the file it must
-    # not delete is the point.
+    # first — the file it must not delete is the point. GNU lstats the
+    # destination under `--force` and reports *that* failure instead:
+    #
+    #     $ ln -sf a.md f/  ln: failed to access 'f/': Not a directory
+    #     $ ln -f  a.md f/  ln: failed to access 'f/': Not a directory
     test "ln -sf does not remove the file it may not link over" do
       {result, bash} = JustBash.exec(bash(), "ln -sf /a.md /f/")
 
       assert result.exit_code == 1
-      assert result.stderr =~ "Not a directory"
+      assert result.stderr == "ln: failed to access '/f/': Not a directory\n"
       assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    test "ln -f reports the same failed access without -s" do
+      {result, bash} = JustBash.exec(bash(), "ln -f /a.md /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "ln: failed to access '/f/': Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    # $ ln -sf a.md nope/
+    # ln: failed to create symbolic link 'nope/': No such file or directory
+    #
+    # Nothing is there to lstat, so `--force` has nothing to report and the
+    # create it goes on to attempt is what fails.
+    test "ln -sf onto a missing destination still reports the failed create" do
+      {result, bash} = JustBash.exec(bash(), "ln -sf /a.md /nope/")
+
+      assert result.exit_code == 1
+
+      assert result.stderr ==
+               "ln: failed to create symbolic link '/nope/': No such file or directory\n"
+
+      refute exists?(bash, "/nope")
     end
 
     # $ sed -i s/F/Z/ f/

--- a/test/just_bash/trailing_slash_test.exs
+++ b/test/just_bash/trailing_slash_test.exs
@@ -447,6 +447,45 @@ defmodule JustBash.TrailingSlashTest do
       assert {:ok, "F\n", _fs} = read(bash, "/f")
     end
 
+    # $ sed -i s/F/Z/ f/
+    # sed: can't read f/: Not a directory
+    #
+    # Real sed never opens `f/` — `open("f/")` is ENOTDIR — so the file it
+    # would have edited is left alone. (Our diagnostics for sed operands are
+    # spelled `sed: <operand>: <reason>` throughout, GNU's `can't read`
+    # prefix predates this rule and is not what #58 is about.)
+    test "sed -i refuses to edit through a destination spelled as a directory" do
+      {result, bash} = JustBash.exec(bash(), "sed -i 's/F/Z/' /f/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "sed: /f/: Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    test "sed -i refuses a trailing dot component too" do
+      {result, bash} = JustBash.exec(bash(), "sed -i 's/F/Z/' /f/.")
+
+      assert result.exit_code == 1
+      assert result.stderr == "sed: /f/.: Not a directory\n"
+      assert {:ok, "F\n", _fs} = read(bash, "/f")
+    end
+
+    test "sed -i will not create the file a slash promised would be a directory" do
+      {result, bash} = JustBash.exec(bash(), "sed -i 's/F/Z/' /nope/")
+
+      assert result.exit_code == 1
+      assert result.stderr == "sed: /nope/: No such file or directory\n"
+      refute exists?(bash, "/nope")
+    end
+
+    test "sed -i still edits a file named without the slash" do
+      {result, bash} = JustBash.exec(bash(), "sed -i 's/F/Z/' /f")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert {:ok, "Z\n", _fs} = read(bash, "/f")
+    end
+
     # $ touch f/
     # touch: cannot touch 'f/': Not a directory
     test "touch refuses a non-directory spelled as one" do

--- a/test/just_bash/trailing_slash_test.exs
+++ b/test/just_bash/trailing_slash_test.exs
@@ -331,6 +331,42 @@ defmodule JustBash.TrailingSlashTest do
     end
   end
 
+  # bash names a redirect target the way the operand was written, not where it
+  # resolved — the two only read alike when the operand is already absolute.
+  # bash 5, in a directory holding the regular file `keep`:
+  #
+  #     $ cd d && echo hi > keep/x  bash: keep/x: Not a directory
+  #     $ cd d && echo hi > keep/   bash: keep/: Not a directory
+  #     $ cd d && echo hi > nope/   bash: nope/: No such file or directory
+  #     $ echo hi > ''              bash: : No such file or directory
+  describe "redirection names the target the way the operand spelled it" do
+    for {command, message} <- [
+          {"cd /d && echo hi > keep/x", "bash: keep/x: Not a directory\n"},
+          {"cd /d && echo hi > keep/", "bash: keep/: Not a directory\n"},
+          {"cd /d && echo hi >> keep/", "bash: keep/: Not a directory\n"},
+          {"cd /d && echo hi > nope/", "bash: nope/: No such file or directory\n"},
+          {"cd /d && echo hi > ../f/", "bash: ../f/: Not a directory\n"}
+        ] do
+      test "`#{command}`" do
+        {result, bash} = JustBash.exec(bash(), unquote(command))
+
+        assert result.exit_code == 1
+        assert result.stderr == unquote(message)
+        assert {:ok, "K\n", _fs} = read(bash, "/d/keep")
+        assert {:ok, "F\n", _fs} = read(bash, "/f")
+      end
+    end
+
+    # An empty target names nothing at all — `open("")` is ENOENT, not a
+    # write to the working directory that resolving it would produce.
+    test "an empty target is reported as the nothing it names" do
+      {result, _bash} = JustBash.exec(bash(), "echo hi > ''")
+
+      assert result.exit_code == 1
+      assert result.stderr == "bash: : No such file or directory\n"
+    end
+  end
+
   describe "output redirection to a target spelled as a directory" do
     # $ cat a.md > f/
     # bash: f/: Not a directory


### PR DESCRIPTION
Closes #58

## What was broken

POSIX resolves `f/` as `f/.`, so a trailing slash asserts that the path is a
directory. `FS.resolve_path/2` normalizes it away, so a command that only sees
the resolved path cannot tell `f` from `f/` — and wrote straight through it.
The repro from the issue:

```elixir
b = JustBash.new(files: %{"/a.md" => "A\n", "/f" => "F\n"})
{r, b} = JustBash.exec(b, "cp /a.md /f/")
r.exit_code #=> 0
elem(JustBash.exec(b, "cat /f"), 0).stdout #=> "A\n"   # /f overwritten
```

Real bash / GNU coreutils 9.11:

```
$ cp a.md f/
cp: cannot stat 'f/': Not a directory
$ echo $?
1
```

The sibling shapes named in the issue behaved the same way — `mv /a.md /f/`
silently overwrote `/f` *and* deleted `/a.md`, and `cat /a.md > /f/` truncated
it. Surveying the other commands whose command-line operand names a file they
write turned up four more: `tee /f/` overwrote it, `touch /f/` was a silent
no-op, `sed -i s/F/Z/ /f/` rewrote it, and `ln -sf /a.md /f/` **unlinked `/f`**
before failing to create the link.

## What the fix does

The issue argued the fix belongs at the path layer, and it does — the operand's
spelling is the only place the information survives. Two new functions in
`JustBash.FS`:

- `directory_spelling?/1` — pure: does this operand's spelling demand a
  directory? A trailing slash, or the `.` / `..` components it stands for.
  (An empty operand names nothing at all, which is a different complaint.)
- `check_directory_spelling/3` — takes the operand's base and its spelling and
  holds it to that promise, returning the error a real `stat("f/")` gives:
  `:enotdir` when something that is not a directory is already there (naming
  the operand as spelled, since that is what gets reported), `:enoent` when
  nothing is there at all.

The demand is made about **the last component the operand names outright** —
everything before the run of `/`, `.` and `..` trailing it — not about where
`resolve_path/2` says the whole thing lands. `..` is collapsed lexically, so
`/f/..` resolves to `/`, a directory whatever `/f` is, while the kernel cannot
walk up out of the regular file `/f` at all. Holding that one path is enough:
every component the run walks through afterwards is an ancestor of it, and an
ancestor of a directory is a directory.

Each destination-taking command combines that with **what it is about to put
there**, which is the distinction GNU makes:

| command | existing non-directory | missing |
|---|---|---|
| `cp a.md f/` | `cp: cannot stat 'f/': Not a directory` | `cp: cannot create regular file 'nope/': No such file or directory` |
| `cp -r d f/` | `cp: cannot stat 'f/': Not a directory` | creates the directory — the copy makes the promise true |
| `mv a.md f/` | `mv: cannot stat 'f/': Not a directory` | `mv: cannot move 'a.md' to 'nope/': No such file or directory` |
| `mv d f/` | `mv: cannot stat 'f/': Not a directory` | renames the directory |
| `> f/` | `bash: f/: Not a directory` | `bash: nope/: No such file or directory` |
| `tee f/` | `tee: f/: Not a directory` | `tee: nope/: No such file or directory` |
| `sed -i s/x/y/ f/` | `sed: f/: Not a directory` | `sed: nope/: No such file or directory` |
| `ln -s a.md f/` | `ln: failed to create symbolic link 'f/': Not a directory` | same, `No such file or directory` |
| `ln -sf a.md f/` | `ln: failed to access 'f/': Not a directory` | `ln: failed to create symbolic link 'nope/': No such file or directory` |
| `touch f/` | `touch: cannot touch 'f/': Not a directory` | `touch: cannot touch 'nope/': No such file or directory` |

A directory target keeps its own diagnostic: `> d/` is still
`bash: d/: Is a directory`, and `touch d/` still exits 0. So does `touch d/..`,
and a bare `touch ..`.

Details that fall out of matching bash rather than bolting a check on the front:

- `mv` stats the source first, then judges the destination's spelling, and only
  then asks whether the two name the same file — the order bash uses. So
  `mv /missing.md /f/` reports the missing source, `mv /nope.md /nope.md`
  reports `cannot stat` rather than `are the same file`, and
  `mv /d/keep /d/` is still refused as a same-file move rather than becoming a
  silent exit-0 no-op. Its `execute/3` body was split into named steps
  (`source_type` → `destination_directory` → `distinct` → `rename`) to make
  room without going past credo's nesting limit.
- `cp -n` no longer quietly "keeps" a destination that the spelling says is not
  a file, and `cp /a.md /a.md/` is a failed stat rather than a self-copy —
  `a.md/` is not a name the regular file `a.md` has. A destination whose
  spelling does not hold is also not a directory the copy may land inside, so
  it never gains the source's basename.
- `ln` checks before `-f` unlinks anything, which is the whole point for
  `ln -sf a.md f/`. GNU words the `--force` case differently — it lstats the
  destination first and reports *that* failure (`failed to access`) — except
  for `:enoent`, where there is nothing to unlink and the create it goes on to
  attempt is what fails.
- Redirection names the target the way it was written rather than where it
  resolved (`bash: f/: …`, not `bash: /w/f: …`). That is what bash prints, and
  it is the only spelling that can carry the slash. An empty target is
  `bash: : No such file or directory` — `open("")` is ENOENT, not a write to
  the working directory that resolving it would produce.

## Tests

New `test/just_bash/trailing_slash_test.exs` — 75 tests. Every message was
taken from a real shell (GNU coreutils 9.11 / bash 5) and the transcript is
quoted next to the case that asserts it. Each destructive case asserts the
destination is **still intact** as well as the exit code and diagnostic. The
corpus covers: `cp` (plain, `-r`, `-n`, `-P`, `f/.`, self-copy, missing
destination, three-operand target, and symlinks to a file *and* to a
directory), `mv` (file, directory, missing destination, missing-source
ordering, and eight spellings of a destination that resolves back to the
source), redirection (`>`, `>>`, `2>`, `&>`, directory target, missing target,
relative targets under a non-root cwd, an empty target, and that the command
body never runs), `tee`, `ln -s`, `ln -sf`, `ln -f`, `sed -i`, `touch`, a
`{command, expected}` table covering `..` across six commands, plus unit tests
for both `FS` functions.

Regression guards that already passed (copying/moving into a real directory,
`cp -r d nope/`, `cp a.md b.md f/`, `touch d/`, `touch d/..`, `sed -i` on a
plain name) are kept in the file so the fix cannot over-correct into refusing
legitimate directory destinations.

## Left out, deliberately

- **Read-side operands** (`cat f/`, `grep … f/`, `ls f/`, `sed f/` without
  `-i`). GNU rejects these too, but the issue is about destinations and the
  read side is a much wider surface; worth its own issue.
- **`rm f/` and `mkdir f/`.** `rm /f/` still removes `/f` (GNU: `rm: cannot
  remove 'f/': Not a directory`) — same rule, but a removal operand rather than
  a destination, and it drags `rm -f` precedence in with it. `mkdir`/`rmdir`
  already require a directory, so only the wording differs there.
- **`curl -o f/` / `wget -O f/`.** Same shape, but the write happens after a
  network fetch and behind the HTTP-client mock, so it belongs with a change
  that can test that path properly.
- **awk's in-program `print > "f/"`.** An awk redirection rather than a shell
  operand, and awk does not resolve the filename against the cwd either —
  a separate, pre-existing gap.
- **`cp -r src nested/deep/`.** GNU refuses to create missing parents; we
  create them. Pre-existing and independent of the slash (`cp -r src
  nested/deep` behaves the same way).
- **A non-final `..` after a non-directory** (`cp a.md f/../g`). `resolve_path/2`
  collapses it lexically the same way, so we create `/g` where GNU reports
  `Not a directory`. That is a `resolve_path/2` gap rather than a destination
  gap, and it needs component-wise resolution to fix properly.
- **`mv` naming each side of "are the same file" as spelled.** GNU prints
  `mv: 'd/keep' and 'd/./keep' are the same file`; we name both by where they
  resolved. Pre-existing, and the refusal is what #58 is about.
- **No new bash fixtures.** Recording the corpus needs Docker (`mix
  bash_fixtures`), so the oracle is quoted in comments instead.

## Gates

```
$ mix compile --force --warnings-as-errors
Compiling 168 files (.ex)
Generated just_bash app

$ mix format --check-formatted
(no output, exit 0)

$ mix credo --strict
  Refactoring opportunities
┃
┃ [F] ↘ Avoid `apply/2` and `apply/3` when the number of arguments is known.
┃       test/support/banned_fixture_apply.ex:4:16 #(BannedCallTracer.Fixture.Apply.run)

Analysis took 1.8 seconds (0.1s to load, 1.7s running 68 checks on 230 files)
5147 mods/funs, found 1 refactoring opportunity.
```

(the one credo finding is the pre-existing intentional test fixture)

```
$ mix test
Finished in 27.0 seconds (26.7s async, 0.2s sync)
2 doctests, 62 properties, 4827 tests, 0 failures (5 excluded)

$ mix dialyzer
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done in 0m3.11s
done (passed successfully)
```
