### PR TITLE
fix: honour `--` as end-of-options for file-operand commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* honour `--` as end-of-options for file-operand commands ([#83](https://github.com/elixir-ai-tools/just_bash/issues/83))
+
 ## [0.1.0] - 2026-01-11
 
 ### Added

--- a/lib/just_bash/commands/awk.ex
+++ b/lib/just_bash/commands/awk.ex
@@ -90,12 +90,17 @@ defmodule JustBash.Commands.Awk do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{
-      program: nil,
-      files: [],
-      field_separator: " ",
-      variables: %{}
-    })
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <-
+           parse_args(option_args, %{
+             program: nil,
+             files: [],
+             field_separator: " ",
+             variables: %{}
+           }) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts) do

--- a/lib/just_bash/commands/base64.ex
+++ b/lib/just_bash/commands/base64.ex
@@ -41,7 +41,11 @@ defmodule JustBash.Commands.Base64 do
   defp build_result({:error, msg}, bash), do: {Command.error(msg), bash}
 
   defp parse_args(args) do
-    parse_args(args, %{decode: false, wrap: 76, files: []})
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <- parse_args(option_args, %{decode: false, wrap: 76, files: []}) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/cat.ex
+++ b/lib/just_bash/commands/cat.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Cat do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -10,6 +11,8 @@ defmodule JustBash.Commands.Cat do
 
   @impl true
   def execute(bash, args, stdin) do
+    args = StdinOperand.drop_end_of_options(args)
+
     if args == [] and stdin != "" do
       {Command.ok(stdin), bash}
     else

--- a/lib/just_bash/commands/cd.ex
+++ b/lib/just_bash/commands/cd.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Cd do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -11,10 +12,11 @@ defmodule JustBash.Commands.Cd do
   @impl true
   def execute(bash, args, _stdin) do
     target =
-      case args do
-        [] -> Map.get(bash.env, "HOME", "/")
-        ["-"] -> Map.get(bash.env, "OLDPWD", bash.cwd)
-        [path | _] -> path
+      case StdinOperand.split_end_of_options(args) do
+        {_before, [path | _]} -> path
+        {[], []} -> Map.get(bash.env, "HOME", "/")
+        {["-"], []} -> Map.get(bash.env, "OLDPWD", bash.cwd)
+        {[path | _], []} -> path
       end
 
     resolved = FS.resolve_path(bash.cwd, target)

--- a/lib/just_bash/commands/chmod.ex
+++ b/lib/just_bash/commands/chmod.ex
@@ -10,6 +10,7 @@ defmodule JustBash.Commands.Chmod do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -29,7 +30,9 @@ defmodule JustBash.Commands.Chmod do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{recursive: false}, [])
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+    {opts, pos} = parse_args(option_args, %{recursive: false}, [])
+    {opts, pos ++ extra}
   end
 
   defp parse_args([], opts, pos), do: {opts, Enum.reverse(pos)}

--- a/lib/just_bash/commands/chown.ex
+++ b/lib/just_bash/commands/chown.ex
@@ -9,6 +9,7 @@ defmodule JustBash.Commands.Chown do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -28,7 +29,9 @@ defmodule JustBash.Commands.Chown do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{recursive: false}, [])
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+    {opts, pos} = parse_args(option_args, %{recursive: false}, [])
+    {opts, pos ++ extra}
   end
 
   defp parse_args([], opts, pos), do: {opts, Enum.reverse(pos)}

--- a/lib/just_bash/commands/comm.ex
+++ b/lib/just_bash/commands/comm.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Comm do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -35,7 +36,17 @@ defmodule JustBash.Commands.Comm do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{suppress1: false, suppress2: false, suppress3: false, files: []})
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <-
+           parse_args(option_args, %{
+             suppress1: false,
+             suppress2: false,
+             suppress3: false,
+             files: []
+           }) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/cut.ex
+++ b/lib/just_bash/commands/cut.ex
@@ -23,13 +23,18 @@ defmodule JustBash.Commands.Cut do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{
-      delimiter: "\t",
-      field_spec: nil,
-      char_spec: nil,
-      suppress_no_delim: false,
-      files: []
-    })
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <-
+           parse_args(option_args, %{
+             delimiter: "\t",
+             field_spec: nil,
+             char_spec: nil,
+             suppress_no_delim: false,
+             files: []
+           }) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts) do

