### PR TITLE
fix: /dev/null exists as a filesystem node so operands agree with redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * honour `--` as end-of-options for file-operand commands ([#83](https://github.com/elixir-ai-tools/just_bash/issues/83))
 * head default line count no longer emits a trailing blank line ([#80](https://github.com/elixir-ai-tools/just_bash/issues/80))
 * tac no longer invents a newline on an unterminated last record ([#82](https://github.com/elixir-ai-tools/just_bash/issues/82))
+* `/dev/null` exists as a filesystem node, so operands agree with redirects ([#78](https://github.com/elixir-ai-tools/just_bash/issues/78))
 
 ## [0.1.0] - 2026-01-11
 

--- a/lib/just_bash/commands/tee.ex
+++ b/lib/just_bash/commands/tee.ex
@@ -59,13 +59,8 @@ defmodule JustBash.Commands.Tee do
 
   defp write_files(fs, cwd, files, content, append) do
     Enum.reduce(files, {fs, "", 0}, fn file, {acc_fs, acc_stderr, acc_code} ->
-      # /dev/null is a black hole - just ignore writes to it
-      if file == "/dev/null" do
-        {acc_fs, acc_stderr, acc_code}
-      else
-        resolved = FS.resolve_path(cwd, file)
-        write_single_file(acc_fs, {cwd, resolved}, file, content, append, acc_stderr, acc_code)
-      end
+      resolved = FS.resolve_path(cwd, file)
+      write_single_file(acc_fs, {cwd, resolved}, file, content, append, acc_stderr, acc_code)
     end)
   end
 

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -15,7 +15,9 @@ defmodule JustBash.FS do
   - **Core operations** delegate to `VFS` and follow vfs conventions:
     reads return `{:ok, payload, fs}` (thread the updated `fs` forward —
     lazy backends cache on read), mutations return `{:ok, fs}`, and all
-    errors are `%VFS.Error{}` structs.
+    errors are `%VFS.Error{}` structs. Paths in `JustBash.FS.Special`
+    (`/dev/null`, and the `/dev` directory that holds it) are answered
+    here before any backend is consulted.
   - **POSIX extensions** (`lstat/2`, `symlink/3`, `readlink/2`, `link/3`,
     `chmod/3`, `append_file/3`) dispatch through `JustBash.FS.POSIX`,
     degrading gracefully on backends without them.
@@ -25,6 +27,7 @@ defmodule JustBash.FS do
 
   alias JustBash.FS.Memory
   alias JustBash.FS.POSIX
+  alias JustBash.FS.Special
   alias JustBash.Limit
   alias VFS.Error
   alias VFS.Path, as: VPath
@@ -165,33 +168,73 @@ defmodule JustBash.FS do
     end
   end
 
-  # ── core operations (delegated to VFS) ───────────────────────────────────
+  # ── core operations (delegated to VFS, special files first) ──────────────
 
   @doc "See `VFS.read_file/2`."
   @spec read_file(t(), String.t()) :: {:ok, binary(), t()} | {:error, Error.t()}
-  defdelegate read_file(fs, path), to: VFS
+  def read_file(fs, path) do
+    case special(path) do
+      {:ok, kind, normalized} -> Special.read_file(fs, kind, normalized)
+      :none -> VFS.read_file(fs, path)
+    end
+  end
 
   @doc "See `VFS.stream_read/3`."
   @spec stream_read(t(), String.t(), keyword()) ::
           {:ok, Enumerable.t(), t()} | {:error, Error.t()}
-  defdelegate stream_read(fs, path, opts \\ []), to: VFS
+  def stream_read(fs, path, opts \\ []) do
+    case special(path) do
+      {:ok, kind, normalized} -> Special.stream_read(fs, kind, normalized, opts)
+      :none -> VFS.stream_read(fs, path, opts)
+    end
+  end
 
   @doc "See `VFS.write_file/4`. The default backend honors `:mode` and `:mtime` opts."
   @spec write_file(t(), String.t(), binary(), write_opts()) ::
           {:ok, t()} | {:error, Error.t()}
-  defdelegate write_file(fs, path, content, opts \\ []), to: VFS
+  def write_file(fs, path, content, opts \\ []) do
+    case special(path) do
+      {:ok, kind, normalized} -> Special.write_file(fs, kind, normalized, content)
+      :none -> VFS.write_file(fs, path, content, opts)
+    end
+  end
 
   @doc "See `VFS.exists?/2`."
   @spec exists?(t(), String.t()) :: {boolean(), t()}
-  defdelegate exists?(fs, path), to: VFS
+  def exists?(fs, path) do
+    case special(path) do
+      {:ok, kind, _normalized} -> Special.exists?(fs, kind)
+      :none -> VFS.exists?(fs, path)
+    end
+  end
 
   @doc "See `VFS.stat/2`. Follows symlinks."
   @spec stat(t(), String.t()) :: {:ok, VFS.Stat.t(), t()} | {:error, Error.t()}
-  defdelegate stat(fs, path), to: VFS
+  def stat(fs, path) do
+    case special(path) do
+      {:ok, kind, normalized} -> Special.stat(fs, kind, normalized)
+      :none -> VFS.stat(fs, path)
+    end
+  end
 
   @doc "See `VFS.readdir/2`."
   @spec readdir(t(), String.t()) :: {:ok, Enumerable.t(), t()} | {:error, Error.t()}
-  defdelegate readdir(fs, path), to: VFS
+  def readdir(fs, path) do
+    case special(path) do
+      {:ok, kind, normalized} ->
+        {entries, fs} = backend_entries(fs, path)
+        Special.readdir(fs, kind, normalized, entries)
+
+      :none ->
+        case VFS.readdir(fs, path) do
+          {:ok, entries, fs} ->
+            {:ok, Special.merge_children(normalize_path(path), Enum.to_list(entries)), fs}
+
+          error ->
+            error
+        end
+    end
+  end
 
   @doc "See `VFS.mkdir/3`. Pass `parents: true` for `mkdir -p` behavior."
   @spec mkdir(t(), String.t(), mkdir_opts()) :: {:ok, t()} | {:error, Error.t()}
@@ -204,7 +247,10 @@ defmodule JustBash.FS do
               "See UPGRADING.md."
     end
 
-    VFS.mkdir(fs, path, opts)
+    case special(path) do
+      {:ok, kind, normalized} -> Special.mkdir(fs, kind, normalized, opts)
+      :none -> VFS.mkdir(fs, path, opts)
+    end
   end
 
   @doc "See `VFS.rm/3`. Pass `recursive: true` to remove directory trees."
@@ -218,7 +264,10 @@ defmodule JustBash.FS do
               "{:error, %VFS.Error{kind: :enoent}} at the call site instead. See UPGRADING.md."
     end
 
-    VFS.rm(fs, path, opts)
+    case special(path) do
+      {:ok, kind, normalized} -> Special.rm(kind, normalized)
+      :none -> VFS.rm(fs, path, opts)
+    end
   end
 
   @doc """
@@ -235,27 +284,58 @@ defmodule JustBash.FS do
 
   @doc "Get stat information without following symlinks."
   @spec lstat(t(), String.t()) :: {:ok, VFS.Stat.t(), t()} | {:error, Error.t()}
-  defdelegate lstat(fs, path), to: POSIX
+  def lstat(fs, path) do
+    case special(path) do
+      {:ok, kind, normalized} -> Special.stat(fs, kind, normalized)
+      :none -> POSIX.lstat(fs, path)
+    end
+  end
 
   @doc "Read the target of a symbolic link."
   @spec readlink(t(), String.t()) :: {:ok, String.t(), t()} | {:error, Error.t()}
-  defdelegate readlink(fs, path), to: POSIX
+  def readlink(fs, path) do
+    case special(path) do
+      {:ok, kind, normalized} -> Special.readlink(kind, normalized)
+      :none -> POSIX.readlink(fs, path)
+    end
+  end
 
   @doc "Create a symbolic link at `link_path` pointing to `target`."
   @spec symlink(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
-  defdelegate symlink(fs, target, link_path), to: POSIX
+  def symlink(fs, target, link_path) do
+    case special(link_path) do
+      {:ok, _kind, normalized} -> Special.refuse_create(normalized)
+      :none -> POSIX.symlink(fs, target, link_path)
+    end
+  end
 
   @doc "Create a hard link."
   @spec link(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
-  defdelegate link(fs, existing_path, new_path), to: POSIX
+  def link(fs, existing_path, new_path) do
+    case {special(existing_path), special(new_path)} do
+      {{:ok, kind, normalized}, _} -> Special.refuse_link(kind, normalized)
+      {:none, {:ok, _kind, normalized}} -> Special.refuse_create(normalized)
+      {:none, :none} -> POSIX.link(fs, existing_path, new_path)
+    end
+  end
 
   @doc "Change file/directory permissions."
   @spec chmod(t(), String.t(), non_neg_integer()) :: {:ok, t()} | {:error, Error.t()}
-  defdelegate chmod(fs, path, mode), to: POSIX
+  def chmod(fs, path, mode) do
+    case special(path) do
+      {:ok, kind, _normalized} -> Special.chmod(fs, kind)
+      :none -> POSIX.chmod(fs, path, mode)
+    end
+  end
 
   @doc "Append content to a file, creating it if it doesn't exist."
   @spec append_file(t(), String.t(), binary()) :: {:ok, t()} | {:error, Error.t()}
-  defdelegate append_file(fs, path, content), to: POSIX
+  def append_file(fs, path, content) do
+    case special(path) do
+      {:ok, kind, normalized} -> Special.append_file(fs, kind, normalized, content)
+      :none -> POSIX.append_file(fs, path, content)
+    end
+  end
 
   # ── compositions ─────────────────────────────────────────────────────────
 
@@ -359,6 +439,24 @@ defmodule JustBash.FS do
   def strerror(kind) when is_atom(kind), do: to_string(kind)
 
   # ── private ──────────────────────────────────────────────────────────────
+
+  defp special(path) do
+    normalized = normalize_path(path)
+
+    case Special.lookup(normalized) do
+      {:ok, kind} -> {:ok, kind, normalized}
+      :none -> :none
+    end
+  end
+
+  # A special directory may not exist in any backend; missing is empty, not
+  # an error, so `/dev` still lists `null` on a fresh `FS.new/0`.
+  defp backend_entries(fs, path) do
+    case VFS.readdir(fs, path) do
+      {:ok, entries, fs} -> {Enum.to_list(entries), fs}
+      {:error, _} -> {[], fs}
+    end
+  end
 
   # The stat behind `check_directory_spelling/3`. The error names the operand
   # as it was spelled, since that spelling is what the caller reports.

--- a/lib/just_bash/fs/special.ex
+++ b/lib/just_bash/fs/special.ex
@@ -1,0 +1,129 @@
+defmodule JustBash.FS.Special do
+  @moduledoc """
+  Device nodes the filesystem layer services itself, rather than storing
+  them in a backend.
+
+  `/dev/null` is the one device the shell already handled on the write
+  side of redirection (`> /dev/null` discards). It did not exist in the
+  VFS, so `cat /dev/null` and `test -e /dev/null` failed even while
+  `cat < /dev/null` succeeded. Resolution consults this table so the
+  read side, the write side, and the operand side agree.
+
+  `/dev` is the directory that holds it. Without that node, `tee /dev/null`
+  would fail looking up the parent, and `ls /dev` would report the path
+  missing. Other `/dev` nodes (`zero`, `stdin`, `stdout`, `stderr`) are
+  not in the table; add them here if the same invariant ever needs them.
+  """
+
+  alias VFS.Error
+  alias VFS.Stat
+
+  @type kind :: :null | :directory
+
+  @null "/dev/null"
+  @dev "/dev"
+  @mtime ~U[1970-01-01 00:00:00Z]
+
+  @doc """
+  Look up a *normalized* path in the special-file table.
+
+  Callers must pass a path that `JustBash.FS.normalize_path/1` has already
+  rooted and collapsed, so `/dev/./null` and `/dev/null` name the same node.
+  """
+  @spec lookup(String.t()) :: {:ok, kind()} | :none
+  def lookup(@null), do: {:ok, :null}
+  def lookup(@dev), do: {:ok, :directory}
+  def lookup(_path), do: :none
+
+  @doc "True when a normalized path is the null device."
+  @spec null?(String.t()) :: boolean()
+  def null?(path), do: lookup(path) == {:ok, :null}
+
+  @doc """
+  Virtual children a special path (or `/`) contributes to `readdir`.
+
+  `/` lists `dev` so the directory that holds `/dev/null` is visible;
+  `/dev` lists `null`.
+  """
+  @spec children(String.t()) :: [String.t()]
+  def children("/"), do: ["dev"]
+  def children(@dev), do: ["null"]
+  def children(_path), do: []
+
+  @spec merge_children(String.t(), [String.t()]) :: [String.t()]
+  def merge_children(path, entries) do
+    entries
+    |> Enum.concat(children(path))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  @spec read_file(term(), kind(), String.t()) :: {:ok, binary(), term()} | {:error, Error.t()}
+  def read_file(fs, :null, _path), do: {:ok, "", fs}
+  def read_file(_fs, :directory, path), do: {:error, Error.new(:eisdir, path: path)}
+
+  @spec write_file(term(), kind(), String.t(), binary()) :: {:ok, term()} | {:error, Error.t()}
+  def write_file(fs, :null, _path, _content), do: {:ok, fs}
+  def write_file(_fs, :directory, path, _content), do: {:error, Error.new(:eisdir, path: path)}
+
+  @spec append_file(term(), kind(), String.t(), binary()) :: {:ok, term()} | {:error, Error.t()}
+  def append_file(fs, :null, _path, _content), do: {:ok, fs}
+  def append_file(_fs, :directory, path, _content), do: {:error, Error.new(:eisdir, path: path)}
+
+  @spec exists?(term(), kind()) :: {true, term()}
+  def exists?(fs, _kind), do: {true, fs}
+
+  @spec stat(term(), kind(), String.t()) :: {:ok, Stat.t(), term()}
+  def stat(fs, :null, _path) do
+    {:ok, %Stat{type: :regular, size: 0, mode: 0o666, mtime: @mtime}, fs}
+  end
+
+  def stat(fs, :directory, _path) do
+    {:ok, %Stat{type: :directory, size: 0, mode: 0o755, mtime: @mtime}, fs}
+  end
+
+  @spec stream_read(term(), kind(), String.t(), keyword()) ::
+          {:ok, Enumerable.t(), term()} | {:error, Error.t()}
+  def stream_read(fs, :null, path, opts) do
+    case VFS.StreamOptions.apply("", opts) do
+      {:ok, stream} -> {:ok, stream, fs}
+      {:error, kind} -> {:error, Error.new(kind, path: path)}
+    end
+  end
+
+  def stream_read(_fs, :directory, path, _opts), do: {:error, Error.new(:eisdir, path: path)}
+
+  @spec readdir(term(), kind(), String.t(), [String.t()]) ::
+          {:ok, [String.t()], term()} | {:error, Error.t()}
+  def readdir(_fs, :null, path, _backend_entries), do: {:error, Error.new(:enotdir, path: path)}
+
+  def readdir(fs, :directory, path, backend_entries) do
+    {:ok, merge_children(path, backend_entries), fs}
+  end
+
+  @spec rm(kind(), String.t()) :: {:error, Error.t()}
+  def rm(_kind, path), do: {:error, Error.new(:eacces, path: path)}
+
+  @spec mkdir(term(), kind(), String.t(), keyword()) :: {:ok, term()} | {:error, Error.t()}
+  def mkdir(fs, :directory, path, opts) do
+    if Keyword.get(opts, :parents, false) do
+      {:ok, fs}
+    else
+      {:error, Error.new(:eexist, path: path)}
+    end
+  end
+
+  def mkdir(_fs, :null, path, _opts), do: {:error, Error.new(:eexist, path: path)}
+
+  @spec chmod(term(), kind()) :: {:ok, term()}
+  def chmod(fs, _kind), do: {:ok, fs}
+
+  @spec readlink(kind(), String.t()) :: {:error, Error.t()}
+  def readlink(_kind, path), do: {:error, Error.new(:einval, path: path)}
+
+  @spec refuse_create(String.t()) :: {:error, Error.t()}
+  def refuse_create(path), do: {:error, Error.new(:eexist, path: path)}
+
+  @spec refuse_link(kind(), String.t()) :: {:error, Error.t()}
+  def refuse_link(_kind, path), do: {:error, Error.new(:eacces, path: path)}
+end

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -19,11 +19,11 @@ defmodule JustBash.Interpreter.Executor.Redirection do
 
   @type result :: %{stdout: String.t(), stderr: String.t(), exit_code: non_neg_integer()}
 
-  # The one path the shell services itself instead of opening in the
-  # filesystem. Both directions have to name the same set: `> /dev/null`
-  # discards, so `< /dev/null` reads empty. Otherwise `cmd < /dev/null` — the
-  # standard way to hand a command a closed stdin — reports a missing file for
-  # a target that was never meant to be one.
+  # The one path the shell discards on the write side instead of opening in
+  # the filesystem. The read side (`< /dev/null`) and every command operand
+  # go through `JustBash.FS`, which services the same path as a special file.
+  # Both layers have to name the same set: `> /dev/null` discards, so
+  # `< /dev/null` and `cat /dev/null` read empty.
   @null_device "/dev/null"
 
   @typedoc """
@@ -440,10 +440,8 @@ defmodule JustBash.Interpreter.Executor.Redirection do
     nil
   end
 
-  # `< /dev/null` is the read side of `> /dev/null`: the shell services it
-  # without touching the filesystem, and the command gets an empty stdin.
-  defp read_stdin_target(@null_device, _bash), do: ""
-
+  # `< /dev/null` is the read side of `> /dev/null`. The filesystem layer
+  # services that path as a special file, so the ordinary read is empty.
   defp read_stdin_target(path, bash) do
     resolved = FS.resolve_path(bash.cwd, path)
 

--- a/test/commands/dev_null_test.exs
+++ b/test/commands/dev_null_test.exs
@@ -1,0 +1,110 @@
+defmodule JustBash.Commands.DevNullTest do
+  @moduledoc """
+  `/dev/null` as a file operand must agree with `/dev/null` as a redirect.
+
+  Issue #78: PR #74 taught the shell to service `cmd < /dev/null`, but the
+  path still did not exist in the VFS, so every command that resolved it as
+  an operand failed. The rows below are the table from that issue, checked
+  against GNU coreutils.
+  """
+  use ExUnit.Case, async: true
+
+  describe "operand and redirect agree" do
+    test "cat /dev/null and cat < /dev/null both exit 0 with empty stdout" do
+      bash = JustBash.new()
+
+      {as_operand, _} = JustBash.exec(bash, "cat /dev/null; echo rc=$?")
+      {as_redirect, _} = JustBash.exec(bash, "cat < /dev/null; echo rc=$?")
+
+      assert as_operand.stdout == "rc=0\n"
+      assert as_operand.stderr == ""
+      assert as_redirect.stdout == "rc=0\n"
+      assert as_redirect.stderr == ""
+    end
+
+    test "echo > /dev/null still discards stdout" do
+      {result, _} = JustBash.exec(JustBash.new(), "echo hello > /dev/null")
+
+      assert result.exit_code == 0
+      assert result.stdout == ""
+      assert result.stderr == ""
+    end
+  end
+
+  describe "the #78 command table" do
+    test "sort /dev/null exits 0" do
+      {result, _} = JustBash.exec(JustBash.new(), "sort /dev/null")
+
+      assert result.exit_code == 0
+      assert result.stdout == ""
+      assert result.stderr == ""
+    end
+
+    test "wc -l /dev/null counts zero lines" do
+      {result, _} = JustBash.exec(JustBash.new(), "wc -l /dev/null")
+
+      assert result.exit_code == 0
+      assert result.stdout == "      0 /dev/null\n"
+      assert result.stderr == ""
+    end
+
+    test "head /dev/null exits 0" do
+      {result, _} = JustBash.exec(JustBash.new(), "head /dev/null")
+
+      assert result.exit_code == 0
+      assert result.stdout == ""
+      assert result.stderr == ""
+    end
+
+    test "cp /dev/null /out truncates /out" do
+      bash = JustBash.new(files: %{"/out" => "old content\n"})
+      {result, bash} = JustBash.exec(bash, "cp /dev/null /out")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, _} = JustBash.exec(bash, "cat /out")
+      assert cat.stdout == ""
+    end
+
+    test "cp /dev/null /out creates an empty /out when it is missing" do
+      {result, bash} = JustBash.exec(JustBash.new(), "cp /dev/null /out")
+
+      assert result.exit_code == 0
+      assert result.stderr == ""
+
+      {cat, _} = JustBash.exec(bash, "cat /out")
+      assert cat.stdout == ""
+    end
+
+    test "test -e /dev/null is true" do
+      {result, _} = JustBash.exec(JustBash.new(), "test -e /dev/null; echo rc=$?")
+
+      assert result.stdout == "rc=0\n"
+      assert result.stderr == ""
+    end
+  end
+
+  describe "writes are discarded" do
+    test "a write through tee does not make later reads return those bytes" do
+      {result, bash} = JustBash.exec(JustBash.new(), "echo secret | tee /dev/null")
+
+      assert result.exit_code == 0
+      assert result.stdout == "secret\n"
+
+      {cat, _} = JustBash.exec(bash, "cat /dev/null")
+      assert cat.stdout == ""
+      assert cat.exit_code == 0
+    end
+
+    test "cp of a real file onto /dev/null discards without creating a regular file" do
+      bash = JustBash.new(files: %{"/src" => "payload\n"})
+      {result, bash} = JustBash.exec(bash, "cp /src /dev/null")
+
+      assert result.exit_code == 0
+
+      {cat, _} = JustBash.exec(bash, "cat /dev/null")
+      assert cat.stdout == ""
+    end
+  end
+end

--- a/test/commands/stdin_operand_test.exs
+++ b/test/commands/stdin_operand_test.exs
@@ -12,9 +12,8 @@ defmodule JustBash.Commands.StdinOperandTest do
       exit, which is worse — a pipeline under `set -e` now dies.
 
     * `/dev/null`, which the write side of redirection already special-cases
-      (`classify_redirection/3`) but the read side did not. `cmd < /dev/null`
-      is the standard way to close a command's stdin, and it started aborting
-      the command.
+      (`classify_redirection/3`). The filesystem layer now services the same
+      path as a special file, so `cmd < /dev/null` and `cmd /dev/null` agree.
 
   The `-` rows are checked against the same command reading a real file with
   the same bytes, rather than against a literal transcript: the invariant is
@@ -248,9 +247,9 @@ defmodule JustBash.Commands.StdinOperandTest do
     end
 
     test "the read side agrees with the write side about which paths are special" do
-      # `> /dev/null` discards without touching the filesystem; `< /dev/null`
-      # has to be the same set of paths, or the two disagree about what a path
-      # even is.
+      # `> /dev/null` discards; `< /dev/null` has to be the same set of paths,
+      # or the two disagree about what a path even is. The filesystem layer
+      # now holds that set, so the operand `cat /dev/null` agrees too.
       {result, _bash} =
         JustBash.exec(sandbox(), "echo hi > /dev/null; echo rc=$?; cat < /dev/null; echo rc=$?")
 

--- a/test/just_bash/fs_test.exs
+++ b/test/just_bash/fs_test.exs
@@ -795,4 +795,66 @@ defmodule JustBash.FSTest do
                FS.link(fs, "/a/f.txt", "/b/g")
     end
   end
+
+  describe "special files" do
+    # `/dev/null` is not stored in the memory backend. Resolution consults a
+    # special-file table so the read side, the write side and the operand
+    # side agree — issue #78.
+    test "read_file of /dev/null is empty" do
+      fs = FS.new()
+      assert {:ok, "", _fs} = FS.read_file(fs, "/dev/null")
+      assert {:ok, "", _fs} = FS.read_file(fs, "/dev/./null")
+    end
+
+    test "write_file to /dev/null discards without persisting" do
+      fs = FS.new()
+      assert {:ok, fs} = FS.write_file(fs, "/dev/null", "secret")
+      assert {:ok, "", _fs} = FS.read_file(fs, "/dev/null")
+    end
+
+    test "append_file to /dev/null discards without persisting" do
+      fs = FS.new()
+      assert {:ok, fs} = FS.append_file(fs, "/dev/null", "secret")
+      assert {:ok, "", _fs} = FS.read_file(fs, "/dev/null")
+    end
+
+    test "exists? and stat see /dev/null" do
+      fs = FS.new()
+      assert {true, fs} = FS.exists?(fs, "/dev/null")
+      assert {:ok, %VFS.Stat{type: :regular, size: 0}, _fs} = FS.stat(fs, "/dev/null")
+      assert {:ok, %VFS.Stat{type: :regular, size: 0}, _fs} = FS.lstat(fs, "/dev/null")
+    end
+
+    test "/dev is a directory holding null" do
+      fs = FS.new()
+      assert {true, fs} = FS.exists?(fs, "/dev")
+      assert {:ok, %VFS.Stat{type: :directory}, fs} = FS.stat(fs, "/dev")
+      assert {:ok, entries, _fs} = FS.readdir(fs, "/dev")
+      assert "null" in Enum.to_list(entries)
+    end
+
+    test "readdir of / includes dev" do
+      fs = FS.new()
+      {:ok, entries, _fs} = FS.readdir(fs, "/")
+      assert "dev" in Enum.to_list(entries)
+    end
+
+    test "cp from /dev/null writes an empty destination" do
+      fs = FS.new(%{"/out" => "old"})
+      assert {:ok, fs} = FS.cp(fs, "/dev/null", "/out")
+      assert {:ok, "", _fs} = FS.read_file(fs, "/out")
+    end
+
+    test "removing /dev/null is refused" do
+      fs = FS.new()
+      assert {:error, %VFS.Error{kind: :eacces}} = FS.rm(fs, "/dev/null")
+      assert {true, _fs} = FS.exists?(fs, "/dev/null")
+    end
+
+    test "a path merely containing dev/null is still a path" do
+      fs = FS.new()
+      assert {:error, %VFS.Error{kind: :enoent}} = FS.read_file(fs, "/nope/dev/null")
+      assert {false, _fs} = FS.exists?(fs, "/nope/dev/null")
+    end
+  end
 end

--- a/test/just_bash/redirect_preflight_test.exs
+++ b/test/just_bash/redirect_preflight_test.exs
@@ -285,12 +285,12 @@ defmodule JustBash.RedirectPreflightTest do
       assert result.stdout == "OR\n"
     end
 
-    test "> /dev/null still discards without touching the filesystem" do
+    test "> /dev/null still discards stdout" do
       {result, b} = JustBash.exec(bash(), "echo hi > /dev/null")
 
       assert result.exit_code == 0
       assert result.stdout == ""
-      refute exists?(b, "/dev/null")
+      assert exists?(b, "/dev/null")
     end
 
     test "2>&1 still folds stderr into stdout" do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #78

`/dev/null` was serviced by the shell but not by the commands, so the redirect worked and the operand did not.

```
# before
$ cat < /dev/null      →  rc=0
$ cat /dev/null        →  rc=1, "cat: /dev/null: No such file or directory"

# after (matches GNU / bash)
$ cat < /dev/null      →  rc=0, empty stdout
$ cat /dev/null        →  rc=0, empty stdout
```

The write side of redirection (`classify_redirection/3`) already discarded `> /dev/null`. The path did not exist in the VFS, so anything that resolved it as an operand failed.

## Approach

The fix is a filesystem-layer special-file table (`JustBash.FS.Special`), not a per-command patch. Resolution consults it before any backend:

| Path | Kind | Read | Write | `exists?` |
| --- | --- | --- | --- | --- |
| `/dev/null` | regular, size 0 | empty | discarded | true |
| `/dev` | directory | `EISDIR` | `EISDIR` | true |

`/dev` is in the table so `tee /dev/null` can stat the parent, and `ls /dev` lists `null`. Other `/dev` nodes (`zero`, `stdin`, `stdout`, `stderr`) are **not** added; they need different semantics (unbounded reads, live streams) and are not required for the read/write/operand invariant.

The write side of redirection still special-cases the literal `/dev/null` so a large `> /dev/null` does not hit the file-size limit. `< /dev/null` now reads through `FS.read_file/2`. `tee` no longer has its own `/dev/null` branch.

## #78 table

| | just_bash (after) | bash / coreutils |
| --- | --- | --- |
| `sort /dev/null` | rc=0 | rc=0 |
| `wc -l /dev/null` | rc=0, `0 /dev/null` | rc=0, `0 /dev/null` |
| `head /dev/null` | rc=0 | rc=0 |
| `cp /dev/null /out` | rc=0, truncates `/out` | rc=0, truncates `/out` |
| `test -e /dev/null` | rc=0 | rc=0 |

`test -f /dev/null` is true here (`VFS.Stat` has no character-device type, and `:regular` is what `cp` / `file` already handle). GNU reports a character special, so `-f` is false. Out of scope unless the same table grows a device type.

## Changes

- `JustBash.FS.Special` — table for `/dev` and `/dev/null`.
- `JustBash.FS` consults the table on read/write/stat/exists/readdir and the POSIX extras.
- `< /dev/null` goes through `FS.read_file/2`; `tee` writes through `FS.write_file/2`.
- Tests for the #78 table, FS-level semantics, and that redirect still discards.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Added new tests
- [x] All existing tests pass

Local gates on this revision:

```
$ mix compile --warnings-as-errors
Generated just_bash app

$ mix format --check-formatted

$ mix credo
Analysis took 2.5 seconds
5488 mods/funs, found no issues.

$ mix credo --strict
[F] Avoid apply/2 and apply/3 when the number of arguments is known.
    test/support/banned_fixture_apply.ex:4:16
# pre-existing intentional test fixture

$ mix test
Finished in 35.9 seconds (35.5s async, 0.4s sync)
2 doctests, 62 properties, 5458 tests, 0 failures (5 excluded)

$ mix docs --warnings-as-errors

$ mix dialyzer
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done (passed successfully)
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass locally with my changes
- [x] I have updated the CHANGELOG.md

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-970336a7-fcfe-4355-9306-6bb1154858e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-970336a7-fcfe-4355-9306-6bb1154858e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

