### PR TITLE
fix: grep BRE alternation, missing-path exit code, and flag-level did-you-mean

### DIFF
--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -685,7 +685,7 @@ defmodule JustBash.CLI do
   defp dispatch_leaf(cli, %Command{} = leaf, path, rest, bash, stdin) do
     label = command_label(cli, path)
 
-    with {:ok, flags, positional, extra} <- parse_leaf_args(leaf, rest, label),
+    with {:ok, flags, positional, extra} <- parse_leaf_args(cli, leaf, path, rest, label),
          :ok <- validate_positionals(leaf.args, positional, label),
          invocation = build_invocation(leaf, flags, positional, extra, bash, stdin, path),
          :ok <- run_validate(leaf, invocation) do
@@ -699,15 +699,59 @@ defmodule JustBash.CLI do
   # Parse a leaf's flags, normalizing to a 4-tuple so the caller is uniform. A leaf that
   # opts into `allow_unknown_flags` collects undeclared flags into `extra`; otherwise `extra`
   # is always empty.
-  defp parse_leaf_args(%Command{allow_unknown_flags: true} = leaf, rest, label) do
-    ArgParser.parse(rest, leaf.flags, command: label, collect_unknown: true)
+  defp parse_leaf_args(cli, %Command{allow_unknown_flags: true} = leaf, path, rest, label) do
+    ArgParser.parse(rest, leaf.flags,
+      command: label,
+      collect_unknown: true,
+      on_unknown_flag: &sibling_flag_hint(cli, path, &1)
+    )
   end
 
-  defp parse_leaf_args(%Command{} = leaf, rest, label) do
-    case ArgParser.parse(rest, leaf.flags, command: label) do
+  defp parse_leaf_args(cli, %Command{} = leaf, path, rest, label) do
+    opts = [command: label, on_unknown_flag: &sibling_flag_hint(cli, path, &1)]
+
+    case ArgParser.parse(rest, leaf.flags, opts) do
       {:ok, flags, positional} -> {:ok, flags, positional, []}
       {:error, _} = err -> err
     end
+  end
+
+  # A leaf rejecting an undeclared flag is one hop from the fix when a sibling command in
+  # the same group declares that exact flag — e.g. `dol log metric --weight` when `dol log
+  # weight` is the leaf that takes `--weight`. This is not fuzzy matching like
+  # `Help.unknown_subcommand/4`'s Jaro suggestion: the flag either is or isn't declared
+  # elsewhere in the group, so an exact declaration match is the whole signal.
+  #
+  # Lives here (rather than in `ArgParser`) because only the CLI tree has a notion of
+  # "sibling commands in the same group" — `ArgParser.parse/3` only ever sees one leaf's
+  # flag spec, threaded in through the `:on_unknown_flag` hook.
+  defp sibling_flag_hint(cli, path, flag) do
+    current_name = List.last(path)
+    group_path = Enum.drop(path, -1)
+
+    cli.commands
+    |> resolve_group_commands(group_path)
+    |> Enum.reject(&(&1.name == current_name or Command.group?(&1)))
+    |> Enum.find(&flag_declared?(&1.flags, flag))
+    |> case do
+      nil -> nil
+      %Command{name: name} -> "did you mean '#{command_label(cli, group_path ++ [name])}'?"
+    end
+  end
+
+  defp resolve_group_commands(commands, []), do: commands
+
+  defp resolve_group_commands(commands, [name | rest]) do
+    case Enum.find(commands, &(&1.name == name)) do
+      %Command{commands: children} -> resolve_group_commands(children, rest)
+      nil -> []
+    end
+  end
+
+  defp flag_declared?(flags, flag) do
+    Enum.any?(flags, fn {_name, spec} ->
+      flag == spec[:short] or flag == spec[:long] or flag in (spec[:aliases] || [])
+    end)
   end
 
   defp build_invocation(_leaf, flags, positional, extra, bash, stdin, path) do

--- a/lib/just_bash/cli.ex
+++ b/lib/just_bash/cli.ex
@@ -720,7 +720,11 @@ defmodule JustBash.CLI do
   # the same group declares that exact flag — e.g. `dol log metric --weight` when `dol log
   # weight` is the leaf that takes `--weight`. This is not fuzzy matching like
   # `Help.unknown_subcommand/4`'s Jaro suggestion: the flag either is or isn't declared
