### PR TITLE
fix: bound a single expanded value so string doubling cannot overrun the sandbox

### DIFF
--- a/lib/just_bash/interpreter/executor.ex
+++ b/lib/just_bash/interpreter/executor.ex
@@ -881,6 +881,7 @@ defmodule JustBash.Interpreter.Executor do
             end
 
           acc = apply_pending_assignments(acc, pending)
+          Limit.check_value_size!(acc, expanded_value)
           # Expand variable references in associative array subscripts
           # e.g. arr[$key] should store as arr[expanded_key]
           resolved_name = expand_assignment_subscript(acc, name)
@@ -909,6 +910,7 @@ defmodule JustBash.Interpreter.Executor do
             expanded_values
             |> Enum.with_index()
             |> Enum.reduce(env, fn {value, idx}, env_acc ->
+              Limit.check_value_size!(acc, value)
               key = "#{name}[#{idx}]"
               Map.put(env_acc, key, value)
             end)
@@ -969,8 +971,12 @@ defmodule JustBash.Interpreter.Executor do
 
   defp apply_pending_assignments(bash, effects) do
     Enum.reduce(effects, bash, fn
-      {:substitution, _stderr, _code}, acc -> acc
-      {name, value}, acc -> %{acc | env: Map.put(acc.env, name, value)}
+      {:substitution, _stderr, _code}, acc ->
+        acc
+
+      {name, value}, acc ->
+        Limit.check_value_size!(acc, value)
+        %{acc | env: Map.put(acc.env, name, value)}
     end)
   end
 

--- a/lib/just_bash/interpreter/expansion.ex
+++ b/lib/just_bash/interpreter/expansion.ex
@@ -14,6 +14,7 @@ defmodule JustBash.Interpreter.Expansion do
   alias JustBash.Interpreter.Expansion.Brace
   alias JustBash.Interpreter.Expansion.Glob
   alias JustBash.Interpreter.Expansion.Parameter
+  alias JustBash.Limit
 
   defmodule UnsetVariableError do
     @moduledoc "Raised when accessing an unset variable with set -u"
@@ -61,7 +62,7 @@ defmodule JustBash.Interpreter.Expansion do
         {expanded, new_assigns} = expand_part(current_bash, part)
         # Apply new assignments to bash so subsequent parts see them
         new_bash = apply_assignments_to_bash(current_bash, new_assigns)
-        {acc <> expanded, new_bash, assigns ++ new_assigns}
+        {Limit.concat!(current_bash, acc, expanded), new_bash, assigns ++ new_assigns}
       end)
 
     {result, assignments}
@@ -102,8 +103,12 @@ defmodule JustBash.Interpreter.Expansion do
 
   defp apply_assignments_to_bash(bash, effects) do
     Enum.reduce(effects, bash, fn
-      {:substitution, _stderr, _code}, acc -> acc
-      {name, value}, acc -> %{acc | env: Map.put(acc.env, name, value)}
+      {:substitution, _stderr, _code}, acc ->
+        acc
+
+      {name, value}, acc ->
+        Limit.check_value_size!(acc, value)
+        %{acc | env: Map.put(acc.env, name, value)}
     end)
   end
 
@@ -431,7 +436,12 @@ defmodule JustBash.Interpreter.Expansion do
         has_unquoted_glob = has_unquoted_glob?(parts)
         expanded_segments = Enum.map(parts, &expand_for_loop_part(bash, &1, ifs))
         needs_ifs_split = Enum.any?(expanded_segments, fn {_, split?} -> split? end)
-        combined = Enum.map_join(expanded_segments, "", fn {str, _} -> str end)
+
+        combined =
+          Enum.reduce(expanded_segments, "", fn {str, _}, acc ->
+            Limit.concat!(bash, acc, str)
+          end)
+
         results = maybe_split_on_ifs(combined, ifs, needs_ifs_split)
         maybe_expand_globs(bash, results, has_unquoted_glob)
     end

