### PR TITLE
fix: shasum -c / sha256sum -c read checksum lines from stdin

### DIFF
--- a/lib/just_bash/commands/sha256sum.ex
+++ b/lib/just_bash/commands/sha256sum.ex
@@ -18,16 +18,19 @@ defmodule JustBash.Commands.Sha256sum do
   def execute(bash, args, stdin) do
     {opts, files} = parse_args(args)
 
+    files = defaults_to_stdin(files)
+
     if opts.check do
-      check_checksums(bash, files)
+      check_checksums(bash, files, stdin)
     else
-      hash_files(bash, defaults_to_stdin(files), stdin)
+      hash_files(bash, files, stdin)
     end
   end
 
-  # No operand at all is the same request as a lone `-`, and one `-` among
-  # several files is still that operand: `sha256sum - f` hashes both,
-  # labelling the first `-`.
+  # No operand at all is the same request as a lone `-`, for hashing and for
+  # `-c`. One `-` among several files is still that operand: `sha256sum - f`
+  # hashes both, labelling the first `-`; `sha256sum -c -` reads checksum
+  # lines from stdin, not a path named `-`.
   defp defaults_to_stdin([]), do: ["-"]
   defp defaults_to_stdin(files), do: files
 
@@ -59,12 +62,10 @@ defmodule JustBash.Commands.Sha256sum do
     {Command.result(stdout, stderr, exit_code), %{bash | fs: fs}}
   end
 