-  # elsewhere in the group, so an exact declaration match is the whole signal.
+  # elsewhere in the group, so an exact declaration match is the whole signal — as long as
+  # that match is unique. `--verbose`, `--json` and `--force` are routinely declared by
+  # several leaves in one group, and there the first sibling in declaration order carries
+  # no more information than any other; a confidently-worded pointer at an arbitrary one
+  # is worse than none, so an ambiguous match yields no hint.
   #
   # Lives here (rather than in `ArgParser`) because only the CLI tree has a notion of
   # "sibling commands in the same group" — `ArgParser.parse/3` only ever sees one leaf's
@@ -732,10 +736,10 @@ defmodule JustBash.CLI do
     cli.commands
     |> resolve_group_commands(group_path)
     |> Enum.reject(&(&1.name == current_name or Command.group?(&1)))
-    |> Enum.find(&flag_declared?(&1.flags, flag))
+    |> Enum.filter(&flag_declared?(&1.flags, flag))
     |> case do
-      nil -> nil
-      %Command{name: name} -> "did you mean '#{command_label(cli, group_path ++ [name])}'?"
+      [%Command{name: name}] -> "did you mean '#{command_label(cli, group_path ++ [name])}'?"
+      _ambiguous_or_none -> nil
     end
   end
 

--- a/lib/just_bash/commands/arg_parser.ex
+++ b/lib/just_bash/commands/arg_parser.ex
@@ -63,7 +63,14 @@ defmodule JustBash.Commands.ArgParser do
   # Parser context struct to reduce function arity
   defmodule Context do
     @moduledoc false
-    defstruct [:short_map, :long_map, :command, :allow_unknown, :collect_unknown]
+    defstruct [
+      :short_map,
+      :long_map,
+      :command,
+      :allow_unknown,
+      :collect_unknown,
+      :on_unknown_flag
+    ]
   end
 
   @doc """
@@ -82,6 +89,11 @@ defmodule JustBash.Commands.ArgParser do
       `{:ok, opts, positional, extra}`. Positionals stay out of `extra`, so a host can
       forward the raw `extra` tokens to a backend whose flags aren't known at definition
       time. `--flag=value` is forwarded as a single token.
+    * `:on_unknown_flag` — a `(flag_name :: String.t() -> String.t() | nil)` called with the
+      bare flag (no `=value`) when it would otherwise be a hard error. A non-nil return is
+      appended to the "unknown option" message, e.g. to point at a sibling command that
+      declares the same flag. Never called in `:allow_unknown`/`:collect_unknown` mode,
+      since there the flag isn't an error at all.
   """
   @spec parse([String.t()], flags_spec(), keyword()) ::
           {:ok, map(), [String.t()]}
@@ -97,7 +109,8 @@ defmodule JustBash.Commands.ArgParser do
       long_map: long_map,
       command: Keyword.get(opts, :command, ""),
       allow_unknown: Keyword.get(opts, :allow_unknown, false),
-      collect_unknown: collect_unknown
+      collect_unknown: collect_unknown,
+      on_unknown_flag: Keyword.get(opts, :on_unknown_flag)
     }
 
     # Parse into a map of only the flags that were actually provided, so we can
@@ -243,7 +256,7 @@ defmodule JustBash.Commands.ArgParser do
     cond do
       ctx.collect_unknown -> parse_loop(args, ctx, opts, positional, [arg | extra])
       ctx.allow_unknown -> parse_loop(args, ctx, opts, [arg | positional], extra)
-      true -> {:error, format_unknown_error(ctx.command, arg)}
+      true -> {:error, format_unknown_error(ctx, arg)}
     end
   end
 
@@ -260,7 +273,7 @@ defmodule JustBash.Commands.ArgParser do
         parse_loop(args, ctx, opts, [flag | positional], extra)
 
       true ->
-        {:error, format_unknown_error(ctx.command, flag)}
+        {:error, format_unknown_error(ctx, flag)}
     end
   end
 
@@ -405,6 +418,26 @@ defmodule JustBash.Commands.ArgParser do
     if String.ends_with?(message, "\n"), do: message, else: message <> "\n"
   end
 