--- a/lib/just_bash/commands/diff.ex
+++ b/lib/just_bash/commands/diff.ex
@@ -2,6 +2,7 @@ defmodule JustBash.Commands.Diff do
   @moduledoc "The `diff` command - compare files line by line."
   @behaviour JustBash.Commands.Command
 
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -33,13 +34,18 @@ defmodule JustBash.Commands.Diff do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{
-      unified: false,
-      brief: false,
-      report_same: false,
-      ignore_case: false,
-      files: []
-    })
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <-
+           parse_args(option_args, %{
+             unified: false,
+             brief: false,
+             report_same: false,
+             ignore_case: false,
+             files: []
+           }) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/du.ex
+++ b/lib/just_bash/commands/du.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Du do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
   alias JustBash.Limit
 
@@ -57,15 +58,20 @@ defmodule JustBash.Commands.Du do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{
-      all_files: false,
-      human_readable: false,
-      summarize: false,
-      grand_total: false,
-      max_depth: nil,
-      files: [],
-      deadline: nil
-    })
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <-
+           parse_args(option_args, %{
+             all_files: false,
+             human_readable: false,
+             summarize: false,
+             grand_total: false,
+             max_depth: nil,
+             files: [],
+             deadline: nil
+           }) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/file.ex
+++ b/lib/just_bash/commands/file.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.File do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -73,7 +74,11 @@ defmodule JustBash.Commands.File do
     do: "#{file}: cannot open (#{FS.strerror(error)})\n"
 
   defp parse_args(args) do
-    parse_args(args, %{brief: false, mime: false, files: []})
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <- parse_args(option_args, %{brief: false, mime: false, files: []}) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/find.ex
+++ b/lib/just_bash/commands/find.ex
@@ -63,6 +63,8 @@ defmodule JustBash.Commands.Find do
 
   defp parse_args([], opts), do: {:ok, opts}
 
+  defp parse_args(["--" | rest], opts), do: parse_args(rest, opts)
+
   defp parse_args(["-name", pattern | rest], opts) do
     parse_args(rest, %{opts | name: pattern})
   end

--- a/lib/just_bash/commands/jq.ex
+++ b/lib/just_bash/commands/jq.ex
@@ -191,7 +191,23 @@ defmodule JustBash.Commands.Jq do
     end
   end
 
-  defp parse_args(args), do: parse_args(args, default_opts())
+  defp parse_args(args), do: parse_args_with_end_of_options(args)
+
+  defp parse_args_with_end_of_options(args) do
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <- parse_args(option_args, default_opts()) do
+      attach_jq_operands(opts, extra)
+    end
+  end
+
+  defp attach_jq_operands(opts, []), do: {:ok, opts}
+  defp attach_jq_operands(%{file: nil} = opts, [file]), do: {:ok, %{opts | file: file}}
+
+  defp attach_jq_operands(%{filter: "."} = opts, [filter, file]),
+    do: {:ok, %{opts | filter: filter, file: file}}
+
+  defp attach_jq_operands(_opts, _), do: {:error, "jq: too many arguments\n"}
 
   defp default_opts do
     %{

--- a/lib/just_bash/commands/markdown.ex
+++ b/lib/just_bash/commands/markdown.ex
@@ -18,6 +18,7 @@ defmodule JustBash.Commands.Markdown do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -106,13 +107,22 @@ defmodule JustBash.Commands.Markdown do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{
-      file: nil,
-      gfm: true,
-      breaks: false,
-      smartypants: false,
-      help: false
-    })
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <-
+           parse_args(option_args, %{
+             file: nil,
+             gfm: true,
+             breaks: false,
+             smartypants: false,
+             help: false
+           }) do
+      case {opts.file, extra} do
+        {_file, []} -> {:ok, opts}
+        {nil, [file | _]} -> {:ok, %{opts | file: file}}
+        {_file, _} -> {:ok, opts}
+      end
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/md5sum.ex
+++ b/lib/just_bash/commands/md5sum.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Md5sum do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -26,7 +27,11 @@ defmodule JustBash.Commands.Md5sum do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{check: false, files: []})
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <- parse_args(option_args, %{check: false, files: []}) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/mkdir.ex
+++ b/lib/just_bash/commands/mkdir.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Mkdir do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -97,7 +98,11 @@ defmodule JustBash.Commands.Mkdir do
     "mkdir: cannot create directory '#{path}': #{FS.strerror(error)}\n"
   end
 