--- a/lib/just_bash/limit.ex
+++ b/lib/just_bash/limit.ex
@@ -3,8 +3,8 @@ defmodule JustBash.Limit do
   Production resource limits for JustBash execution.
 
   Prevents untrusted scripts from exhausting memory or CPU by enforcing
-  hard caps on computation steps, output size, file size, regex patterns,
-  execution nesting depth, and elapsed wall clock time.
+  hard caps on computation steps, output size, file size, value size, regex
+  patterns, execution nesting depth, and elapsed wall clock time.
 
   ## Usage
 
@@ -27,6 +27,7 @@ defmodule JustBash.Limit do
   | `:max_steps` | 10_000 | 100_000 | 1_000_000 |
   | `:max_output_bytes` | 65_536 | 1_048_576 | 10_485_760 |
   | `:max_file_bytes` | 65_536 | 1_048_576 | 10_485_760 |
+  | `:max_value_bytes` | 65_536 | 1_048_576 | 10_485_760 |
   | `:max_regex_pattern_bytes` | 10_000 | 10_000 | 10_000 |
   | `:max_exec_depth` | 128 | 128 | 128 |
   | `:max_wall_ms` | 1_000 | 5_000 | 30_000 |
@@ -40,6 +41,13 @@ defmodule JustBash.Limit do
   `:max_steps` does double duty: a whole word is one step no matter what it
   expands into, so it is also the cap on how many words a single word may
   expand into — see `check_expansion_words!/2`.