-  defp format_unknown_error("", flag), do: "unknown option: #{flag}\n"
-  defp format_unknown_error(cmd, flag), do: "#{cmd}: unknown option: #{flag}\n"
+  # `raw_flag` may carry a `=value` suffix (the `--flag=value` self-contained form); the
+  # sibling lookup needs the bare flag name, but the message still echoes what the caller
+  # actually typed.
+  defp format_unknown_error(ctx, raw_flag) do
+    base =
+      case ctx.command do
+        "" -> "unknown option: #{raw_flag}\n"
+        cmd -> "#{cmd}: unknown option: #{raw_flag}\n"
+      end
+
+    flag_name = raw_flag |> String.split("=", parts: 2) |> List.first()
+
+    case unknown_flag_hint(ctx, flag_name) do
+      nil -> base
+      hint -> String.trim_trailing(base, "\n") <> " — #{hint}\n"
+    end
+  end
+
+  defp unknown_flag_hint(%Context{on_unknown_flag: nil}, _flag), do: nil
+
+  defp unknown_flag_hint(%Context{on_unknown_flag: fun}, flag) when is_function(fun, 1),
+    do: fun.(flag)
 end

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -239,24 +239,44 @@ defmodule JustBash.Commands.Grep do
     Limit.check_regex_size!(bash.limits, pattern)
     opts = if flags.i, do: [:caseless], else: []
 
+    base_pattern =
+      if flags.f_fixed do
+        Regex.escape(pattern)
+      else
+        bre_alternation_to_pcre(pattern, flags)
+      end
+
     regex_pattern =
       cond do
-        flags.f_fixed ->
-          Regex.escape(pattern)
-
-        flags.w ->
-          "\\b" <> pattern <> "\\b"
-
-        flags.x ->
-          "^" <> pattern <> "$"
-
-        true ->
-          pattern
+        flags.w -> "\\b" <> base_pattern <> "\\b"
+        flags.x -> "^" <> base_pattern <> "$"
+        true -> base_pattern
       end
 
     case Regex.compile(regex_pattern, opts) do
       {:ok, regex} -> regex
       {:error, _} -> Regex.compile!(Regex.escape(pattern), opts)
+    end
+  end
+
+  # Real `grep` without `-E`/`-P` is BRE, where `\|` is alternation. This is
+  # PCRE (`Regex.compile/2`), where `\|` is an escaped literal pipe — and
+  # `\|` compiles cleanly either way, so passing a BRE pattern through
+  # unchanged never hits the `{:error, _}` fallback above. It just silently
+  # matches a literal pipe character that the input almost never contains,
+  # turning the single most common agent idiom (`grep -r "a\|b"`) into a
+  # quiet false negative instead of a compile error.
+  #
+  # This rewrites only `\|` -> `|`. Full BRE emulation — bare `(`, `)`, `{`
+  # as literals, `\(...\)` as groups, `\{n,m\}` as bounds — is a much larger
+  # surface with more ways to get it partially right, and is left alone
+  # rather than half-translated. `\|` is the dominant idiom and the one that
+  # caused the incident this fixes, so it is handled on its own.
+  defp bre_alternation_to_pcre(pattern, flags) do
+    if flags.e_ext or flags.p_pcre do
+      pattern
+    else
+      String.replace(pattern, "\\|", "|")
     end
   end
 

--- a/lib/just_bash/commands/grep.ex
+++ b/lib/just_bash/commands/grep.ex
@@ -99,9 +99,16 @@ defmodule JustBash.Commands.Grep do
     show_filename =
       flags.with_filename or (length(expanded_files) > 1 and not flags.no_filename)
 
+    # `-q` is specified to exit "immediately ... if any match is found", so real
+    # grep never opens the operands after the first matching one and never
+    # reports their errors. Halting is that short-circuit — and it keeps the
+    # error of an operand read *before* the match, which GNU also prints.
     {results, any_match, errors, fs} =