-  defp parse_flags(args), do: parse_flags(args, %{p: false}, [])
+  defp parse_flags(args) do
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+    {flags, paths} = parse_flags(option_args, %{p: false}, [])
+    {flags, paths ++ extra}
+  end
 
   defp parse_flags(["-p" | rest], flags, paths),
     do: parse_flags(rest, %{flags | p: true}, paths)

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -3,14 +3,19 @@ defmodule JustBash.Commands.Mv do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
   def names, do: ["mv"]
 
   @impl true
-  def execute(bash, [src, dest], _stdin), do: move(bash, src, dest)
-  def execute(bash, _args, _stdin), do: {Command.error("mv: missing file operand\n"), bash}
+  def execute(bash, args, _stdin) do
+    case StdinOperand.drop_end_of_options(args) do
+      [src, dest] -> move(bash, src, dest)
+      _ -> {Command.error("mv: missing file operand\n"), bash}
+    end
+  end
 
   defp move(bash, src, dest) do
     src_resolved = FS.resolve_path(bash.cwd, src)

--- a/lib/just_bash/commands/od.ex
+++ b/lib/just_bash/commands/od.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Od do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -10,11 +11,15 @@ defmodule JustBash.Commands.Od do
 
   @impl true
   def execute(bash, args, stdin) do
-    case parse_args(args, %{format: :octal, file: nil}) do
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    case parse_args(option_args, %{format: :octal, file: nil}) do
       {:error, msg} ->
         {Command.error(msg), bash}
 
       {:ok, opts} ->
+        opts = if extra == [], do: opts, else: %{opts | file: List.last(extra)}
+
         case read_input(bash, opts.file, stdin) do
           {:ok, data, bash} -> {Command.ok(render(data, opts.format)), bash}
           {:error, msg} -> {Command.error(msg), bash}

--- a/lib/just_bash/commands/paste.ex
+++ b/lib/just_bash/commands/paste.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Paste do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -43,7 +44,11 @@ defmodule JustBash.Commands.Paste do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{delimiter: "\t", serial: false, files: []})
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <- parse_args(option_args, %{delimiter: "\t", serial: false, files: []}) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/realpath.ex
+++ b/lib/just_bash/commands/realpath.ex
@@ -16,6 +16,7 @@ defmodule JustBash.Commands.Realpath do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -72,7 +73,9 @@ defmodule JustBash.Commands.Realpath do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{mode: :default}, [])
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+    {opts, paths} = parse_args(option_args, %{mode: :default}, [])
+    {opts, paths ++ extra}
   end
 
   defp parse_args([], opts, paths), do: {opts, Enum.reverse(paths)}

--- a/lib/just_bash/commands/rm.ex
+++ b/lib/just_bash/commands/rm.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Rm do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -31,7 +32,11 @@ defmodule JustBash.Commands.Rm do
     {Command.result("", stderr, exit_code), %{bash | fs: new_fs}}
   end
 
-  defp parse_flags(args), do: parse_flags(args, %{r: false, f: false}, [])
+  defp parse_flags(args) do
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+    {flags, paths} = parse_flags(option_args, %{r: false, f: false}, [])
+    {flags, paths ++ extra}
+  end
 
   defp parse_flags(["-r" | rest], flags, paths),
     do: parse_flags(rest, %{flags | r: true}, paths)

--- a/lib/just_bash/commands/sed.ex
+++ b/lib/just_bash/commands/sed.ex
@@ -69,13 +69,18 @@ defmodule JustBash.Commands.Sed do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{
-      scripts: [],
-      files: [],
-      silent: false,
-      in_place: false,
-      extended_regex: false
-    })
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <-
+           parse_args(option_args, %{
+             scripts: [],
+             files: [],
+             silent: false,
+             in_place: false,
+             extended_regex: false
+           }) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/sha256sum.ex
+++ b/lib/just_bash/commands/sha256sum.ex
@@ -35,7 +35,9 @@ defmodule JustBash.Commands.Sha256sum do
   defp defaults_to_stdin(files), do: files
 
   defp parse_args(args) do