-  defp check_checksums(bash, files) do
+  defp check_checksums(bash, files, stdin) do
     {stdout, stderr, exit_code, fs} =
       Enum.reduce(files, {"", "", 0, bash.fs}, fn file, {out, err, code, fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
-
-        case FS.read_file(fs, resolved) do
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
           {:ok, content, new_fs} ->
             verify_checksum_file(bash, content, out, err, code, new_fs)
 

--- a/lib/just_bash/commands/shasum.ex
+++ b/lib/just_bash/commands/shasum.ex
@@ -28,16 +28,19 @@ defmodule JustBash.Commands.Shasum do
         _ -> :sha
       end
 
+    files = defaults_to_stdin(files)
+
     if opts.check do
-      check_checksums(bash, algorithm, files)
+      check_checksums(bash, algorithm, files, stdin)
     else
-      hash_files(bash, algorithm, defaults_to_stdin(files), stdin)
+      hash_files(bash, algorithm, files, stdin)
     end
   end
 
-  # No operand at all is the same request as a lone `-`, and one `-` among
-  # several files is still that operand: `shasum - f` hashes both, labelling
-  # the first `-`.
+  # No operand at all is the same request as a lone `-`, for hashing and for
+  # `-c`. One `-` among several files is still that operand: `shasum - f`
+  # hashes both, labelling the first `-`; `shasum -c -` reads checksum lines
+  # from stdin, not a path named `-`.
   defp defaults_to_stdin([]), do: ["-"]
   defp defaults_to_stdin(files), do: files
 
@@ -73,12 +76,10 @@ defmodule JustBash.Commands.Shasum do
     {Command.result(stdout, stderr, exit_code), %{bash | fs: fs}}
   end
 
-  defp check_checksums(bash, algorithm, files) do
+  defp check_checksums(bash, algorithm, files, stdin) do
     {stdout, stderr, exit_code, fs} =
       Enum.reduce(files, {"", "", 0, bash.fs}, fn file, {out, err, code, fs} ->
-        resolved = FS.resolve_path(bash.cwd, file)
-
-        case FS.read_file(fs, resolved) do
+        case StdinOperand.read(fs, bash.cwd, file, stdin) do
           {:ok, content, new_fs} ->
             verify_checksum_file(bash, algorithm, content, out, err, code, new_fs)
 

--- a/test/commands/new_builtins_test.exs
+++ b/test/commands/new_builtins_test.exs
@@ -77,6 +77,46 @@ defmodule JustBash.Commands.NewBuiltinsTest do
       expected = :crypto.hash(:sha256, "data") |> Base.encode16(case: :lower)
       assert String.trim(result.stdout) == expected
     end
+
+    # `-c` must not resolve `-` as a path, and a missing operand is stdin,
+    # not a silent exit 0 after verifying nothing. GNU/BSD `sha256sum -c`
+    # reads checksum lines from stdin in both cases.
+    test "-c - reads checksum lines from stdin, not a path named -" do
+      {result, _} = check_sha256("-c -")
+
+      assert result.stdout == "/f: OK\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "-c with no operand reads checksum lines from stdin" do
+      {result, _} = check_sha256("-c")
+
+      assert result.stdout == "/f: OK\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "-c still verifies a checksum file operand" do
+      content = "hello"
+      hash = sha256(content)
+
+      bash = JustBash.new(files: %{"/f" => content, "/sums" => "#{hash}  /f\n"})
+      {result, _} = JustBash.exec(bash, "sha256sum -c /sums")
+
+      assert result.stdout == "/f: OK\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "-c - reports FAILED and exits 1 on a mismatch" do
+      hash = sha256("hello")
+      bash = JustBash.new(files: %{"/f" => "world"})
+      {result, _} = JustBash.exec(bash, "printf '#{hash}  /f\\n' | sha256sum -c -")
+
+      assert result.stdout =~ "/f: FAILED"
+      assert result.exit_code == 1
+    end
   end
 
   describe "shasum" do
@@ -99,6 +139,43 @@ defmodule JustBash.Commands.NewBuiltinsTest do
       {result, _} = JustBash.exec(bash, "shasum -a 256 /f.txt | cut -d' ' -f1")
       expected = :crypto.hash(:sha256, "data") |> Base.encode16(case: :lower)
       assert String.trim(result.stdout) == expected
+    end
+
+    test "-c - reads checksum lines from stdin, not a path named -" do
+      {result, _} = check_shasum("-c -")
+
+      assert result.stdout == "/f: OK\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "-c with no operand reads checksum lines from stdin" do
+      {result, _} = check_shasum("-c")
+
+      assert result.stdout == "/f: OK\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "-c still verifies a checksum file operand" do
+      content = "hello"
+      hash = sha1(content)
+
+      bash = JustBash.new(files: %{"/f" => content, "/sums" => "#{hash}  /f\n"})
+      {result, _} = JustBash.exec(bash, "shasum -c /sums")
+
+      assert result.stdout == "/f: OK\n"
+      assert result.stderr == ""
+      assert result.exit_code == 0
+    end
+
+    test "-c - reports FAILED and exits 1 on a mismatch" do
+      hash = sha1("hello")
+      bash = JustBash.new(files: %{"/f" => "world"})
+      {result, _} = JustBash.exec(bash, "printf '#{hash}  /f\\n' | shasum -c -")
+
+      assert result.stdout =~ "/f: FAILED"
+      assert result.exit_code == 1
     end
   end
 
@@ -297,5 +374,22 @@ defmodule JustBash.Commands.NewBuiltinsTest do
       {result, _} = JustBash.exec(bash, "yes no | head -2")
       assert result.stdout == "no\nno\n"
     end
+  end
+
+  defp sha256(content), do: :crypto.hash(:sha256, content) |> Base.encode16(case: :lower)
+  defp sha1(content), do: :crypto.hash(:sha, content) |> Base.encode16(case: :lower)
+
+  defp check_sha256(args) do
+    content = "hello"
+    hash = sha256(content)
+    bash = JustBash.new(files: %{"/f" => content})
+    JustBash.exec(bash, "printf '#{hash}  /f\\n' | sha256sum #{args}")
+  end
+
+  defp check_shasum(args) do
+    content = "hello"
+    hash = sha1(content)
+    bash = JustBash.new(files: %{"/f" => content})
+    JustBash.exec(bash, "printf '#{hash}  /f\\n' | shasum #{args}")
   end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #81

`shasum -c` / `sha256sum -c` treated `-` as a filesystem path and treated a missing operand as success after verifying nothing. That is a silent wrong answer for agent tool-use: a caller checking a checksum got exit 0 whether or not the file matched.

GNU coreutils `sha256sum` and Perl `shasum` both read checksum lines from stdin when the operand is `-` or when there is no operand. The hashing path already had that `StdinOperand` treatment (PR #74); check mode did not.

## User-visible behavior

```
# before
$ printf 'HASH  /f\n' | sha256sum -c -
# => rc=1, sha256sum: -: No such file or directory

$ printf 'HASH  /f\n' | sha256sum -c
# => rc=0, no output

# after (matches GNU/BSD)
$ printf 'HASH  /f\n' | sha256sum -c -
# => rc=0, /f: OK

$ printf 'HASH  /f\n' | sha256sum -c
# => rc=0, /f: OK
```

A checksum file operand is unchanged: `sha256sum -c /sums` still verifies that file. A mismatch still prints `FAILED` and exits 1. `JustBash.exec/2` does not raise.

## Changes
- Check mode uses `defaults_to_stdin/1`, so a missing operand is `-`
- Check mode reads the checksum list through `StdinOperand.read/4`, so `-` is stdin rather than a path
- Tests cover `-` as stdin, a missing operand, a normal file operand, and a mismatch via stdin — for both `sha256sum` and `shasum`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added new tests
- [x] All existing tests pass
- [x] Checked against GNU `sha256sum` 9.4 and Perl `shasum` 6.04

Local gates:

```
mix compile --warnings-as-errors
mix format --check-formatted
mix credo --strict   # only the pre-existing apply/2 test fixture
mix test
# Finished in 32.5 seconds
# 2 doctests, 62 properties, 5364 tests, 0 failures (5 excluded)
mix docs --warnings-as-errors
mix dialyzer
# Total errors: 13, Skipped: 13, Unnecessary Skips: 0
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b87ba721-8d35-4ae5-ab3d-95b7fb50363d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b87ba721-8d35-4ae5-ab3d-95b7fb50363d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