-      Enum.reduce(expanded_files, {[], false, "", bash.fs}, fn file, acc ->
-        process_file(bash, file, stdin, regex, flags, show_filename, acc)
+      Enum.reduce_while(expanded_files, {[], false, "", bash.fs}, fn file, acc ->
+        case process_file(bash, file, stdin, regex, flags, show_filename, acc) do
+          {_, true, _, _} = matched when flags.q -> {:halt, matched}
+          next -> {:cont, next}
+        end
       end)
 
     build_files_result(%{bash | fs: fs}, results, any_match, errors, flags)
@@ -243,13 +250,16 @@ defmodule JustBash.Commands.Grep do
       if flags.f_fixed do
         Regex.escape(pattern)
       else
-        bre_alternation_to_pcre(pattern, flags)
+        bre_pipes_to_pcre(pattern, flags)
       end
 
+    # The group is not cosmetic: `\bfoo|bar\b` is read as `(\bfoo)|(bar\b)`,
+    # so each anchor would bind to a single branch and `-w`/`-x` would admit
+    # unanchored matches of every other one.
     regex_pattern =
       cond do
-        flags.w -> "\\b" <> base_pattern <> "\\b"
-        flags.x -> "^" <> base_pattern <> "$"
+        flags.w -> "\\b(?:" <> base_pattern <> ")\\b"
+        flags.x -> "^(?:" <> base_pattern <> ")$"
         true -> base_pattern
       end
 
@@ -259,26 +269,47 @@ defmodule JustBash.Commands.Grep do
     end
   end
 
-  # Real `grep` without `-E`/`-P` is BRE, where `\|` is alternation. This is
-  # PCRE (`Regex.compile/2`), where `\|` is an escaped literal pipe — and
-  # `\|` compiles cleanly either way, so passing a BRE pattern through
-  # unchanged never hits the `{:error, _}` fallback above. It just silently
-  # matches a literal pipe character that the input almost never contains,
-  # turning the single most common agent idiom (`grep -r "a\|b"`) into a
-  # quiet false negative instead of a compile error.
+  # Real `grep` without `-E`/`-P` is BRE, where `\|` is alternation and a bare
+  # `|` is an ordinary character. This is PCRE (`Regex.compile/2`), where those
+  # two meanings are exactly swapped — and both spellings compile cleanly either
+  # way, so a BRE pattern passed through unchanged never reaches the
+  # `{:error, _}` fallback above. It just quietly matches something else: `a\|b`
+  # looks for a literal pipe the input almost never contains, turning the single
+  # most common agent idiom (`grep -r "a\|b"`) into a false negative, while
+  # `a|b` matches either half of a pattern whose author meant it verbatim.
   #
-  # This rewrites only `\|` -> `|`. Full BRE emulation — bare `(`, `)`, `{`
-  # as literals, `\(...\)` as groups, `\{n,m\}` as bounds — is a much larger
-  # surface with more ways to get it partially right, and is left alone
-  # rather than half-translated. `\|` is the dominant idiom and the one that
-  # caused the incident this fixes, so it is handled on its own.
-  defp bre_alternation_to_pcre(pattern, flags) do
+  # One left-to-right scan fixes both, and scanning is what makes the escaped
+  # forms come out right. `a\\|b` is a literal backslash followed by a BRE pipe;
+  # a blind `String.replace(pattern, "\\|", "|")` finds a `\|` straddling the
+  # backslash pair and rewrites it, so the pattern ends up matching the literal
+  # text `a|b`. Consuming each backslash together with the character it escapes
+  # means an escaped character is never re-read as syntax.
+  #
+  # Only the pipe is translated. Full BRE emulation — bare `(`, `)`, `{` as
+  # literals, `\(...\)` as groups, `\{n,m\}` as bounds — is a much larger
+  # surface with more ways to land partially right, and is left alone rather
+  # than half-translated.
+  defp bre_pipes_to_pcre(pattern, flags) do
     if flags.e_ext or flags.p_pcre do
       pattern
     else
-      String.replace(pattern, "\\|", "|")
+      pattern |> do_bre_pipes_to_pcre([]) |> IO.iodata_to_binary()
     end
   end
+
+  defp do_bre_pipes_to_pcre(<<>>, acc), do: Enum.reverse(acc)
+
+  defp do_bre_pipes_to_pcre(<<"\\|", rest::binary>>, acc),
+    do: do_bre_pipes_to_pcre(rest, ["|" | acc])
+
+  defp do_bre_pipes_to_pcre(<<"\\", escaped::binary-size(1), rest::binary>>, acc),
+    do: do_bre_pipes_to_pcre(rest, ["\\" <> escaped | acc])
+
+  defp do_bre_pipes_to_pcre(<<"|", rest::binary>>, acc),
+    do: do_bre_pipes_to_pcre(rest, ["\\|" | acc])
+
+  defp do_bre_pipes_to_pcre(<<char::binary-size(1), rest::binary>>, acc),
+    do: do_bre_pipes_to_pcre(rest, [char | acc])
 
   defp grep_line(line, regex, flags, line_num, prefix) do
     matches = Regex.match?(regex, line)

--- a/test/cli/routing_test.exs
+++ b/test/cli/routing_test.exs
@@ -157,6 +157,36 @@ defmodule JustBash.CLI.RoutingTest do
     end
   end
 
+  describe "flag-level did-you-mean" do
+    test "an unknown long flag declared by a sibling leaf names it" do
+      result = run("acme pr open 1 --report 5")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: --report — did you mean 'acme pr review'?"
+    end
+
+    test "an unknown short flag declared by a sibling leaf names it" do
+      result = run("acme pr open 1 -v")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: -v — did you mean 'acme pr review'?"
+    end
+
+    test "an unknown flag no sibling declares gets no suggestion" do
+      result = run("acme pr open 1 --bogus x")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: --bogus\n"
+      refute result.stderr =~ "did you mean"
+    end
+
+    test "a flag declared by a leaf in a different group is not suggested" do
+      # `--report` belongs to `pr review`; `product list` is a sibling of `product`, not of
+      # `pr review`, so the group-scoped lookup must not reach across groups.
+      result = run("acme product list --report 5")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: --report\n"
+      refute result.stderr =~ "did you mean"
+    end
+  end
+
   describe "passthrough flags" do
     defp passthrough_cli do
       CLI.new("acme",

--- a/test/cli/routing_test.exs
+++ b/test/cli/routing_test.exs
@@ -185,6 +185,63 @@ defmodule JustBash.CLI.RoutingTest do
       assert result.stderr =~ "unknown option: --report\n"
       refute result.stderr =~ "did you mean"
     end
+
+    # `--verbose`, `--json` and `--force` are routinely declared by several leaves in one
+    # group. The hint's whole claim to confidence is that an exact declaration match names
+    # *the* command the caller wanted — which only holds while the match is unique.
+    defp ambiguous_cli do
+      leaf = fn name ->
+        CLI.command(name,
+          doc: "Emit #{name}",
+          flags: [verbose: [type: :boolean, short: "-v"]],
+          run: fn inv -> {Command.ok("#{name}\n"), inv.bash} end
+        )
+      end
+
+      CLI.new("dol",
+        commands: [
+          CLI.command("log",
+            doc: "Logging",
+            commands: [
+              leaf.("metric"),
+              leaf.("event"),
+              CLI.command("tail",
+                doc: "Tail the log",
+                run: fn inv -> {Command.ok("tail\n"), inv.bash} end
+              )
+            ]
+          )
+        ]
+      )
+    end
+
+    defp run_ambiguous(script) do
+      bash = JustBash.new(commands: %{"dol" => ambiguous_cli()})
+      {result, _bash} = JustBash.exec(bash, script)
+      result
+    end
+
+    test "an unknown flag several siblings declare gets no suggestion" do
+      result = run_ambiguous("dol log tail --verbose")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: --verbose\n"
+      refute result.stderr =~ "did you mean"
+    end
+
+    test "an unknown short flag several siblings declare gets no suggestion" do
+      result = run_ambiguous("dol log tail -v")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: -v\n"
+      refute result.stderr =~ "did you mean"
+    end
+
+    test "a sole declaring sibling is still named when the group has other leaves" do
+      # The uniqueness check must not suppress the hint whenever a group is merely large.
+      result = run_ambiguous("dol log metric --bogus")
+      assert result.exit_code == 2
+      assert result.stderr =~ "unknown option: --bogus\n"
+      refute result.stderr =~ "did you mean"
+    end
   end
 
   describe "passthrough flags" do

--- a/test/commands/error_message_test.exs
+++ b/test/commands/error_message_test.exs
@@ -208,8 +208,20 @@ defmodule JustBash.Commands.ErrorMessageTest do
       assert result.exit_code == 2
     end
 
-    test "grep -q still exits 0 when a line was selected" do
+    # `-q` exits "immediately ... if any match is found", so the operands after the
+    # first matching one are never opened and their errors never reported. Which
+    # errors survive is therefore ordering-dependent, and both orders are recorded
+    # against real grep in the fixture corpus.
+    test "grep -q stops at the first match, so a later unreadable file is never named" do
       {result, _bash} = JustBash.exec(sandbox(:enoent), "grep -q hi /f /nope")
+
+      assert result.stdout == ""
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "grep -q still exits 0 when a line was selected after a read failure" do
+      {result, _bash} = JustBash.exec(sandbox(:enoent), "grep -q hi /nope /f")
 
       assert result.stdout == ""
       assert result.stderr == "grep: /nope: No such file or directory\n"

--- a/test/fixtures/bash_cases/grep.json
+++ b/test/fixtures/bash_cases/grep.json
@@ -180,6 +180,61 @@
       "name": "grep missing file: stderr names the missing path",
       "script": "grep 'a' does-not-exist.txt 2>err.txt; cat err.txt",
       "content_hash": "e2bb48f461d8be28"
+    },
+    {
+      "name": "grep -w with BRE alternation: the word anchors bind to the whole alternation, not one branch",
+      "script": "echo foobar | grep -w 'foo\\|bar'; echo $?",
+      "content_hash": "3583b257c06671d8"
+    },
+    {
+      "name": "grep -w with BRE alternation: a whole-word alternative still matches",
+      "script": "echo foo | grep -w 'nope\\|foo'; echo $?",
+      "content_hash": "09bb336226ca9975"
+    },
+    {
+      "name": "grep -x with BRE alternation: the line anchors bind to the whole alternation, not one branch",
+      "script": "echo foobaz | grep -x 'foo\\|bar'; echo $?",
+      "content_hash": "670ac038ba046609"
+    },
+    {
+      "name": "grep -x with BRE alternation: a whole-line alternative still matches",
+      "script": "echo bar | grep -x 'foo\\|bar'; echo $?",
+      "content_hash": "6579c93f70a9727a"
+    },
+    {
+      "name": "grep BRE: an escaped backslash before a pipe leaves the pipe a literal, not alternation",
+      "script": "echo 'a|b' | grep 'a\\\\|b'; echo $?",
+      "content_hash": "a9a7a5fe75c26949"
+    },
+    {
+      "name": "grep BRE: an escaped backslash before a pipe matches a literal backslash-pipe",
+      "script": "printf 'a\\\\|b\\n' | grep 'a\\\\|b'; echo $?",
+      "content_hash": "b3d93e5fc8476004"
+    },
+    {
+      "name": "grep BRE: a bare pipe is a literal, not alternation",
+      "script": "echo ab | grep 'a|b'; echo $?",
+      "content_hash": "7c97e022fdfef971"
+    },
+    {
+      "name": "grep BRE: a bare pipe matches a literal pipe character",
+      "script": "echo 'a|b' | grep 'a|b'; echo $?",
+      "content_hash": "abd3790733635d79"
+    },
+    {
+      "name": "grep error kind: a path under a regular file is Not a directory, not No such file",
+      "script": "echo hi > a.txt; grep hi a.txt/x; echo $?",
+      "content_hash": "182ef5287977a525"
+    },
+    {
+      "name": "grep -q: stops at the first match and never opens the later operands",
+      "script": "echo hi > a.txt; grep -q hi a.txt nope.txt; echo $?",
+      "content_hash": "9e5e9393471b7a48"
+    },
+    {
+      "name": "grep -q: an operand read before the match still reports its error",
+      "script": "echo hi > a.txt; grep -q hi nope.txt a.txt; echo $?",
+      "content_hash": "cfce295cc614eed8"
     }
   ]
 }