-    parse_args(args, %{check: false}, [])
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+    {opts, files} = parse_args(option_args, %{check: false}, [])
+    {opts, files ++ extra}
   end
 
   defp parse_args([], opts, files), do: {opts, Enum.reverse(files)}

--- a/lib/just_bash/commands/shasum.ex
+++ b/lib/just_bash/commands/shasum.ex
@@ -45,7 +45,9 @@ defmodule JustBash.Commands.Shasum do
   defp defaults_to_stdin(files), do: files
 
   defp parse_args(args) do
-    parse_args(args, %{algorithm: "1", check: false}, [])
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+    {opts, files} = parse_args(option_args, %{algorithm: "1", check: false}, [])
+    {opts, files ++ extra}
   end
 
   defp parse_args([], opts, files), do: {opts, Enum.reverse(files)}

--- a/lib/just_bash/commands/source.ex
+++ b/lib/just_bash/commands/source.ex
@@ -8,6 +8,7 @@ defmodule JustBash.Commands.Source do
 
   @behaviour JustBash.Commands.Command
 
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
   alias JustBash.Interpreter.Executor
   alias JustBash.Parser
@@ -17,7 +18,7 @@ defmodule JustBash.Commands.Source do
 
   @impl true
   def execute(bash, args, _stdin) do
-    case args do
+    case StdinOperand.drop_end_of_options(args) do
       [] ->
         {%{stdout: "", stderr: "bash: source: filename argument required\n", exit_code: 2}, bash}
 

