### PR TITLE
fix: head default line count no longer emits a trailing blank line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 * honour `--` as end-of-options for file-operand commands ([#83](https://github.com/elixir-ai-tools/just_bash/issues/83))
+* head default line count no longer emits a trailing blank line ([#80](https://github.com/elixir-ai-tools/just_bash/issues/80))
 
 ## [0.1.0] - 2026-01-11
 

--- a/lib/just_bash/commands/head.ex
+++ b/lib/just_bash/commands/head.ex
@@ -102,12 +102,16 @@ defmodule JustBash.Commands.Head do
     format_head_output(content, n)
   end
 
-  defp format_head_output(content, n) do
-    lines = String.split(content, "\n")
-    output = lines |> Enum.take(n) |> Enum.join("\n")
+  # GNU head prints through the nth newline, or the whole file when there
+  # aren't that many. String.split/2 leaves an empty piece after a
+  # terminating newline; taking it and then appending "\n" again was the
+  # extra blank line on the default count (and any -n larger than the file).
+  defp format_head_output(_content, n) when n <= 0, do: ""
 
-    if String.ends_with?(content, "\n") or length(lines) <= n,
-      do: output <> "\n",
-      else: output
+  defp format_head_output(content, n) do
+    case content |> :binary.matches("\n") |> Enum.at(n - 1) do
+      {offset, 1} -> binary_part(content, 0, offset + 1)
+      nil -> content
+    end
   end
 end

--- a/test/commands/text_processing_test.exs
+++ b/test/commands/text_processing_test.exs
@@ -104,6 +104,7 @@ defmodule JustBash.Commands.TextProcessingTest do
       bash = JustBash.new(files: %{"/empty.txt" => ""})
       {result, _} = JustBash.exec(bash, "head /empty.txt")
       assert result.exit_code == 0
+      assert result.stdout == ""
     end
 
     test "head with multiple files shows headers" do
@@ -116,6 +117,57 @@ defmodule JustBash.Commands.TextProcessingTest do
       assert result.stdout =~ "line1a"
       assert result.stdout =~ "==> /b.txt <=="
       assert result.stdout =~ "line1b"
+    end
+
+    # GNU head of a short file is the file itself. `x=$(head f)` strips the
+    # extra trailing newline before anyone sees it; byte-compare stdout.
+    test "head of a one-line file does not emit a trailing blank line" do
+      bash = JustBash.new(files: %{"/f" => "x\n"})
+      {result, _} = JustBash.exec(bash, "head /f")
+      assert result.exit_code == 0
+      assert result.stdout == "x\n"
+    end
+
+    test "head of stdin does not emit a trailing blank line" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "echo x | head")
+      assert result.exit_code == 0
+      assert result.stdout == "x\n"
+    end
+
+    test "head -n1 of a one-line file still matches GNU" do
+      bash = JustBash.new(files: %{"/f" => "x\n"})
+      {result, _} = JustBash.exec(bash, "head -n1 /f")
+      assert result.exit_code == 0
+      assert result.stdout == "x\n"
+    end
+
+    test "head -n2 of a one-line file does not emit a trailing blank line" do
+      bash = JustBash.new(files: %{"/f" => "x\n"})
+      {result, _} = JustBash.exec(bash, "head -n2 /f")
+      assert result.exit_code == 0
+      assert result.stdout == "x\n"
+    end
+
+    test "head of a file without a trailing newline does not add one" do
+      bash = JustBash.new(files: %{"/f" => "x"})
+      {result, _} = JustBash.exec(bash, "head /f")
+      assert result.exit_code == 0
+      assert result.stdout == "x"
+    end
+
+    test "head default multi-file headers do not insert extra blank lines" do
+      bash = JustBash.new(files: %{"/f" => "x\n", "/g" => "hi\n"})
+      {result, _} = JustBash.exec(bash, "head /f /g")
+      assert result.exit_code == 0
+      assert result.stdout == "==> /f <==\nx\n\n==> /g <==\nhi\n"
+    end
+
+    test "head -n1 multi-file headers still match GNU" do
+      bash = JustBash.new(files: %{"/f" => "x\n", "/g" => "hi\n"})
+      {result, _} = JustBash.exec(bash, "head -n1 /f /g")
+      assert result.exit_code == 0
+      assert result.stdout == "==> /f <==\nx\n\n==> /g <==\nhi\n"
     end
 
     test "head -c N outputs first N bytes from file" do
@@ -224,6 +276,30 @@ defmodule JustBash.Commands.TextProcessingTest do
       assert result.stdout =~ "line2a"
       assert result.stdout =~ "==> /b.txt <=="
       assert result.stdout =~ "line2b"
+    end
+
+    # Tail splits with trim: true, so the default count does not double-count a
+    # terminating newline the way head did. Byte-compare so a rewrite cannot
+    # grow the same hole.
+    test "tail of a one-line file does not emit a trailing blank line" do
+      bash = JustBash.new(files: %{"/f" => "x\n"})
+      {result, _} = JustBash.exec(bash, "tail /f")
+      assert result.exit_code == 0
+      assert result.stdout == "x\n"
+    end
+
+    test "tail of stdin does not emit a trailing blank line" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "echo x | tail")
+      assert result.exit_code == 0
+      assert result.stdout == "x\n"
+    end
+
+    test "tail default multi-file headers do not insert extra blank lines" do
+      bash = JustBash.new(files: %{"/f" => "x\n", "/g" => "hi\n"})
+      {result, _} = JustBash.exec(bash, "tail /f /g")
+      assert result.exit_code == 0
+      assert result.stdout == "==> /f <==\nx\n\n==> /g <==\nhi\n"
     end
 
     test "tail -c N outputs last N bytes from file" do

--- a/test/edge_cases_test.exs
+++ b/test/edge_cases_test.exs
@@ -103,7 +103,8 @@ defmodule JustBash.EdgeCasesTest do
     test "head with single line no newline" do
       bash = JustBash.new(files: %{"/no_newline.txt" => "single line"})
       {result, _} = JustBash.exec(bash, "head -1 /no_newline.txt")
-      assert result.stdout == "single line\n"
+      # GNU head does not invent a terminator the file did not have.
+      assert result.stdout == "single line"
     end
 
     test "tail with single line no newline" do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #80

`head` of a short file printed an extra trailing blank line on the **default** (and any larger) line count. GNU prints the file as-is.

```
# /f = "x\n"
# before
$ head /f          →  "x\n\n"
$ echo x | head    →  "x\n\n"
$ head /f /g       →  extra blank line after each body

# after (matches GNU)
$ head /f          →  "x\n"
$ echo x | head    →  "x\n"
$ head -n1 /f      →  "x\n"   (already matched; still does)
$ head /f /g       →  "==> /f <==\nx\n\n==> /g <==\nhi\n"
```

`x=$(head f)` hides the extra newline because command substitution strips trailing newlines, which is part of why this survived. Tests byte-compare `result.stdout`.

## Cause

Not a separate default-count path, and not the multi-file separator. `format_head_output/2` always runs for line mode. `String.split("x\n", "\n")` yields `["x", ""]`; taking the default 10 pieces reconstructs `"x\n"`, and then the function appended another `"\n"` because the content already ended with a newline (or because `length(lines) <= n`). `head -n1` happened to drop the empty piece, which is why the explicit form already matched GNU. `head -n2 /f` had the same hole. Multi-file just made the extra newline visible twice.

The same append-when-taking-the-whole-file path also invented a terminator for a file that had none (`"x"` → `"x\n"`). GNU does not.

## Tail

`tail` does **not** have this bug. It splits with `trim: true`, so `"x\n"` is `["x"]` and one `"\n"` is appended. Tests pin `tail /f`, `echo x | tail`, and default multi-file headers so a later rewrite cannot grow the same hole. Files that lack a terminating newline are a different shape and are not this issue.

## Changes

- `format_head_output/2` prints through the nth newline, or the whole file when there are fewer than n newlines.
- Byte-compare tests for the issue's cases, `head -n2` (same hole, not default-specific), a file without a terminator, empty file stdout, and tail of a one-line file.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added new tests
- [x] All existing tests pass

Local gates:

```
mix compile --warnings-as-errors
mix format --check-formatted
mix credo            # clean
mix credo --strict   # only the pre-existing apply/2 test fixture
mix test
# Finished in 33.1 seconds
# 2 doctests, 62 properties, 5430 tests, 0 failures (5 excluded)
mix docs --warnings-as-errors
mix dialyzer
# Total errors: 13, Skipped: 13, Unnecessary Skips: 0
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
- [x] I have updated the CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08462aab-391f-4f5f-9302-b53a609d35af?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08462aab-391f-4f5f-9302-b53a609d35af&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