--- a/test/fixtures/bash_cases/grep.json
+++ b/test/fixtures/bash_cases/grep.json
@@ -150,6 +150,36 @@
       "name": "grep combined flags: grep -cv count inverted",
       "script": "echo -e 'a\\nb\\na\\nc' | grep -cv 'a'",
       "content_hash": "bf2808f23b3b4b52"
+    },
+    {
+      "name": "grep BRE alternation: backslash-pipe is alternation, not a literal pipe",
+      "script": "echo -e 'bodyweight noted\\nunrelated line' | grep 'bodyweight\\|weight\\|weigh'",
+      "content_hash": "fe70c984fb3a65c3"
+    },
+    {
+      "name": "grep BRE alternation: matches on any of several alternatives",
+      "script": "echo -e 'foo\\nbar\\nbaz\\nqux' | grep 'foo\\|baz'",
+      "content_hash": "4b84a60be05b10fc"
+    },
+    {
+      "name": "grep BRE alternation: no match among alternatives returns exit 1",
+      "script": "echo -e 'foo\\nbar' | grep 'nope\\|nada'; echo $?",
+      "content_hash": "b58af548f549a2dc"
+    },
+    {
+      "name": "grep BRE alternation: -E treats a backslash-pipe as an escaped literal pipe, not alternation",
+      "script": "echo 'a|b' | grep -E 'a\\|b'; echo $?",
+      "content_hash": "37d67361d0969a77"
+    },
+    {
+      "name": "grep missing file: nonexistent path is an error, not a silent no-match",
+      "script": "echo 'hello' > exists.txt; grep -l 'hello' exists.txt does-not-exist.txt; echo $?",
+      "content_hash": "4e6647cdc9342927"
+    },
+    {
+      "name": "grep missing file: stderr names the missing path",
+      "script": "grep 'a' does-not-exist.txt 2>err.txt; cat err.txt",
+      "content_hash": "e2bb48f461d8be28"
     }
   ]
 }

