### PR TITLE
fix: tac does not invent a newline on an unterminated last record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * honour `--` as end-of-options for file-operand commands ([#83](https://github.com/elixir-ai-tools/just_bash/issues/83))
 * head default line count no longer emits a trailing blank line ([#80](https://github.com/elixir-ai-tools/just_bash/issues/80))
+* tac no longer invents a newline on an unterminated last record ([#82](https://github.com/elixir-ai-tools/just_bash/issues/82))
 
 ## [0.1.0] - 2026-01-11
 

--- a/lib/just_bash/commands/rev.ex
+++ b/lib/just_bash/commands/rev.ex
@@ -15,48 +15,65 @@ defmodule JustBash.Commands.Rev do
       {:error, msg} ->
         {Command.error(msg), bash}
 
-      {:ok, data, fs} ->
-        {Command.ok(reverse_chars_per_line(data)), %{bash | fs: fs}}
+      {:ok, output, fs} ->
+        {Command.ok(output), %{bash | fs: fs}}
     end
   end
 
-  # `rev` is line-local, so reading the operands in the order given is all it
-  # takes to put each one's lines where they belong — unlike `tac`, which has
-  # to reverse each operand on its own.
+  # `rev a b` is `rev a; rev b`, not `cat a b | rev`. Concatenating first
+  # glues an unterminated last line of `a` onto the first line of `b` and
+  # reverses them as one record.
   defp read_operands(bash, files, stdin) do
     files
     |> defaults_to_stdin()
-    |> Enum.reduce_while({:ok, "", bash.fs}, fn file, {:ok, acc, fs} ->
+    |> Enum.reduce_while({:ok, [], bash.fs}, fn file, {:ok, acc, fs} ->
       case StdinOperand.read(fs, bash.cwd, file, stdin) do
-        {:ok, data, fs} -> {:cont, {:ok, acc <> data, fs}}
+        {:ok, data, fs} -> {:cont, {:ok, [reverse_chars_per_line(data) | acc], fs}}
         {:error, error} -> {:halt, {:error, "rev: #{file}: #{FS.strerror(error)}\n"}}
       end
     end)
+    |> collect()
   end
 
   defp defaults_to_stdin([]), do: ["-"]
   defp defaults_to_stdin(files), do: files
 
+  defp collect({:ok, reversed, fs}),
+    do: {:ok, reversed |> Enum.reverse() |> IO.iodata_to_binary(), fs}
+
+  defp collect({:error, _msg} = error), do: error
+
   defp reverse_chars_per_line(content) do
-    has_trailing_newline = String.ends_with?(content, "\n")
+    content
+    |> records()
+    |> Enum.map(&reverse_record/1)
+    |> IO.iodata_to_binary()
+  end
 
-    lines =
-      content
-      |> String.split("\n", trim: false)
+  # A record is text up to and including its separator. The last record
+  # carries none when the input has no trailing newline, so reversing
+  # characters must not manufacture one.
+  defp records(content) do
+    content
+    |> String.split("\n", trim: false)
+    |> attach_separators()
+  end
 
-    lines =
-      if has_trailing_newline and List.last(lines) == "" do
-        List.delete_at(lines, -1)
-      else
-        lines
-      end
+  defp attach_separators([""]), do: []
 
-    reversed = Enum.map_join(lines, "\n", &reverse_string/1)
+  defp attach_separators(parts) do
+    {last, rest} = List.pop_at(parts, -1)
+    rest |> Enum.map(&(&1 <> "\n")) |> attach_last(last)
+  end
 
-    if has_trailing_newline do
-      reversed <> "\n"
+  defp attach_last(terminated, ""), do: terminated
+  defp attach_last(terminated, last) when is_binary(last), do: terminated ++ [last]
+
+  defp reverse_record(record) do
+    if String.ends_with?(record, "\n") do
+      reverse_string(binary_part(record, 0, byte_size(record) - 1)) <> "\n"
     else
-      reversed
+      reverse_string(record)
     end
   end
 

--- a/lib/just_bash/commands/tac.ex
+++ b/lib/just_bash/commands/tac.ex
@@ -25,7 +25,7 @@ defmodule JustBash.Commands.Tac do
     |> defaults_to_stdin()
     |> Enum.reduce_while({:ok, [], bash.fs}, fn file, {:ok, acc, fs} ->
       case StdinOperand.read(fs, bash.cwd, file, stdin) do
-        {:ok, data, fs} -> {:cont, {:ok, [reverse_lines(data) | acc], fs}}
+        {:ok, data, fs} -> {:cont, {:ok, [reverse_records(data) | acc], fs}}
         {:error, error} -> {:halt, {:error, read_error(file, error)}}
       end
     end)
@@ -48,20 +48,29 @@ defmodule JustBash.Commands.Tac do
   defp read_error(file, error),
     do: "tac: failed to open '#{file}' for reading: #{FS.strerror(error)}\n"
 
-  defp reverse_lines(content) do
-    lines = String.split(content, "\n", trim: false)
-
-    lines =
-      if List.last(lines) == "" do
-        List.delete_at(lines, -1)
-      else
-        lines
-      end
-
-    if lines == [] do
-      ""
-    else
-      Enum.reverse(lines) |> Enum.join("\n") |> Kernel.<>("\n")
-    end
+  # GNU tac reverses records, not newline-split lines. A record is the text
+  # up to and including its separator; an unterminated last record carries
+  # none. Split-and-rejoin manufactured a separator `"1\n2"` never had.
+  defp reverse_records(content) do
+    content
+    |> records()
+    |> Enum.reverse()
+    |> IO.iodata_to_binary()
   end
+
+  defp records(content) do
+    content
+    |> String.split("\n", trim: false)
+    |> attach_separators()
+  end
+
+  defp attach_separators([""]), do: []
+
+  defp attach_separators(parts) do
+    {last, rest} = List.pop_at(parts, -1)
+    rest |> Enum.map(&(&1 <> "\n")) |> attach_last(last)
+  end
+
+  defp attach_last(terminated, ""), do: terminated
+  defp attach_last(terminated, last) when is_binary(last), do: terminated ++ [last]
 end

--- a/test/commands/stdin_operand_test.exs
+++ b/test/commands/stdin_operand_test.exs
@@ -193,6 +193,26 @@ defmodule JustBash.Commands.StdinOperandTest do
       assert {%{stdout: "4\n3\n2\n1\n"}, _} = JustBash.exec(bash, piped <> "tac /b -")
     end
 
+    # `tac n a` is still `tac n; tac a`. The unterminated last record of n
+    # stays without a separator, so it glues to a's first reversed record.
+    # Bytes pinned against /usr/bin/tac on this host.
+    test "tac two-file unterminated last line matches GNU record split" do
+      bash = JustBash.new(files: %{"/n" => "1\n2", "/a" => "1\n2\n"})
+
+      assert {%{stdout: "21\n2\n1\n"}, _} = JustBash.exec(bash, "tac /n /a")
+      assert {%{stdout: "2\n1\n21\n"}, _} = JustBash.exec(bash, "tac /a /n")
+    end
+
+    # GNU rev reverses each operand on its own and concatenates. Concatenating
+    # first then reversing glues the unterminated last line of n to the first
+    # line of a and reverses them as one record.
+    test "rev reverses each operand on its own, including unterminated last lines" do
+      bash = JustBash.new(files: %{"/n" => "ab\ncd", "/a" => "ef\ngh\n"})
+
+      assert {%{stdout: "ba\ndcfe\nhg\n"}, _} = JustBash.exec(bash, "rev /n /a")
+      assert {%{stdout: "fe\nhg\nba\ndc"}, _} = JustBash.exec(bash, "rev /a /n")
+    end
+
     test "an operand after `--` is a path, dash and all" do
       bash = JustBash.new(files: %{"/-f" => "12\n34\n"})
 

--- a/test/commands/text_processing_test.exs
+++ b/test/commands/text_processing_test.exs
@@ -1254,6 +1254,54 @@ defmodule JustBash.Commands.TextProcessingTest do
       assert result.exit_code == 1
       assert result.stderr =~ "No such file"
     end
+
+    # GNU tac reverses records, and a record is text up to and including its
+    # separator. An unterminated last record carries no newline, so reversing
+    # "1\n2" is "2" then "1\n" — "21\n" — not a split-and-rejoin that
+    # manufactures a separator. Bytes pinned against /usr/bin/tac.
+    test "tac of an unterminated last line does not invent a newline" do
+      bash = JustBash.new(files: %{"/n" => "1\n2"})
+      {result, _} = JustBash.exec(bash, "tac /n")
+      assert result.exit_code == 0
+      assert result.stdout == "21\n"
+    end
+
+    test "tac of stdin without a trailing newline matches the file case" do
+      bash = JustBash.new()
+      {result, _} = JustBash.exec(bash, "printf '1\\n2' | tac")
+      assert result.exit_code == 0
+      assert result.stdout == "21\n"
+    end
+
+    test "tac of a single unterminated line does not invent a newline" do
+      bash = JustBash.new(files: %{"/only" => "only"})
+      {result, _} = JustBash.exec(bash, "tac /only")
+      assert result.exit_code == 0
+      assert result.stdout == "only"
+    end
+
+    test "tac of terminated input still reverses lines" do
+      bash = JustBash.new(files: %{"/a" => "1\n2\n"})
+      {result, _} = JustBash.exec(bash, "tac /a")
+      assert result.exit_code == 0
+      assert result.stdout == "2\n1\n"
+    end
+
+    test "tac | tac of terminated input restores the original bytes" do
+      bash = JustBash.new(files: %{"/a" => "1\n2\n"})
+      {result, _} = JustBash.exec(bash, "tac /a | tac")
+      assert result.exit_code == 0
+      assert result.stdout == "1\n2\n"
+    end
+
+    # GNU itself does not restore "1\n2": the missing separator is gone after
+    # the first reverse, so the second tac sees the single record "21\n".
+    test "tac | tac of unterminated input matches GNU" do
+      bash = JustBash.new(files: %{"/n" => "1\n2"})
+      {result, _} = JustBash.exec(bash, "tac /n | tac")
+      assert result.exit_code == 0
+      assert result.stdout == "21\n"
+    end
   end
 
   describe "rev command" do
@@ -1286,6 +1334,15 @@ defmodule JustBash.Commands.TextProcessingTest do
       {result, _} = JustBash.exec(bash, "rev /nonexistent")
       assert result.exit_code == 1
       assert result.stderr =~ "No such file"
+    end
+
+    # Single-file rev already keeps an unterminated last line. Pin the bytes
+    # so a later split-and-rejoin cannot invent a separator the way tac did.
+    test "rev of an unterminated last line does not invent a newline" do
+      bash = JustBash.new(files: %{"/n" => "ab\ncd"})
+      {result, _} = JustBash.exec(bash, "rev /n")
+      assert result.exit_code == 0
+      assert result.stdout == "ba\ndc"
     end
   end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #82

`tac` reversed by splitting on newlines and rejoining, which manufactured a separator the input never had.

```
# /n = "1\n2"   (no trailing newline)
# before
$ tac /n          →  "2\n1\n"
$ tac /n | tac    →  "1\n2\n"

# after (matches GNU /usr/bin/tac on this host)
$ tac /n          →  "21\n"
$ tac /n | tac    →  "21\n"
$ tac /a          →  "2\n1\n"     (/a = "1\n2\n")
$ tac /a | tac    →  "1\n2\n"
```

`tac` reverses *records*. A record is text up to and including its separator. The unterminated last record of `"1\n2"` is `"2"` — no separator — so reverse is `"2"` then `"1\n"`, i.e. `"21\n"`.

## Two-file case

Pinned against `/usr/bin/tac` on this host (not `gtac`; they are the same GNU binary here). Matches the string in #82:

```
# /n = "1\n2",  /a = "1\n2\n"
$ tac /n /a   →  "21\n2\n1\n"
$ tac /a /n   →  "2\n1\n21\n"
```

Ordering was already `tac a; tac b` after #74. The remaining hole was the same record split on each operand.

## `tac | tac` invertibility

Terminated input is invertible: `"1\n2\n"` → `"2\n1\n"` → `"1\n2\n"`.

Unterminated input is **not** invertible on GNU either. After the first reverse the missing separator is gone, so the second `tac` sees the single record `"21\n"` and prints it again. Tests byte-compare that GNU result rather than claiming a round-trip the oracle does not do.

## rev

Single-file `rev` already kept an unterminated last line (`"ab\ncd"` → `"ba\ndc"`). The analogous hole was two-file: concatenating first glued the last line of `n` onto the first line of `a` and reversed them as one record.

```
# /n = "ab\ncd",  /a = "ef\ngh\n"
# before (cat then rev):  "ba\nfedc\nhg\n"
# after  (rev n; rev a), pinned against /usr/bin/rev:  "ba\ndcfe\nhg\n"
```

## tail -r

GNU `tail` has no `-r`. JustBash `tail` does not implement it. No reverse-record path there.

## Changes

- `tac` splits into records that carry their own separator and reverses those.
- `rev` uses the same record split, and reverses each operand on its own (`rev a; rev b`).
- Byte-compare tests for unterminated single-file, stdin, two-file, terminated identity, and `tac | tac`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added new tests
- [x] All existing tests pass

Local gates on this revision:

```
$ mix compile --warnings-as-errors
Generated just_bash app

$ mix format --check-formatted

$ mix credo
Analysis took 2.1 seconds
5443 mods/funs, found no issues.

$ mix credo --strict
[F] Avoid apply/2 and apply/3 when the number of arguments is known.
    test/support/banned_fixture_apply.ex:4:16
# pre-existing intentional test fixture

$ mix test
Finished in 36.2 seconds (35.7s async, 0.4s sync)
2 doctests, 62 properties, 5439 tests, 0 failures (5 excluded)

$ mix docs --warnings-as-errors

$ mix dialyzer
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done (passed successfully)
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
- [x] I have updated the CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30738347-09bf-40e2-9bb9-a4e0c66056dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30738347-09bf-40e2-9bb9-a4e0c66056dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