+
+  `:max_value_bytes` bounds a single expanded value. A step like
+  `v=${v}${v}` doubles a binary with no other bound seeing inside it, so
+  without this cap the wall clock cannot fire until that allocation
+  finishes. Call `concat!/3` (or `check_value_size!/2` with a byte count)
+  before the memory is spent, the way `check_expansion_words!/2` is called
+  as a word list is produced.
   """
 
   defmodule ExceededError do
@@ -52,6 +60,7 @@ defmodule JustBash.Limit do
     - `:expansion_limit` — one word expanded into too many words
     - `:output_limit` — stdout + stderr exceeded byte cap
     - `:file_size_limit` — single file write exceeded byte cap
+    - `:value_size_limit` — a single expanded value exceeded byte cap
     - `:regex_pattern_limit` — regex pattern string too large
     - `:exec_depth_limit` — eval/source nesting too deep
     - `:wall_clock_limit` — a single `JustBash.exec/2` ran too long
@@ -80,6 +89,7 @@ defmodule JustBash.Limit do
     :max_steps,
     :max_output_bytes,
     :max_file_bytes,
+    :max_value_bytes,
     :max_regex_pattern_bytes,
     :max_exec_depth,
     :max_wall_ms
@@ -88,6 +98,7 @@ defmodule JustBash.Limit do
     :max_steps,
     :max_output_bytes,
     :max_file_bytes,
+    :max_value_bytes,
     :max_regex_pattern_bytes,
     :max_exec_depth,
     :max_wall_ms
@@ -97,6 +108,7 @@ defmodule JustBash.Limit do
           max_steps: pos_integer(),
           max_output_bytes: pos_integer(),
           max_file_bytes: pos_integer(),
+          max_value_bytes: pos_integer(),
           max_regex_pattern_bytes: pos_integer(),
           max_exec_depth: pos_integer(),
           max_wall_ms: pos_integer()
@@ -110,6 +122,7 @@ defmodule JustBash.Limit do
     max_steps: 100_000,
     max_output_bytes: 1_048_576,
     max_file_bytes: 1_048_576,
+    max_value_bytes: 1_048_576,
     max_regex_pattern_bytes: 10_000,
     max_exec_depth: 128,
     max_wall_ms: 5_000
@@ -128,6 +141,7 @@ defmodule JustBash.Limit do
       | max_steps: 10_000,
         max_output_bytes: 65_536,
         max_file_bytes: 65_536,
+        max_value_bytes: 65_536,
         max_wall_ms: 1_000
     }
 
@@ -137,6 +151,7 @@ defmodule JustBash.Limit do
       | max_steps: 1_000_000,
         max_output_bytes: 10_485_760,
         max_file_bytes: 10_485_760,
+        max_value_bytes: 10_485_760,
         max_wall_ms: 30_000
     }
 
@@ -204,6 +219,25 @@ defmodule JustBash.Limit do
     end
 
     :ok
+  end
+
+  @doc """
+  Concatenate two binaries, raising `ExceededError` if the result would
+  exceed `:max_value_bytes`.
+
+  The check is on the sum of the sizes, so the oversized result is never
+  allocated — a single `v=${v}${v}` of a multi-gigabyte value is the hole
+  this closes. Call this as word parts are joined, not with the finished
+  binary.
+  """
+  @spec concat!(JustBash.t(), binary(), binary()) :: binary()
+  def concat!(%{limits: nil}, left, right) when is_binary(left) and is_binary(right) do
+    left <> right
+  end
+
+  def concat!(bash, left, right) when is_binary(left) and is_binary(right) do
+    check_value_size!(bash, byte_size(left) + byte_size(right))
+    left <> right
   end
 
   @doc "Track output bytes. Raises `ExceededError` if limit is reached."
@@ -322,6 +356,31 @@ defmodule JustBash.Limit do
         kind: :file_size_limit,
         message: "file size limit exceeded (#{limits.max_file_bytes} bytes)",
         limit: limits.max_file_bytes,
+        actual: size
+    end
+
+    :ok
+  end
+
+  @doc """
+  Check a value's size before keeping it. Raises `ExceededError` if too large.
+
+  Accepts the data binary, or a byte count so callers can refuse a
+  concatenation before it is built — see `concat!/3`.
+  """
+  @spec check_value_size!(JustBash.t(), String.t() | non_neg_integer()) :: :ok
+  def check_value_size!(%{limits: nil}, _data), do: :ok
+
+  def check_value_size!(bash, data) when is_binary(data) do
+    check_value_size!(bash, byte_size(data))
+  end
+
+  def check_value_size!(%{limits: limits}, size) when is_integer(size) do
+    if size > limits.max_value_bytes do
+      raise ExceededError,
+        kind: :value_size_limit,
+        message: "value size limit exceeded (#{limits.max_value_bytes} bytes)",
+        limit: limits.max_value_bytes,
         actual: size
     end
 

--- a/test/limit_resource_exhaustion_test.exs
+++ b/test/limit_resource_exhaustion_test.exs
@@ -90,6 +90,22 @@ defmodule JustBash.Limit.ResourceExhaustionTest do
     end
   end
 
+  describe "memory exhaustion via variables" do
+    test "exponential string doubling is bounded by value size" do
+      bash = strict_bash(max_value_bytes: 500)
+      {result, _} = JustBash.exec(bash, "v=abc; while true; do v=${v}${v}; done")
+      assert result.exit_code == 1
+      assert result.stderr =~ "value size limit"
+    end
+
+    test "a normal-size assignment still succeeds" do
+      bash = strict_bash(max_value_bytes: 500)
+      {result, _} = JustBash.exec(bash, "v=hello; echo $v")
+      assert result.exit_code == 0
+      assert result.stdout == "hello\n"
+    end
+  end
+
   describe "memory exhaustion via filesystem" do
     test "write oversized file" do
       bash = strict_bash(max_file_bytes: 100)

--- a/test/limit_test.exs
+++ b/test/limit_test.exs
@@ -8,22 +8,26 @@ defmodule JustBash.LimitTest do
       limits = Limit.new(:default)
       assert limits.max_steps == 100_000
       assert limits.max_output_bytes == 1_048_576
+      assert limits.max_value_bytes == 1_048_576
     end
 
     test "strict preset" do
       limits = Limit.new(:strict)
       assert limits.max_steps == 10_000
+      assert limits.max_value_bytes == 65_536
     end
 
     test "relaxed preset" do
       limits = Limit.new(:relaxed)
       assert limits.max_steps == 1_000_000
+      assert limits.max_value_bytes == 10_485_760
     end
 
     test "custom keyword list merges with defaults" do
       limits = Limit.new(max_steps: 42)
       assert limits.max_steps == 42
       assert limits.max_output_bytes == 1_048_576
+      assert limits.max_value_bytes == 1_048_576
     end
 
     test "false disables limits" do
@@ -40,6 +44,47 @@ defmodule JustBash.LimitTest do
       assert_raise ArgumentError, ~r/positive integers/, fn ->
         Limit.new(max_steps: 0)
       end
+    end
+  end
+
+  describe "Limit.concat!/3" do
+    test "concatenates when the result fits" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+      assert Limit.concat!(bash, "hello", "wor") == "hellowor"
+    end
+
+    test "allows a result right at the bound" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+      assert Limit.concat!(bash, "hello", "world") == "helloworld"
+    end
+
+    test "raises without concatenating when the sum would exceed the bound" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+
+      assert_raise Limit.ExceededError, ~r/value size limit exceeded \(10 bytes\)/, fn ->
+        Limit.concat!(bash, "hello", "world!")
+      end
+    end
+
+    test "is a no-op bound when limits are disabled" do
+      bash = JustBash.new(limits: false)
+      assert Limit.concat!(bash, "hello", "world") == "helloworld"
+    end
+  end
+
+  describe "Limit.check_value_size!/2" do
+    test "accepts a byte count so callers can refuse before allocating" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+      assert Limit.check_value_size!(bash, 10) == :ok
+
+      assert_raise Limit.ExceededError, ~r/value size limit exceeded \(10 bytes\)/, fn ->
+        Limit.check_value_size!(bash, 11)
+      end
+    end
+
+    test "passes when limits are disabled" do
+      bash = JustBash.new(limits: false)
+      assert Limit.check_value_size!(bash, 1_000_000) == :ok
     end
   end
 
@@ -132,6 +177,29 @@ defmodule JustBash.LimitTest do
       bash = JustBash.new(limits: [max_file_bytes: 1000])
       {result, _bash} = JustBash.exec(bash, ~s(echo "hello" > /tmp/small.txt))
       assert result.exit_code == 0
+    end
+  end
+
+  describe "value size limit" do
+    test "stops execution when an assignment would exceed the bound" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+      {result, _bash} = JustBash.exec(bash, ~s(v=abcdefghijk; echo "$v"))
+      assert result.exit_code == 1
+      assert result.stderr =~ "value size limit exceeded (10 bytes)"
+    end
+
+    test "allows an assignment right at the bound" do
+      bash = JustBash.new(limits: [max_value_bytes: 8])
+      {result, _bash} = JustBash.exec(bash, ~s(v=12345678; echo "$v"))
+      assert result.exit_code == 0
+      assert result.stdout == "12345678\n"
+    end
+
+    test "a normal-size assignment is untouched" do
+      bash = JustBash.new(limits: [max_value_bytes: 1_000])
+      {result, _bash} = JustBash.exec(bash, "v=hello; echo $v")
+      assert result.exit_code == 0
+      assert result.stdout == "hello\n"
     end
   end
 

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -656,6 +656,55 @@ defmodule JustBash.SandboxContractTest do
     end
   end
 
+  describe "a value that grows from a short input" do
+    # Deadline checks sit between statements. One `v=${v}${v}` doubles a binary
+    # with no size cap, so the next check cannot fire until that allocation
+    # finishes — measured at ~2.4–2.9× `max_wall_ms` on a 1s budget, and the
+    # overrun grows with the value. `max_value_bytes` refuses before the
+    # concat, the way `check_expansion_words!/2` refuses before a range is
+    # built. Each probe runs under a task so a regression fails the test
+    # instead of OOMing the suite.
+    setup do
+      {:ok,
+       bash: JustBash.new(limits: [max_value_bytes: 1_000, max_wall_ms: 5_000, max_steps: 10_000])}
+    end
+
+    test "string doubling is refused before a huge allocation", %{bash: bash} do
+      {elapsed_us, result} =
+        bounded_exec_timed(bash, "v=abc; while true; do v=${v}${v}; done")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "value size limit exceeded (1000 bytes)"
+      # Unbounded, this is the GB-scale concat that overran `max_wall_ms` by
+      # ~3×. Under a 1_000-byte cap it must finish on the order of a few
+      # doublings, not a wall-clock budget.
+      assert elapsed_us < 200_000
+    end
+
+    test "unquoted doubling is the same hole", %{bash: bash} do
+      result = bounded_exec(bash, "v=abc; while true; do v=$v$v; done")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "value size limit exceeded (1000 bytes)"
+    end
+
+    test "a normal-size assignment is untouched" do
+      bash = JustBash.new(limits: [max_value_bytes: 1_000])
+      result = bounded_exec(bash, "v=hello; v=${v}${v}; echo $v")
+
+      assert result.exit_code == 0
+      assert result.stdout == "hellohello\n"
+    end
+
+    test "limits: false leaves doubling unbounded by value size" do
+      bash = JustBash.new(limits: false)
+      result = bounded_exec(bash, "v=ab; v=${v}${v}; v=${v}${v}; echo ${#v}")
+
+      assert result.exit_code == 0
+      assert result.stdout == "8\n"
+    end
+  end
+
   describe "a recursive traversal" do
     # `find` never returned through a symlink cycle (#53). The cycle is gone,
     # but nothing structural stopped the next one — a whole tree walk is one


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #77

A single assignment like `v=${v}${v}` could allocate gigabytes between deadline checks, so `max_wall_ms` overran by ~3× and nothing bounded the size of one value. `JustBash.exec/2` still returned — that contract from #73 holds — but the declared wall-clock bound was advisory when one step was unboundedly expensive.

The wall clock cannot pre-empt a single BEAM binary allocation. The fix is a size cap on a value, checked **before** the concat, the same shape as `check_expansion_words!/2` refusing a range before it is built.

## User-visible contract

New limit key **`:max_value_bytes`**, same defaults as `:max_file_bytes` / `:max_output_bytes`:

| key | `:strict` | `:default` | `:relaxed` |
| --- | --- | --- | --- |
| `:max_value_bytes` | 65_536 | 1_048_576 | 10_485_760 |

A script that grows a value past the cap now terminates with a shell result:

```
bash: value size limit exceeded (65536 bytes)
```

exit 1, script halted. `JustBash.exec/2` does not raise. Existing bounds are unchanged.

```elixir
# limits: :strict  (max_value_bytes: 65_536, max_wall_ms: 1_000)
"v=abc; while true; do v=${v}${v}; done"
# => exit 1, "bash: value size limit exceeded (65536 bytes)"
#    in well under the wall-clock budget; no GB-scale allocation
```

A normal-size assignment is untouched. `limits: false` still disables every bound, including this one.

## What changed

- `Limit.concat!/3` checks `byte_size(left) + byte_size(right)` and only then concatenates, so the oversized result is never allocated.
- Word-part expansion (`v=${v}${v}`, `v=$v$v`) joins through that helper.
- Assignment stores the value only after `check_value_size!/2` (backstop for a single oversized literal).

## Tests

- Doubling (`${v}${v}` and `$v$v`) is refused under a 1_000-byte cap, with an elapsed-time guard so a regression cannot spend a wall-clock budget allocating.
- A normal-size assignment still succeeds.
- An assignment right at the bound is allowed; one byte over is not.
- `concat!/3` and `check_value_size!/2` cover the “refuse before allocating” API, including `limits: false`.

## Gates

`mix compile --warnings-as-errors`

`mix format --check-formatted`

`mix credo --strict` — the single finding is the intentional `apply/2` test fixture; identical on `main`.

`mix test`

```
Finished in 35.1 seconds (34.6s async, 0.4s sync)
2 doctests, 62 properties, 5353 tests, 0 failures (5 excluded)
```

`mix docs --warnings-as-errors`

`mix dialyzer`

```
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done (passed successfully)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84a59c4e-750d-40a3-9096-be744536f0bd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84a59c4e-750d-40a3-9096-be744536f0bd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