--- a/test/fixtures/bash_expected/grep.json
+++ b/test/fixtures/bash_expected/grep.json
@@ -251,6 +251,83 @@
       "name": "grep missing file: stderr names the missing path",
       "stderr": "",
       "stdout": "grep: does-not-exist.txt: No such file or directory\n"
+    },
+    {
+      "content_hash": "3583b257c06671d8",
+      "exit_code": 0,
+      "name": "grep -w with BRE alternation: the word anchors bind to the whole alternation, not one branch",
+      "stderr": "",
+      "stdout": "1\n"
+    },
+    {
+      "content_hash": "09bb336226ca9975",
+      "exit_code": 0,
+      "name": "grep -w with BRE alternation: a whole-word alternative still matches",
+      "stderr": "",
+      "stdout": "foo\n0\n"
+    },
+    {
+      "content_hash": "670ac038ba046609",
+      "exit_code": 0,
+      "name": "grep -x with BRE alternation: the line anchors bind to the whole alternation, not one branch",
+      "stderr": "",
+      "stdout": "1\n"
+    },
+    {
+      "content_hash": "6579c93f70a9727a",
+      "exit_code": 0,
+      "name": "grep -x with BRE alternation: a whole-line alternative still matches",
+      "stderr": "",
+      "stdout": "bar\n0\n"
+    },
+    {
+      "content_hash": "a9a7a5fe75c26949",
+      "exit_code": 0,
+      "name": "grep BRE: an escaped backslash before a pipe leaves the pipe a literal, not alternation",
+      "stderr": "",
+      "stdout": "1\n"
+    },
+    {
+      "content_hash": "b3d93e5fc8476004",
+      "exit_code": 0,
+      "name": "grep BRE: an escaped backslash before a pipe matches a literal backslash-pipe",
+      "stderr": "",
+      "stdout": "a\\|b\n0\n"
+    },
+    {
+      "content_hash": "7c97e022fdfef971",
+      "exit_code": 0,
+      "name": "grep BRE: a bare pipe is a literal, not alternation",
+      "stderr": "",
+      "stdout": "1\n"
+    },
+    {
+      "content_hash": "abd3790733635d79",
+      "exit_code": 0,
+      "name": "grep BRE: a bare pipe matches a literal pipe character",
+      "stderr": "",
+      "stdout": "a|b\n0\n"
+    },
+    {
+      "content_hash": "182ef5287977a525",
+      "exit_code": 0,
+      "name": "grep error kind: a path under a regular file is Not a directory, not No such file",
+      "stderr": "grep: a.txt/x: Not a directory\n",
+      "stdout": "2\n"
+    },
+    {
+      "content_hash": "9e5e9393471b7a48",
+      "exit_code": 0,
+      "name": "grep -q: stops at the first match and never opens the later operands",
+      "stderr": "",
+      "stdout": "0\n"
+    },
+    {
+      "content_hash": "cfce295cc614eed8",
+      "exit_code": 0,
+      "name": "grep -q: an operand read before the match still reports its error",
+      "stderr": "grep: nope.txt: No such file or directory\n",
+      "stdout": "0\n"
     }
   ],
   "suite": "grep"

