### PR TITLE
fix: awk's empty for(;;) condition is true, matching gawk

### DIFF
--- a/lib/just_bash/commands/awk/evaluator.ex
+++ b/lib/just_bash/commands/awk/evaluator.ex
@@ -942,7 +942,7 @@ defmodule JustBash.Commands.Awk.Evaluator do
   defp execute_for_loop(cond_expr, update, body, state) do
     Limit.check_deadline!(state.deadline)
 
-    if truthy?(evaluate_expression(cond_expr, state)) do
+    if for_condition_true?(cond_expr, state) do
       case execute_loop_body(body, state) do
         {:break, new_state} ->
           new_state
@@ -958,6 +958,15 @@ defmodule JustBash.Commands.Awk.Evaluator do
     else
       state
     end
+  end
+
+  # POSIX awk / gawk: an omitted for-condition is a constant true. The parser
+  # stores that as nil; evaluating it as an unknown expression produced ""
+  # (falsy), so for(;;) never entered the body.
+  defp for_condition_true?(nil, _state), do: true
+
+  defp for_condition_true?(cond_expr, state) do
+    truthy?(evaluate_expression(cond_expr, state))
   end
 
   defp execute_while_loop(cond_expr, body, state) do

--- a/test/commands/awk_test.exs
+++ b/test/commands/awk_test.exs
@@ -725,6 +725,25 @@ defmodule JustBash.Commands.AwkTest do
       assert result.stdout == "1\n2\n3\n"
     end
 
+    # POSIX/gawk: an omitted for-condition is a constant true. Evaluating the
+    # missing expression as the empty string made for(;;) a silent no-op.
+    test "empty for(;;) condition is true and the body runs" do
+      bash = JustBash.new(files: %{"/data.txt" => "x\n"})
+
+      {result, _} =
+        JustBash.exec(bash, "awk 'BEGIN{n=0; for(;;){n++; if(n>3) break}; print n}'")
+
+      assert result.stdout == "4\n"
+      assert result.exit_code == 0
+    end
+
+    test "for(i=0;i<n;i++) still counts from zero" do
+      bash = JustBash.new(files: %{"/data.txt" => "x\n"})
+      {result, _} = JustBash.exec(bash, "awk 'BEGIN{n=3; for(i=0;i<n;i++)print i}'")
+      assert result.stdout == "0\n1\n2\n"
+      assert result.exit_code == 0
+    end
+
     test "for loop with compound body" do
       bash = JustBash.new(files: %{"/data.txt" => "x\n"})
 

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -552,6 +552,13 @@ defmodule JustBash.SandboxContractTest do
       assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
     end
 
+    test "awk's empty for(;;) is a loop, not a no-op, and is still bounded", %{bash: bash} do
+      result = bounded_exec(bash, "awk 'BEGIN{for(;;){x=x+1}}'")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "execution wall clock limit exceeded (50 ms)"
+    end
+
     test "awk's do-while loop is bounded", %{bash: bash} do
       result = bounded_exec(bash, "awk 'BEGIN{do{x=x+1}while(1)}'")
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #76

`awk`'s empty `for(;;)` condition was treated as false, so the loop body never ran. GNU awk (and POSIX awk) treat an omitted for-condition as a constant true — `for(;;)` is the idiomatic infinite loop, exited with `break`.

The failure mode was silent: exit 0, empty stderr, wrong answer. An agent writing `for(;;)` got a confidently empty result.

```
# before
awk 'BEGIN{n=0; for(;;){n++; if(n>3) break}; print n}'
# => 0

# after (matches gawk)
awk 'BEGIN{n=0; for(;;){n++; if(n>3) break}; print n}'
# => 4
```

A bounded `for(i=0;i<n;i++)` is unchanged. An unbounded `for(;;)` without `break` still hits `max_wall_ms` and returns a shell result; `JustBash.exec/2` does not raise.

## Cause

The parser already stored a missing for-condition as `nil`. The evaluator passed that `nil` through `evaluate_expression/2`, whose catch-all returns `""`, and `""` is falsy in awk. `while()` / `do-while` always require an expression at parse time, so they do not share this hole.

## What changed

- `execute_for_loop/4` treats a `nil` condition as true.
- Tests cover empty `for(;;)` with `break` (prints 4, exit 0), a normal `for(i=0;i<n;i++)`, and unbounded `for(;;)` still stopping at the wall clock.

## Gates

`mix compile --warnings-as-errors`

`mix format --check-formatted`

`mix credo --strict` — the single finding is the intentional `apply/2` test fixture; identical on `main`.

`mix test`

```
Finished in 43.9 seconds (43.5s async, 0.4s sync)
2 doctests, 62 properties, 5356 tests, 0 failures (5 excluded)
```

`mix docs --warnings-as-errors`

`mix dialyzer`

```
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done (passed successfully)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a426063-d8dc-44ec-93d0-05d0b3c60d8b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a426063-d8dc-44ec-93d0-05d0b3c60d8b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