--- a/lib/just_bash/commands/stat.ex
+++ b/lib/just_bash/commands/stat.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Stat do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -55,7 +56,11 @@ defmodule JustBash.Commands.Stat do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{format: nil, files: []})
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <- parse_args(option_args, %{format: nil, files: []}) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/stdin_operand.ex
+++ b/lib/just_bash/commands/stdin_operand.ex
@@ -44,10 +44,52 @@ defmodule JustBash.Commands.StdinOperand do
   fewer input than it was given and still exits 0.
   """
   @spec operands([String.t()]) :: [String.t()]
-  def operands(args), do: do_operands(args, [])
+  def operands(args) do
+    {before, extra} = split_end_of_options(args)
+    keep_dash_operands(before) ++ extra
+  end
+
+  @doc """
+  Split `args` at the first `--`.
+
+  Returns `{before, extra}` where `extra` is everything after `--` and must
+  not be parsed as options. A second `--` is an operand named `--`. When `--`
+  is absent, `extra` is `[]` and `before` is `args`.
+
+  Hand-rolled parsers call this once at their entry point, parse flags from
+  `before`, and append `extra` as file operands — the same `--` stop
+  `FlagParser` and `operands/1` already implement:
+
+      {option_args, extra} = StdinOperand.split_end_of_options(args)
+      with {:ok, opts} <- parse_flags(option_args, defaults) do
+        {:ok, %{opts | files: opts.files ++ extra}}
+      end
+  """
+  @spec split_end_of_options([String.t()]) :: {[String.t()], [String.t()]}
+  def split_end_of_options(args) do
+    case Enum.split_while(args, &(&1 != "--")) do
+      {before, ["--" | extra]} -> {before, extra}
+      {before, []} -> {before, []}
+    end
+  end
+
+  @doc """
+  Drop the first `--` and keep every other argument, including ones that
+  look like flags.
+
+  For a command that does not parse options, arguments on either side of
+  `--` are operands. Concatenating them is the POSIX reading of `--` as a
+  marker rather than a filename. After `--`, a second `--` stays an operand.
+  """
+  @spec drop_end_of_options([String.t()]) :: [String.t()]
+  def drop_end_of_options(args) do
+    {before, extra} = split_end_of_options(args)
+    before ++ extra
+  end
+
+  defp keep_dash_operands(args), do: do_operands(args, [])
 
   defp do_operands([], acc), do: Enum.reverse(acc)
-  defp do_operands(["--" | rest], acc), do: Enum.reverse(acc, rest)
   defp do_operands([@dash | rest], acc), do: do_operands(rest, [@dash | acc])
   defp do_operands([@dash <> _ | rest], acc), do: do_operands(rest, acc)
   defp do_operands([operand | rest], acc), do: do_operands(rest, [operand | acc])

--- a/lib/just_bash/commands/tee.ex
+++ b/lib/just_bash/commands/tee.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Tee do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -31,7 +32,11 @@ defmodule JustBash.Commands.Tee do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{append: false, files: []})
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <- parse_args(option_args, %{append: false, files: []}) do
+      {:ok, %{opts | files: opts.files ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/touch.ex
+++ b/lib/just_bash/commands/touch.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Touch do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -11,7 +12,9 @@ defmodule JustBash.Commands.Touch do
   @impl true
   def execute(bash, args, _stdin) do
     {new_fs, stderr, exit_code} =
-      Enum.reduce(args, {bash.fs, "", 0}, fn path, acc ->
+      args
+      |> StdinOperand.drop_end_of_options()
+      |> Enum.reduce({bash.fs, "", 0}, fn path, acc ->
         touch_file(bash.cwd, path, acc)
       end)
 

--- a/lib/just_bash/commands/tree.ex
+++ b/lib/just_bash/commands/tree.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Tree do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
   alias JustBash.Limit
 
@@ -38,13 +39,18 @@ defmodule JustBash.Commands.Tree do
   end
 
   defp parse_args(args) do
-    parse_args(args, %{
-      show_hidden: false,
-      dirs_only: false,
-      max_depth: nil,
-      full_path: false,
-      dirs: []
-    })
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    with {:ok, opts} <-
+           parse_args(option_args, %{
+             show_hidden: false,
+             dirs_only: false,
+             max_depth: nil,
+             full_path: false,
+             dirs: []
+           }) do
+      {:ok, %{opts | dirs: opts.dirs ++ extra}}
+    end
   end
 
   defp parse_args([], opts), do: {:ok, opts}

--- a/lib/just_bash/commands/xxd.ex
+++ b/lib/just_bash/commands/xxd.ex
@@ -3,6 +3,7 @@ defmodule JustBash.Commands.Xxd do
   @behaviour JustBash.Commands.Command
 
   alias JustBash.Commands.Command
+  alias JustBash.Commands.StdinOperand
   alias JustBash.FS
 
   @impl true
@@ -10,11 +11,15 @@ defmodule JustBash.Commands.Xxd do
 
   @impl true
   def execute(bash, args, stdin) do
-    case parse_args(args, %{cols: 16, len: nil, seek: 0, plain: false, file: nil}) do
+    {option_args, extra} = StdinOperand.split_end_of_options(args)
+
+    case parse_args(option_args, %{cols: 16, len: nil, seek: 0, plain: false, file: nil}) do
       {:error, msg} ->
         {Command.error(msg), bash}
 
       {:ok, opts} ->
+        opts = if extra == [], do: opts, else: %{opts | file: List.last(extra)}
+
         case read_input(bash, opts.file, stdin) do
           {:ok, data, bash} ->
             data = slice(data, opts.seek, opts.len)

--- a/lib/just_bash/commands/xxd.ex
+++ b/lib/just_bash/commands/xxd.ex
@@ -47,8 +47,6 @@ defmodule JustBash.Commands.Xxd do
 
   defp parse_args([file | rest], opts), do: parse_args(rest, %{opts | file: file})
 
-  defp to_int(n) when is_integer(n), do: n
-
   defp to_int(n) do
     case Integer.parse(n) do
       {i, _} -> i

--- a/test/commands/end_of_options_test.exs
+++ b/test/commands/end_of_options_test.exs
@@ -1,0 +1,282 @@
+defmodule JustBash.Commands.EndOfOptionsTest do
+  @moduledoc """
+  `--` ends option parsing. Everything after it is an operand.
+
+  Some commands honoured that, others treated `--` as a filename or as an
+  invalid option. The worst case printed the correct result *and* exited 1
+  (`shasum -- /f`). Issue #83 wants the same treatment as #68's unknown-flag
+  matrix: every Registry command that takes a file operand is enumerated, so a
+  new command cannot join without classifying.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.Commands.Registry
+  alias JustBash.Commands.StdinOperand
+
+  @content "hello\n"
+  @other "world\n"
+  @json "{\"k\":1}\n"
+  @markdown "# Hi\n"
+  @script "echo sourced\n"
+
+  # Every command whose invocation takes a file operand. FILE is replaced with
+  # the path; `--` is inserted immediately before that operand. The reference
+  # run is the same invocation without `--`. They must agree, succeed, and not
+  # mention `--` as a file or an option.
+  #
+  # A row may name its own path (a directory, a JSON document, a destination
+  # that should not already exist) and the stdin a writer such as `tee` needs.
+  @file_operand [
+    "cat FILE",
+    "head FILE",
+    "tail FILE",
+    "tac FILE",
+    "rev FILE",
+    "nl FILE",
+    "fold FILE",
+    "expand FILE",
+    "paste FILE",
+    "base64 FILE",
+    "md5sum FILE",
+    "sha256sum FILE",
+    "shasum FILE",
+    "od -c FILE",
+    "xxd FILE",
+    "cut -c1 FILE",
+    "file FILE",
+    "stat FILE",
+    "sort FILE",
+    "uniq FILE",
+    "realpath FILE",
+    "touch FILE",
+    {"wc -l FILE", "/f", ""},
+    {"grep hello FILE", "/f", ""},
+    {"sed -n p FILE", "/f", ""},
+    {"awk '{print}' FILE", "/f", ""},
+    {"jq . FILE", "/j.json", ""},
+    {"markdown FILE", "/readme.md", ""},
+    {"md FILE", "/readme.md", ""},
+    {"source FILE", "/script.sh", ""},
+    {". FILE", "/script.sh", ""},
+    {"comm FILE FILE", "/f", ""},
+    {"diff FILE FILE", "/f", ""},
+    {"cp FILE /out", "/f", ""},
+    {"mv FILE /out", "/f", ""},
+    {"rm FILE", "/f", ""},
+    {"ls FILE", "/d", ""},
+    {"find FILE", "/d", ""},
+    {"tree FILE", "/d", ""},
+    {"du FILE", "/d", ""},
+    {"cd FILE; pwd", "/d", ""},
+    {"mkdir FILE", "/newdir", ""},
+    {"tee FILE", "/out", @content},
+    {"ln FILE /link", "/f", ""},
+    {"chmod 644 FILE", "/f", ""},
+    {"chown u FILE", "/f", ""},
+    {"readlink -f FILE", "/f", ""}
+  ]
+
+  # The rest of the registry: `--` is not a file-operand marker for these.
+  # Kept explicit so a command added to the registry has to be classified.
+  @no_file_operand %{
+    "echo" => "writes arguments; does not open a path",
+    "true" => "ignores operands",
+    ":" => "alias of true",
+    "false" => "ignores operands",
+    "pwd" => "prints the working directory",
+    "export" => "assigns shell variables",
+    "unset" => "unsets shell variables",
+    "test" => "expression operands, not a file-opening utility",
+    "[" => "alias of test",
+    "printf" => "formats arguments",
+    "basename" => "string operation on a path name, does not open it",
+    "dirname" => "string operation on a path name, does not open it",
+    "read" => "reads stdin into variables",
+    "seq" => "emits numbers",
+    "tr" => "translates stdin character sets",
+    "date" => "prints a date; operands are format strings",
+    "sleep" => "duration operand",
+    "exit" => "status operand",
+    "env" => "assigns environment and runs a command",
+    "printenv" => "prints environment variables",
+    "which" => "looks up command names",
+    "hostname" => "prints the host name",
+    "xargs" => "builds a command from stdin",
+    "curl" => "URL operand",
+    "wget" => "URL operand",
+    "set" => "shell options and positional parameters",
+    "local" => "assigns function-local variables",
+    "declare" => "alias of local",
+    "typeset" => "alias of local",
+    "break" => "loop control",
+    "continue" => "loop control",
+    "shift" => "positional parameters",
+    "return" => "function return",
+    "getopts" => "option parsing builtin",
+    "trap" => "signal handlers",
+    "eval" => "evaluates a string as a script",
+    "command" => "looks up / invokes another command",
+    "uname" => "prints system information",
+    "mktemp" => "template operand, not an existing file",
+    "whoami" => "prints the user name",
+    "id" => "prints user identity",
+    "nproc" => "prints CPU count",
+    "arch" => "prints architecture",
+    "yes" => "repeats arguments",
+    "type" => "describes command names"
+  }
+
+  @rows Enum.map(@file_operand, fn
+          {script, path, stdin} -> {script, path, stdin}
+          script -> {script, "/f", ""}
+        end)
+
+  describe "StdinOperand.split_end_of_options/1" do
+    test "splits at the first -- and leaves a second -- as an operand" do
+      assert StdinOperand.split_end_of_options(["-n", "--", "/f"]) == {["-n"], ["/f"]}
+      assert StdinOperand.split_end_of_options(["--", "-n", "/f"]) == {[], ["-n", "/f"]}
+      assert StdinOperand.split_end_of_options(["--", "--", "/f"]) == {[], ["--", "/f"]}
+      assert StdinOperand.split_end_of_options(["/f", "-n"]) == {["/f", "-n"], []}
+    end
+
+    test "drop_end_of_options/1 concatenates both sides so -- is not a filename" do
+      assert StdinOperand.drop_end_of_options(["--", "/f"]) == ["/f"]
+      assert StdinOperand.drop_end_of_options(["/f", "--"]) == ["/f"]
+      assert StdinOperand.drop_end_of_options(["--", "--"]) == ["--"]
+    end
+  end
+
+  describe "the registry is fully classified" do
+    test "every command either takes a file operand or is skipped with a reason" do
+      named = Enum.map(@rows, fn {script, _, _} -> command_name(script) end)
+      classified = MapSet.new(named ++ Map.keys(@no_file_operand))
+
+      assert MapSet.new(Registry.list()) == classified
+    end
+  end
+
+  describe "`--` ends option parsing for every file-operand command" do
+    for {script, path, stdin} <- @rows do
+      test "#{script}" do
+        {script, path, stdin} = {unquote(script), unquote(path), unquote(stdin)}
+        with_dd = insert_end_of_options(script)
+        {reference, _} = run(script, path, stdin)
+        {observed, after_bash} = run(with_dd, path, stdin)
+
+        assert reference.exit_code == 0,
+               "#{script} without -- exited #{reference.exit_code}: #{inspect(reference)}"
+
+        assert observed.exit_code == 0,
+               "#{with_dd} exited #{observed.exit_code}: #{inspect(observed)}"
+
+        assert strip_volatile(observed.stdout) == strip_volatile(reference.stdout)
+        assert observed.stderr == reference.stderr
+
+        refute observed.stderr =~ "--",
+               "#{with_dd} mentioned -- in stderr: #{inspect(observed.stderr)}"
+
+        # touch/mkdir used to create a file named `--` and still exit 0, so
+        # comparing transcripts was not enough.
+        {leftover, _} = JustBash.exec(after_bash, ~s[test -e "./--" && echo leaked || echo clean])
+        assert leftover.stdout =~ "clean"
+      end
+    end
+  end
+
+  describe "the issue #83 table" do
+    test "shasum -- /f hashes the file and exits 0, with nothing about --" do
+      {result, _} = JustBash.exec(sandbox(), "shasum -- /f")
+      {expected, _} = JustBash.exec(sandbox(), "shasum /f")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert result.stdout == expected.stdout
+      assert result.stdout =~ ~r/^[0-9a-f]{40}  \/f\n$/
+    end
+
+    test "sha256sum -- /f hashes the file and exits 0" do
+      {result, _} = JustBash.exec(sandbox(), "sha256sum -- /f")
+      {expected, _} = JustBash.exec(sandbox(), "sha256sum /f")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert result.stdout == expected.stdout
+    end
+
+    test "cat -- /f prints the file and exits 0" do
+      {result, _} = JustBash.exec(sandbox(), "cat -- /f")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert result.stdout == @content
+    end
+
+    test "md5sum -- /f hashes the file and exits 0" do
+      {result, _} = JustBash.exec(sandbox(), "md5sum -- /f")
+      {expected, _} = JustBash.exec(sandbox(), "md5sum /f")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert result.stdout == expected.stdout
+    end
+
+    test "base64 -- /f encodes the file and exits 0" do
+      {result, _} = JustBash.exec(sandbox(), "base64 -- /f")
+      {expected, _} = JustBash.exec(sandbox(), "base64 /f")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+      assert result.stdout == expected.stdout
+    end
+  end
+
+  describe "a filename that begins with a dash" do
+    # POSIX `--` exists so a file named `-f` is not taken as a flag.
+    test "cat -- -f reads a file named -f" do
+      bash = JustBash.new(files: %{"/-f" => "dashfile\n"})
+
+      assert {%{stdout: "dashfile\n", stderr: "", exit_code: 0}, _} =
+               JustBash.exec(bash, "cd /; cat -- -f")
+    end
+  end
+
+  defp sandbox do
+    JustBash.new(
+      files: %{
+        "/f" => @content,
+        "/g" => @other,
+        "/j.json" => @json,
+        "/readme.md" => @markdown,
+        "/script.sh" => @script,
+        "/d/x" => "x\n"
+      }
+    )
+  end
+
+  defp insert_end_of_options(script) do
+    String.replace(script, "FILE", "-- FILE", global: false)
+  end
+
+  defp run(script, path, stdin) do
+    invoked = String.replace(script, "FILE", path)
+    bash = sandbox()
+
+    if stdin == "" do
+      JustBash.exec(bash, invoked)
+    else
+      JustBash.exec(bash, "printf #{inspect(stdin)} | " <> invoked)
+    end
+  end
+
+  defp strip_volatile(stdout) do
+    String.replace(stdout, ~r/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z/, "<ts>")
+  end
+
+  # Take the token that names a Registry command. `source` / `.` are the first
+  # token; `cd FILE; pwd` still starts with `cd`.
+  defp command_name(script) do
+    script
+    |> String.split(" ", trim: true)
+    |> Enum.find(&Registry.exists?/1)
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #83