--- a/test/fixtures/bash_expected/grep.json
+++ b/test/fixtures/bash_expected/grep.json
@@ -209,6 +209,48 @@
       "name": "grep combined flags: grep -cv count inverted",
       "stderr": "",
       "stdout": "2\n"
+    },
+    {
+      "content_hash": "fe70c984fb3a65c3",
+      "exit_code": 0,
+      "name": "grep BRE alternation: backslash-pipe is alternation, not a literal pipe",
+      "stderr": "",
+      "stdout": "bodyweight noted\n"
+    },
+    {
+      "content_hash": "4b84a60be05b10fc",
+      "exit_code": 0,
+      "name": "grep BRE alternation: matches on any of several alternatives",
+      "stderr": "",
+      "stdout": "foo\nbaz\n"
+    },
+    {
+      "content_hash": "b58af548f549a2dc",
+      "exit_code": 0,
+      "name": "grep BRE alternation: no match among alternatives returns exit 1",
+      "stderr": "",
+      "stdout": "1\n"
+    },
+    {
+      "content_hash": "37d67361d0969a77",
+      "exit_code": 0,
+      "name": "grep BRE alternation: -E treats a backslash-pipe as an escaped literal pipe, not alternation",
+      "stderr": "",
+      "stdout": "a|b\n0\n"
+    },
+    {
+      "content_hash": "4e6647cdc9342927",
+      "exit_code": 0,
+      "name": "grep missing file: nonexistent path is an error, not a silent no-match",
+      "stderr": "grep: does-not-exist.txt: No such file or directory\n",
+      "stdout": "exists.txt\n2\n"
+    },
+    {
+      "content_hash": "e2bb48f461d8be28",
+      "exit_code": 0,
+      "name": "grep missing file: stderr names the missing path",
+      "stderr": "",
+      "stdout": "grep: does-not-exist.txt: No such file or directory\n"
     }
   ],
   "suite": "grep"


### PR DESCRIPTION
## What broke

A production agent ran `grep -ril "bodyweight\|weight\|weigh" /memory`, got
an empty result at exit 1, and concluded the fact wasn't recorded — it was,
in two of the files under `/memory`. Full writeup, including a second
downstream fix for the flag-level recovery path, is in
[the downstream issue](https://github.com/davydog187/dol/issues/80).

## 1. `grep`'s `\|` is BRE alternation, not an escaped literal pipe

`compile_pattern/3` (`lib/just_bash/commands/grep.ex`) passed the pattern
straight to `Regex.compile/2` (PCRE), where `\|` is an escaped literal pipe.
Real `grep` without `-E`/`-P` is BRE, where `\|` is alternation. The PCRE
pattern compiles cleanly either way, so the existing `{:error, _} ->
Regex.escape(...)` fallback never fires — the pattern just silently matches
a literal pipe character that occurs nowhere:

```elixir
Regex.compile!(~S(bodyweight\|weight\|weigh), "i")
|> Regex.match?("- **Bodyweight:** 208 lb, logged as a metric row 2026-08-18.")
#=> false          # before: silent miss, exit 1

Regex.compile!("bodyweight|weight|weigh", "i") |> Regex.match?(same)
#=> true           # what real BSD/GNU grep -ril returns on the same file
```

**Fix shipped:** rewrite only `\|` -> `|` when neither `-E` nor `-P` is
given. `\|` is the dominant agent idiom for alternation (and the one that
caused the incident above); full BRE emulation (bare `(`, `)`, `{` as
literals, `\(...\)` as groups, `\{n,m\}` as bounds, etc.) is a much larger
surface with more ways to land partially right, so it's deliberately left
alone rather than half-translated.

Also fixed on the same path: a missing or unreadable file was silently
swallowed (`{:error, _} -> {acc, had_match, fs}`), producing exit 1 with no
stderr — indistinguishable from "no match" from the caller's side. Real
grep exits 2 and names the path (`grep: FILE: No such file or directory`).
Fixed to match, including `-q`'s documented "exit 0 on a match even if an
error was also detected on another file" priority inversion.

Fixture-corpus cases recorded against real GNU grep (Ubuntu 24.04, in the
Docker corpus) cover both: alternation matching/non-matching, `-E`
opting out of the rewrite, and the missing-path exit code/stderr message.

## 2. An unknown flag now names the sibling command that declares it

Separately: `dol log metric --weight 207.8` (a plausible guess — the right
command is `dol log weight`) failed loudly with `unknown option: --weight`
and a usage line, but nothing pointed at the sibling leaf that actually
declares `--weight`. `allow_unknown_flags` already defaults to `false`, so
there's no silent-drop bug here — just a missing recovery pointer at the
single point (stderr) an agent reads to self-correct.

`ArgParser.parse/3` gains an `:on_unknown_flag` hook, called with the bare
flag name whenever it would otherwise be a hard error; a non-nil return is
appended to the message. `JustBash.CLI` wires it up in `dispatch_leaf/6`,
scanning sibling commands in the same group for one that declares the
flag — an exact declaration match, not the Jaro-distance fuzzy match
`Help.unknown_subcommand/4` already uses for subcommand-name typos (that's
the right tool for a name typo, not for "which leaf owns this flag").

```
dol log metric: unknown option: --weight — did you mean 'dol log weight'?
```

New tests in `test/cli/routing_test.exs` cover: a sibling's long flag, a
sibling's short flag, no suggestion when no sibling declares the flag, and
no cross-group leakage (a flag declared by a leaf in an unrelated group is
not suggested).

## Testing

- `mix test` — full suite green, 5086 passed / 5 excluded (pre-existing
  `:live` exclusions, unrelated to this change)
- `mix bash_fixtures.verify` — corpus sound
- `mix format --check-formatted` — clean on all changed files