POSIX `--` ends option parsing; everything after it is an operand. Some commands already did that (`sort`, `wc`, `head`, `tac`, `rev`). Others treated `--` as a filename or rejected it as an invalid option.

The worst case was split-brain: `shasum -- /f` printed the correct hash **and** exited 1 with `shasum: --: No such file or directory`, so a caller checking the exit code and a caller reading stdout disagreed about whether it worked.

## User-visible behavior

```
# before
$ shasum -- /f
<hash>  /f
shasum: --: No such file or directory    # rc=1, and the correct hash on stdout
$ cat -- /f
cat: --: No such file or directory       # rc=1
$ md5sum -- /f
md5sum: invalid option '--'              # rc=1
$ base64 -- /f
base64: invalid option '--'              # rc=1

# after (matches GNU/BSD)
$ shasum -- /f
<hash>  /f                               # rc=0, stderr empty
$ cat -- /f
hello
$ md5sum -- /f
<hash>  /f                               # rc=0
$ base64 -- /f
aGVsbG8K                                 # rc=0
```

`--` is also how a filename beginning with a dash is passed: `cat -- -f` reads a file named `-f`. `JustBash.exec/2` does not raise.

## Changes

- `StdinOperand.split_end_of_options/1` is the shared `--` stop that `FlagParser` and `StdinOperand.operands/1` already implemented. Hand-rolled parsers call it once at their entry point, parse flags from the left side, and append the remainder as operands.
- Commands that take no options (`cat`, `touch`, `mv`, `source`) drop `--` rather than opening a path named `--`.
- `test/commands/end_of_options_test.exs` enumerates `cmd -- FILE` for every Registry command that takes a file operand, with an explicit skip-and-reason for the rest, so a new command cannot join unclassified.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added new tests
- [x] All existing tests pass

Local gates:

```
mix compile --warnings-as-errors
mix format --check-formatted
mix credo --strict   # only the pre-existing apply/2 test fixture
mix test
# Finished in 33.4 seconds
# 2 doctests, 62 properties, 5420 tests, 0 failures (5 excluded)
mix docs --warnings-as-errors
mix dialyzer
# Total errors: 13, Skipped: 13, Unnecessary Skips: 0
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
- [x] I have updated the CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a629592-1661-4692-9157-3b93c35c850a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a629592-1661-4692-9157-3b93c35c850a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

