### PR TITLE
fix: empty path operands are ENOENT, not the current directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* empty-string path operands are `ENOENT`, not the current directory ([#79](https://github.com/elixir-ai-tools/just_bash/issues/79))
 * honour `--` as end-of-options for file-operand commands ([#83](https://github.com/elixir-ai-tools/just_bash/issues/83))
 * head default line count no longer emits a trailing blank line ([#80](https://github.com/elixir-ai-tools/just_bash/issues/80))
 * tac no longer invents a newline on an unterminated last record ([#82](https://github.com/elixir-ai-tools/just_bash/issues/82))

--- a/lib/just_bash/commands/cd.ex
+++ b/lib/just_bash/commands/cd.ex
@@ -20,8 +20,8 @@ defmodule JustBash.Commands.Cd do
       end
 
     case FS.resolve_path(bash.cwd, target) do
-      {:error, :enoent} ->
-        {Command.error("bash: cd: #{target}: #{FS.strerror(:enoent)}\n"), bash}
+      {:error, %VFS.Error{} = error} ->
+        {Command.error("bash: cd: #{target}: #{FS.strerror(error)}\n"), bash}
 
       resolved ->
         stat_and_enter(bash, target, resolved, args)

--- a/lib/just_bash/commands/cd.ex
+++ b/lib/just_bash/commands/cd.ex
@@ -19,8 +19,16 @@ defmodule JustBash.Commands.Cd do
         {[path | _], []} -> path
       end
 
-    resolved = FS.resolve_path(bash.cwd, target)
+    case FS.resolve_path(bash.cwd, target) do
+      {:error, :enoent} ->
+        {Command.error("bash: cd: #{target}: #{FS.strerror(:enoent)}\n"), bash}
 
+      resolved ->
+        stat_and_enter(bash, target, resolved, args)
+    end
+  end
+
+  defp stat_and_enter(bash, target, resolved, args) do
     case FS.stat(bash.fs, resolved) do
       {:ok, %{type: :directory}, fs} ->
         new_env =

--- a/lib/just_bash/commands/command.ex
+++ b/lib/just_bash/commands/command.ex
@@ -33,7 +33,7 @@ defmodule JustBash.Commands.Command do
   @doc """
   Resolve a path relative to the current working directory.
   """
-  @spec resolve_path(bash(), String.t()) :: String.t()
+  @spec resolve_path(bash(), String.t()) :: FS.resolved()
   def resolve_path(bash, path) do
     FS.resolve_path(bash.cwd, path)
   end

--- a/lib/just_bash/commands/mkdir.ex
+++ b/lib/just_bash/commands/mkdir.ex
@@ -90,6 +90,8 @@ defmodule JustBash.Commands.Mkdir do
     |> Enum.scan(&Path.join(&2, &1))
   end
 
+  defp non_directory?(_fs, {:error, :enoent}), do: false
+
   defp non_directory?(fs, resolved) do
     match?({:ok, %VFS.Stat{type: type}, _fs} when type != :directory, FS.stat(fs, resolved))
   end

--- a/lib/just_bash/commands/mkdir.ex
+++ b/lib/just_bash/commands/mkdir.ex
@@ -90,7 +90,7 @@ defmodule JustBash.Commands.Mkdir do
     |> Enum.scan(&Path.join(&2, &1))
   end
 
-  defp non_directory?(_fs, {:error, :enoent}), do: false
+  defp non_directory?(_fs, {:error, %VFS.Error{}}), do: false
 
   defp non_directory?(fs, resolved) do
     match?({:ok, %VFS.Stat{type: type}, _fs} when type != :directory, FS.stat(fs, resolved))

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -43,9 +43,9 @@ defmodule JustBash.Commands.Mv do
 
   # A destination that already exists as a directory receives the source under
   # its own basename; anything else is the name the move lands under.
-  defp destination(fs, {:error, :enoent}, dest, dest_resolved), do: {dest_resolved, dest, fs}
+  defp destination(fs, {:error, %VFS.Error{}}, dest, dest_resolved), do: {dest_resolved, dest, fs}
 
-  defp destination(fs, _src_resolved, dest, {:error, :enoent} = dest_resolved),
+  defp destination(fs, _src_resolved, dest, {:error, %VFS.Error{}} = dest_resolved),
     do: {dest_resolved, dest, fs}
 
   defp destination(fs, src_resolved, dest, dest_resolved) do

--- a/lib/just_bash/commands/mv.ex
+++ b/lib/just_bash/commands/mv.ex
@@ -43,6 +43,11 @@ defmodule JustBash.Commands.Mv do
 
   # A destination that already exists as a directory receives the source under
   # its own basename; anything else is the name the move lands under.
+  defp destination(fs, {:error, :enoent}, dest, dest_resolved), do: {dest_resolved, dest, fs}
+
+  defp destination(fs, _src_resolved, dest, {:error, :enoent} = dest_resolved),
+    do: {dest_resolved, dest, fs}
+
   defp destination(fs, src_resolved, dest, dest_resolved) do
     case FS.stat(fs, dest_resolved) do
       {:ok, %VFS.Stat{type: :directory}, fs} ->
@@ -68,13 +73,16 @@ defmodule JustBash.Commands.Mv do
   #
   # (`a.md/` never reaches here — `destination_directory/3` reports it, which
   # is why this asks nothing about the spelling.)
-  defp distinct(src_resolved, dest_final) do
+  defp distinct(src_resolved, dest_final)
+       when is_binary(src_resolved) and is_binary(dest_final) do
     if FS.normalize_path(src_resolved) == FS.normalize_path(dest_final) do
       {:error, "mv: '#{src_resolved}' and '#{dest_final}' are the same file\n"}
     else
       :ok
     end
   end
+
+  defp distinct(_src_resolved, _dest_final), do: :ok
 
   defp source_type(bash, src, src_resolved) do
     case FS.lstat(bash.fs, src_resolved) do
@@ -97,7 +105,7 @@ defmodule JustBash.Commands.Mv do
   defp destination_directory(bash, {src, src_type}, dest) do
     case FS.check_directory_spelling(bash.fs, bash.cwd, dest) do
       {:ok, _fs} -> :ok
-      {:error, %VFS.Error{kind: :enoent}} when src_type == :directory -> :ok
+      {:error, %VFS.Error{kind: :enoent}} when src_type == :directory and dest != "" -> :ok
       {:error, %VFS.Error{} = error} -> {:error, dest_error(src, dest, error)}
     end
   end

--- a/lib/just_bash/commands/readlink.ex
+++ b/lib/just_bash/commands/readlink.ex
@@ -69,7 +69,7 @@ defmodule JustBash.Commands.Readlink do
     parse_args(rest, %{opts | files: opts.files ++ [file]})
   end
 
-  defp process_file(_fs, {:error, :enoent}, _original, _canonicalize), do: {:error, :enoent}
+  defp process_file(_fs, {:error, %VFS.Error{}}, _original, _canonicalize), do: {:error, :enoent}
 
   defp process_file(fs, path, _original, false) do
     case FS.readlink(fs, path) do
@@ -83,7 +83,7 @@ defmodule JustBash.Commands.Readlink do
   end
 
   @dialyzer {:nowarn_function, do_resolve_path: 3}
-  defp do_resolve_path(_fs, {:error, :enoent}, _seen), do: {:error, :enoent}
+  defp do_resolve_path(_fs, {:error, %VFS.Error{}}, _seen), do: {:error, :enoent}
 
   defp do_resolve_path(fs, path, seen) do
     if MapSet.member?(seen, path) do

--- a/lib/just_bash/commands/readlink.ex
+++ b/lib/just_bash/commands/readlink.ex
@@ -83,8 +83,6 @@ defmodule JustBash.Commands.Readlink do
   end
 
   @dialyzer {:nowarn_function, do_resolve_path: 3}
-  defp do_resolve_path(_fs, {:error, %VFS.Error{}}, _seen), do: {:error, :enoent}
-
   defp do_resolve_path(fs, path, seen) do
     if MapSet.member?(seen, path) do
       {:ok, path}
@@ -96,8 +94,10 @@ defmodule JustBash.Commands.Readlink do
   defp resolve_path_uncached(fs, path, seen) do
     case FS.readlink(fs, path) do
       {:ok, target, fs} ->
-        new_path = resolve_target(path, target)
-        do_resolve_path(fs, new_path, MapSet.put(seen, path))
+        case resolve_target(path, target) do
+          {:error, %VFS.Error{}} -> {:error, :enoent}
+          new_path -> do_resolve_path(fs, new_path, MapSet.put(seen, path))
+        end
 
       {:error, _} ->
         {:ok, path}

--- a/lib/just_bash/commands/readlink.ex
+++ b/lib/just_bash/commands/readlink.ex
@@ -69,6 +69,8 @@ defmodule JustBash.Commands.Readlink do
     parse_args(rest, %{opts | files: opts.files ++ [file]})
   end
 
+  defp process_file(_fs, {:error, :enoent}, _original, _canonicalize), do: {:error, :enoent}
+
   defp process_file(fs, path, _original, false) do
     case FS.readlink(fs, path) do
       {:ok, target, _fs} -> {:ok, target}
@@ -81,6 +83,8 @@ defmodule JustBash.Commands.Readlink do
   end
 
   @dialyzer {:nowarn_function, do_resolve_path: 3}
+  defp do_resolve_path(_fs, {:error, :enoent}, _seen), do: {:error, :enoent}
+
   defp do_resolve_path(fs, path, seen) do
     if MapSet.member?(seen, path) do
       {:ok, path}

--- a/lib/just_bash/commands/realpath.ex
+++ b/lib/just_bash/commands/realpath.ex
@@ -52,6 +52,8 @@ defmodule JustBash.Commands.Realpath do
     end
   end
 
+  defp check(fs, {:error, :enoent}, _mode), do: {:error, :enoent, fs}
+
   defp check(fs, _resolved, :missing), do: {:ok, fs}
 
   defp check(fs, resolved, :existing) do

--- a/lib/just_bash/commands/realpath.ex
+++ b/lib/just_bash/commands/realpath.ex
@@ -52,7 +52,7 @@ defmodule JustBash.Commands.Realpath do
     end
   end
 
-  defp check(fs, {:error, :enoent}, _mode), do: {:error, :enoent, fs}
+  defp check(fs, {:error, %VFS.Error{} = error}, _mode), do: {:error, error, fs}
 
   defp check(fs, _resolved, :missing), do: {:ok, fs}
 

--- a/lib/just_bash/commands/tee.ex
+++ b/lib/just_bash/commands/tee.ex
@@ -84,6 +84,10 @@ defmodule JustBash.Commands.Tee do
   # tee does not create missing parent directories, so an absent parent is
   # reported instead of being conjured up; a parent that exists but is not
   # a directory is ENOTDIR, as the kernel would report it.
+  defp write_below_parent(fs, {:error, :enoent}, file, _content, _append, acc_stderr, _acc_code) do
+    {fs, acc_stderr <> "tee: #{file}: #{FS.strerror(:enoent)}\n", 1}
+  end
+
   defp write_below_parent(fs, resolved, file, content, append, acc_stderr, acc_code) do
     parent = Path.dirname(resolved)
 

--- a/lib/just_bash/commands/tee.ex
+++ b/lib/just_bash/commands/tee.ex
@@ -84,8 +84,16 @@ defmodule JustBash.Commands.Tee do
   # tee does not create missing parent directories, so an absent parent is
   # reported instead of being conjured up; a parent that exists but is not
   # a directory is ENOTDIR, as the kernel would report it.
-  defp write_below_parent(fs, {:error, :enoent}, file, _content, _append, acc_stderr, _acc_code) do
-    {fs, acc_stderr <> "tee: #{file}: #{FS.strerror(:enoent)}\n", 1}
+  defp write_below_parent(
+         fs,
+         {:error, %VFS.Error{} = error},
+         file,
+         _content,
+         _append,
+         acc_stderr,
+         _acc_code
+       ) do
+    {fs, acc_stderr <> "tee: #{file}: #{FS.strerror(error)}\n", 1}
   end
 
   defp write_below_parent(fs, resolved, file, content, append, acc_stderr, acc_code) do

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -67,8 +67,16 @@ defmodule JustBash.FS do
   # ── path helpers (pure) ──────────────────────────────────────────────────
   #
   # Tolerant wrappers over `VFS.Path`: bash deals in user input, so these
-  # accept relative and empty paths by rooting them at "/", where
-  # `VFS.Path.normalize/1` would raise.
+  # accept relative paths by rooting them at "/", where
+  # `VFS.Path.normalize/1` would raise. An empty *pathname* is different —
+  # POSIX `open("")` is `ENOENT`, never the current directory — and
+  # `resolve_path/2` is the one place that says so.
+
+  @typedoc """
+  A path `resolve_path/2` produced: an absolute string, or `{:error, :enoent}`
+  when the operand was the empty pathname.
+  """
+  @type resolved :: String.t() | {:error, :enoent}
 
   @doc """
   Normalize a filesystem path. Relative input is rooted at `/`.
@@ -97,8 +105,13 @@ defmodule JustBash.FS do
 
   @doc """
   Resolve `path` relative to `base`. Absolute paths ignore the base.
+
+  An empty pathname names nothing. `VFS.Path.join/2` collapses an empty
+  component onto `base`, which made `cat ''` report "Is a directory" for
+  the working directory. POSIX is the other way: `open("")` is `ENOENT`.
   """
-  @spec resolve_path(String.t(), String.t()) :: String.t()
+  @spec resolve_path(String.t(), String.t()) :: resolved()
+  def resolve_path(_base, ""), do: {:error, :enoent}
   def resolve_path(_base, "/" <> _ = path), do: normalize_path(path)
   def resolve_path(base, path), do: VPath.join(normalize_path(base), path)
 
@@ -126,8 +139,9 @@ defmodule JustBash.FS do
 
   @doc """
   Hold `spelling` — a path as an operand wrote it, read relative to `base` —
-  to what its spelling promised: `{:ok, fs}` unless it demands a directory
-  (see `directory_spelling?/1`) and what it demands it of is not one.
+  to what its spelling promised: `{:ok, fs}` unless it names nothing (an
+  empty operand is `ENOENT`) or demands a directory (see
+  `directory_spelling?/1`) and what it demands it of is not one.
 
   What it demands it of is the last component the spelling names outright, not
   where `resolve_path/2` says the whole thing lands: `..` is collapsed
@@ -141,6 +155,8 @@ defmodule JustBash.FS do
   — a recursive copy, say — can ignore.
   """
   @spec check_directory_spelling(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
+  def check_directory_spelling(_fs, _base, ""), do: {:error, Error.new(:enoent, path: "")}
+
   def check_directory_spelling(fs, base, spelling) do
     if directory_spelling?(spelling) do
       require_directory(fs, spelling, asserted_directory(base, spelling))
@@ -171,7 +187,10 @@ defmodule JustBash.FS do
   # ── core operations (delegated to VFS, special files first) ──────────────
 
   @doc "See `VFS.read_file/2`."
-  @spec read_file(t(), String.t()) :: {:ok, binary(), t()} | {:error, Error.t()}
+  @spec read_file(t(), resolved()) :: {:ok, binary(), t()} | {:error, Error.t()}
+  def read_file(_fs, path) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
   def read_file(fs, path) do
     case special(path) do
       {:ok, kind, normalized} -> Special.read_file(fs, kind, normalized)
@@ -180,9 +199,14 @@ defmodule JustBash.FS do
   end
 
   @doc "See `VFS.stream_read/3`."
-  @spec stream_read(t(), String.t(), keyword()) ::
+  @spec stream_read(t(), resolved(), keyword()) ::
           {:ok, Enumerable.t(), t()} | {:error, Error.t()}
-  def stream_read(fs, path, opts \\ []) do
+  def stream_read(fs, path, opts \\ [])
+
+  def stream_read(_fs, path, _opts) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
+  def stream_read(fs, path, opts) do
     case special(path) do
       {:ok, kind, normalized} -> Special.stream_read(fs, kind, normalized, opts)
       :none -> VFS.stream_read(fs, path, opts)
@@ -190,9 +214,14 @@ defmodule JustBash.FS do
   end
 
   @doc "See `VFS.write_file/4`. The default backend honors `:mode` and `:mtime` opts."
-  @spec write_file(t(), String.t(), binary(), write_opts()) ::
+  @spec write_file(t(), resolved(), binary(), write_opts()) ::
           {:ok, t()} | {:error, Error.t()}
-  def write_file(fs, path, content, opts \\ []) do
+  def write_file(fs, path, content, opts \\ [])
+
+  def write_file(_fs, path, _content, _opts) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
+  def write_file(fs, path, content, opts) do
     case special(path) do
       {:ok, kind, normalized} -> Special.write_file(fs, kind, normalized, content)
       :none -> VFS.write_file(fs, path, content, opts)
@@ -200,7 +229,9 @@ defmodule JustBash.FS do
   end
 
   @doc "See `VFS.exists?/2`."
-  @spec exists?(t(), String.t()) :: {boolean(), t()}
+  @spec exists?(t(), resolved()) :: {boolean(), t()}
+  def exists?(fs, path) when path == "" or path == {:error, :enoent}, do: {false, fs}
+
   def exists?(fs, path) do
     case special(path) do
       {:ok, kind, _normalized} -> Special.exists?(fs, kind)
@@ -209,7 +240,9 @@ defmodule JustBash.FS do
   end
 
   @doc "See `VFS.stat/2`. Follows symlinks."
-  @spec stat(t(), String.t()) :: {:ok, VFS.Stat.t(), t()} | {:error, Error.t()}
+  @spec stat(t(), resolved()) :: {:ok, VFS.Stat.t(), t()} | {:error, Error.t()}
+  def stat(_fs, path) when path == "" or path == {:error, :enoent}, do: empty_operand_error()
+
   def stat(fs, path) do
     case special(path) do
       {:ok, kind, normalized} -> Special.stat(fs, kind, normalized)
@@ -218,7 +251,9 @@ defmodule JustBash.FS do
   end
 
   @doc "See `VFS.readdir/2`."
-  @spec readdir(t(), String.t()) :: {:ok, Enumerable.t(), t()} | {:error, Error.t()}
+  @spec readdir(t(), resolved()) :: {:ok, Enumerable.t(), t()} | {:error, Error.t()}
+  def readdir(_fs, path) when path == "" or path == {:error, :enoent}, do: empty_operand_error()
+
   def readdir(fs, path) do
     case special(path) do
       {:ok, kind, normalized} ->
@@ -237,8 +272,13 @@ defmodule JustBash.FS do
   end
 
   @doc "See `VFS.mkdir/3`. Pass `parents: true` for `mkdir -p` behavior."
-  @spec mkdir(t(), String.t(), mkdir_opts()) :: {:ok, t()} | {:error, Error.t()}
-  def mkdir(fs, path, opts \\ []) do
+  @spec mkdir(t(), resolved(), mkdir_opts()) :: {:ok, t()} | {:error, Error.t()}
+  def mkdir(fs, path, opts \\ [])
+
+  def mkdir(_fs, path, _opts) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
+  def mkdir(fs, path, opts) do
     # The 0.3 option was `recursive:`; silently ignoring it would make
     # `mkdir -p`-style callers fail far from the cause. Refuse loudly.
     if Keyword.has_key?(opts, :recursive) do
@@ -254,8 +294,13 @@ defmodule JustBash.FS do
   end
 
   @doc "See `VFS.rm/3`. Pass `recursive: true` to remove directory trees."
-  @spec rm(t(), String.t(), rm_opts()) :: {:ok, t()} | {:error, Error.t()}
-  def rm(fs, path, opts \\ []) do
+  @spec rm(t(), resolved(), rm_opts()) :: {:ok, t()} | {:error, Error.t()}
+  def rm(fs, path, opts \\ [])
+
+  def rm(_fs, path, _opts) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
+  def rm(fs, path, opts) do
     # The 0.3 option was `force:`; silently ignoring it would surface as
     # spurious :enoent errors. Refuse loudly.
     if Keyword.has_key?(opts, :force) do
@@ -283,7 +328,9 @@ defmodule JustBash.FS do
   # ── POSIX extensions (dispatched through JustBash.FS.POSIX) ─────────────
 
   @doc "Get stat information without following symlinks."
-  @spec lstat(t(), String.t()) :: {:ok, VFS.Stat.t(), t()} | {:error, Error.t()}
+  @spec lstat(t(), resolved()) :: {:ok, VFS.Stat.t(), t()} | {:error, Error.t()}
+  def lstat(_fs, path) when path == "" or path == {:error, :enoent}, do: empty_operand_error()
+
   def lstat(fs, path) do
     case special(path) do
       {:ok, kind, normalized} -> Special.stat(fs, kind, normalized)
@@ -292,7 +339,9 @@ defmodule JustBash.FS do
   end
 
   @doc "Read the target of a symbolic link."
-  @spec readlink(t(), String.t()) :: {:ok, String.t(), t()} | {:error, Error.t()}
+  @spec readlink(t(), resolved()) :: {:ok, String.t(), t()} | {:error, Error.t()}
+  def readlink(_fs, path) when path == "" or path == {:error, :enoent}, do: empty_operand_error()
+
   def readlink(fs, path) do
     case special(path) do
       {:ok, kind, normalized} -> Special.readlink(kind, normalized)
@@ -301,7 +350,10 @@ defmodule JustBash.FS do
   end
 
   @doc "Create a symbolic link at `link_path` pointing to `target`."
-  @spec symlink(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
+  @spec symlink(t(), String.t(), resolved()) :: {:ok, t()} | {:error, Error.t()}
+  def symlink(_fs, _target, path) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
   def symlink(fs, target, link_path) do
     case special(link_path) do
       {:ok, _kind, normalized} -> Special.refuse_create(normalized)
@@ -310,7 +362,13 @@ defmodule JustBash.FS do
   end
 
   @doc "Create a hard link."
-  @spec link(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
+  @spec link(t(), resolved(), resolved()) :: {:ok, t()} | {:error, Error.t()}
+  def link(_fs, path, _new_path) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
+  def link(_fs, _existing_path, path) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
   def link(fs, existing_path, new_path) do
     case {special(existing_path), special(new_path)} do
       {{:ok, kind, normalized}, _} -> Special.refuse_link(kind, normalized)
@@ -320,7 +378,10 @@ defmodule JustBash.FS do
   end
 
   @doc "Change file/directory permissions."
-  @spec chmod(t(), String.t(), non_neg_integer()) :: {:ok, t()} | {:error, Error.t()}
+  @spec chmod(t(), resolved(), non_neg_integer()) :: {:ok, t()} | {:error, Error.t()}
+  def chmod(_fs, path, _mode) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
   def chmod(fs, path, mode) do
     case special(path) do
       {:ok, kind, _normalized} -> Special.chmod(fs, kind)
@@ -329,7 +390,10 @@ defmodule JustBash.FS do
   end
 
   @doc "Append content to a file, creating it if it doesn't exist."
-  @spec append_file(t(), String.t(), binary()) :: {:ok, t()} | {:error, Error.t()}
+  @spec append_file(t(), resolved(), binary()) :: {:ok, t()} | {:error, Error.t()}
+  def append_file(_fs, path, _content) when path == "" or path == {:error, :enoent},
+    do: empty_operand_error()
+
   def append_file(fs, path, content) do
     case special(path) do
       {:ok, kind, normalized} -> Special.append_file(fs, kind, normalized, content)
@@ -359,8 +423,16 @@ defmodule JustBash.FS do
   otherwise unbounded; with a deadline, each directory descended into checks
   the wall clock and raises `JustBash.Limit.ExceededError` once it has passed.
   """
-  @spec cp(t(), String.t(), String.t(), cp_opts()) :: {:ok, t()} | {:error, Error.t()}
-  def cp(fs, src, dest, opts \\ []) do
+  @spec cp(t(), resolved(), resolved(), cp_opts()) :: {:ok, t()} | {:error, Error.t()}
+  def cp(fs, src, dest, opts \\ [])
+
+  def cp(_fs, src, _dest, _opts) when src == "" or src == {:error, :enoent},
+    do: empty_operand_error()
+
+  def cp(_fs, _src, dest, _opts) when dest == "" or dest == {:error, :enoent},
+    do: empty_operand_error()
+
+  def cp(fs, src, dest, opts) do
     src_norm = normalize_path(src)
     dest_norm = normalize_path(dest)
     recursive = Keyword.get(opts, :recursive, false)
@@ -401,7 +473,10 @@ defmodule JustBash.FS do
   Moving a directory into its own subtree fails with `:einval` (see
   `cp/4`) rather than looping.
   """
-  @spec mv(t(), String.t(), String.t()) :: {:ok, t()} | {:error, Error.t()}
+  @spec mv(t(), resolved(), resolved()) :: {:ok, t()} | {:error, Error.t()}
+  def mv(_fs, src, _dest) when src == "" or src == {:error, :enoent}, do: empty_operand_error()
+  def mv(_fs, _src, dest) when dest == "" or dest == {:error, :enoent}, do: empty_operand_error()
+
   def mv(fs, src, dest) do
     src_norm = normalize_path(src)
     dest_norm = normalize_path(dest)
@@ -440,6 +515,8 @@ defmodule JustBash.FS do
 
   # ── private ──────────────────────────────────────────────────────────────
 
+  defp empty_operand_error, do: {:error, Error.new(:enoent, path: "")}
+
   defp special(path) do
     normalized = normalize_path(path)
 
@@ -460,6 +537,9 @@ defmodule JustBash.FS do
 
   # The stat behind `check_directory_spelling/3`. The error names the operand
   # as it was spelled, since that spelling is what the caller reports.
+  defp require_directory(_fs, spelling, {:error, :enoent}),
+    do: {:error, Error.new(:enoent, path: spelling)}
+
   defp require_directory(fs, spelling, resolved) do
     case stat(fs, resolved) do
       {:ok, %VFS.Stat{type: :directory}, fs} -> {:ok, fs}
@@ -509,8 +589,13 @@ defmodule JustBash.FS do
       {:ok, %VFS.Stat{type: :symlink}, fs} ->
         case readlink(fs, candidate) do
           {:ok, target, fs} ->
-            target_components = parent |> resolve_path(target) |> split_path()
-            resolve_components(fs, target_components ++ rest, "/", hops + 1, lexical)
+            case resolve_path(parent, target) do
+              {:error, :enoent} ->
+                {lexical, fs}
+
+              resolved ->
+                resolve_components(fs, split_path(resolved) ++ rest, "/", hops + 1, lexical)
+            end
 
           {:error, %Error{}} ->
             {lexical, fs}

--- a/lib/just_bash/fs/fs.ex
+++ b/lib/just_bash/fs/fs.ex
@@ -73,10 +73,11 @@ defmodule JustBash.FS do
   # `resolve_path/2` is the one place that says so.
 
   @typedoc """
-  A path `resolve_path/2` produced: an absolute string, or `{:error, :enoent}`
-  when the operand was the empty pathname.
+  A path `resolve_path/2` produced: an absolute string, or
+  `{:error, %VFS.Error{kind: :enoent}}` when the operand was the empty
+  pathname.
   """
-  @type resolved :: String.t() | {:error, :enoent}
+  @type resolved :: String.t() | {:error, Error.t()}
 
   @doc """
   Normalize a filesystem path. Relative input is rooted at `/`.
@@ -111,7 +112,7 @@ defmodule JustBash.FS do
   the working directory. POSIX is the other way: `open("")` is `ENOENT`.
   """
   @spec resolve_path(String.t(), String.t()) :: resolved()
-  def resolve_path(_base, ""), do: {:error, :enoent}
+  def resolve_path(_base, ""), do: empty_operand_error()
   def resolve_path(_base, "/" <> _ = path), do: normalize_path(path)
   def resolve_path(base, path), do: VPath.join(normalize_path(base), path)
 
@@ -188,8 +189,8 @@ defmodule JustBash.FS do
 
   @doc "See `VFS.read_file/2`."
   @spec read_file(t(), resolved()) :: {:ok, binary(), t()} | {:error, Error.t()}
-  def read_file(_fs, path) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def read_file(_fs, ""), do: empty_operand_error()
+  def read_file(_fs, {:error, %Error{}} = error), do: error
 
   def read_file(fs, path) do
     case special(path) do
@@ -203,8 +204,8 @@ defmodule JustBash.FS do
           {:ok, Enumerable.t(), t()} | {:error, Error.t()}
   def stream_read(fs, path, opts \\ [])
 
-  def stream_read(_fs, path, _opts) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def stream_read(_fs, "", _opts), do: empty_operand_error()
+  def stream_read(_fs, {:error, %Error{}} = error, _opts), do: error
 
   def stream_read(fs, path, opts) do
     case special(path) do
@@ -218,8 +219,8 @@ defmodule JustBash.FS do
           {:ok, t()} | {:error, Error.t()}
   def write_file(fs, path, content, opts \\ [])
 
-  def write_file(_fs, path, _content, _opts) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def write_file(_fs, "", _content, _opts), do: empty_operand_error()
+  def write_file(_fs, {:error, %Error{}} = error, _content, _opts), do: error
 
   def write_file(fs, path, content, opts) do
     case special(path) do
@@ -230,7 +231,8 @@ defmodule JustBash.FS do
 
   @doc "See `VFS.exists?/2`."
   @spec exists?(t(), resolved()) :: {boolean(), t()}
-  def exists?(fs, path) when path == "" or path == {:error, :enoent}, do: {false, fs}
+  def exists?(fs, ""), do: {false, fs}
+  def exists?(fs, {:error, %Error{}}), do: {false, fs}
 
   def exists?(fs, path) do
     case special(path) do
@@ -241,7 +243,8 @@ defmodule JustBash.FS do
 
   @doc "See `VFS.stat/2`. Follows symlinks."
   @spec stat(t(), resolved()) :: {:ok, VFS.Stat.t(), t()} | {:error, Error.t()}
-  def stat(_fs, path) when path == "" or path == {:error, :enoent}, do: empty_operand_error()
+  def stat(_fs, ""), do: empty_operand_error()
+  def stat(_fs, {:error, %Error{}} = error), do: error
 
   def stat(fs, path) do
     case special(path) do
@@ -252,7 +255,8 @@ defmodule JustBash.FS do
 
   @doc "See `VFS.readdir/2`."
   @spec readdir(t(), resolved()) :: {:ok, Enumerable.t(), t()} | {:error, Error.t()}
-  def readdir(_fs, path) when path == "" or path == {:error, :enoent}, do: empty_operand_error()
+  def readdir(_fs, ""), do: empty_operand_error()
+  def readdir(_fs, {:error, %Error{}} = error), do: error
 
   def readdir(fs, path) do
     case special(path) do
@@ -275,8 +279,8 @@ defmodule JustBash.FS do
   @spec mkdir(t(), resolved(), mkdir_opts()) :: {:ok, t()} | {:error, Error.t()}
   def mkdir(fs, path, opts \\ [])
 
-  def mkdir(_fs, path, _opts) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def mkdir(_fs, "", _opts), do: empty_operand_error()
+  def mkdir(_fs, {:error, %Error{}} = error, _opts), do: error
 
   def mkdir(fs, path, opts) do
     # The 0.3 option was `recursive:`; silently ignoring it would make
@@ -297,8 +301,8 @@ defmodule JustBash.FS do
   @spec rm(t(), resolved(), rm_opts()) :: {:ok, t()} | {:error, Error.t()}
   def rm(fs, path, opts \\ [])
 
-  def rm(_fs, path, _opts) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def rm(_fs, "", _opts), do: empty_operand_error()
+  def rm(_fs, {:error, %Error{}} = error, _opts), do: error
 
   def rm(fs, path, opts) do
     # The 0.3 option was `force:`; silently ignoring it would surface as
@@ -329,7 +333,8 @@ defmodule JustBash.FS do
 
   @doc "Get stat information without following symlinks."
   @spec lstat(t(), resolved()) :: {:ok, VFS.Stat.t(), t()} | {:error, Error.t()}
-  def lstat(_fs, path) when path == "" or path == {:error, :enoent}, do: empty_operand_error()
+  def lstat(_fs, ""), do: empty_operand_error()
+  def lstat(_fs, {:error, %Error{}} = error), do: error
 
   def lstat(fs, path) do
     case special(path) do
@@ -340,7 +345,8 @@ defmodule JustBash.FS do
 
   @doc "Read the target of a symbolic link."
   @spec readlink(t(), resolved()) :: {:ok, String.t(), t()} | {:error, Error.t()}
-  def readlink(_fs, path) when path == "" or path == {:error, :enoent}, do: empty_operand_error()
+  def readlink(_fs, ""), do: empty_operand_error()
+  def readlink(_fs, {:error, %Error{}} = error), do: error
 
   def readlink(fs, path) do
     case special(path) do
@@ -351,8 +357,8 @@ defmodule JustBash.FS do
 
   @doc "Create a symbolic link at `link_path` pointing to `target`."
   @spec symlink(t(), String.t(), resolved()) :: {:ok, t()} | {:error, Error.t()}
-  def symlink(_fs, _target, path) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def symlink(_fs, _target, ""), do: empty_operand_error()
+  def symlink(_fs, _target, {:error, %Error{}} = error), do: error
 
   def symlink(fs, target, link_path) do
     case special(link_path) do
@@ -363,11 +369,10 @@ defmodule JustBash.FS do
 
   @doc "Create a hard link."
   @spec link(t(), resolved(), resolved()) :: {:ok, t()} | {:error, Error.t()}
-  def link(_fs, path, _new_path) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
-
-  def link(_fs, _existing_path, path) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def link(_fs, "", _new_path), do: empty_operand_error()
+  def link(_fs, {:error, %Error{}} = error, _new_path), do: error
+  def link(_fs, _existing_path, ""), do: empty_operand_error()
+  def link(_fs, _existing_path, {:error, %Error{}} = error), do: error
 
   def link(fs, existing_path, new_path) do
     case {special(existing_path), special(new_path)} do
@@ -379,8 +384,8 @@ defmodule JustBash.FS do
 
   @doc "Change file/directory permissions."
   @spec chmod(t(), resolved(), non_neg_integer()) :: {:ok, t()} | {:error, Error.t()}
-  def chmod(_fs, path, _mode) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def chmod(_fs, "", _mode), do: empty_operand_error()
+  def chmod(_fs, {:error, %Error{}} = error, _mode), do: error
 
   def chmod(fs, path, mode) do
     case special(path) do
@@ -391,8 +396,8 @@ defmodule JustBash.FS do
 
   @doc "Append content to a file, creating it if it doesn't exist."
   @spec append_file(t(), resolved(), binary()) :: {:ok, t()} | {:error, Error.t()}
-  def append_file(_fs, path, _content) when path == "" or path == {:error, :enoent},
-    do: empty_operand_error()
+  def append_file(_fs, "", _content), do: empty_operand_error()
+  def append_file(_fs, {:error, %Error{}} = error, _content), do: error
 
   def append_file(fs, path, content) do
     case special(path) do
@@ -426,11 +431,10 @@ defmodule JustBash.FS do
   @spec cp(t(), resolved(), resolved(), cp_opts()) :: {:ok, t()} | {:error, Error.t()}
   def cp(fs, src, dest, opts \\ [])
 
-  def cp(_fs, src, _dest, _opts) when src == "" or src == {:error, :enoent},
-    do: empty_operand_error()
-
-  def cp(_fs, _src, dest, _opts) when dest == "" or dest == {:error, :enoent},
-    do: empty_operand_error()
+  def cp(_fs, "", _dest, _opts), do: empty_operand_error()
+  def cp(_fs, {:error, %Error{}} = error, _dest, _opts), do: error
+  def cp(_fs, _src, "", _opts), do: empty_operand_error()
+  def cp(_fs, _src, {:error, %Error{}} = error, _opts), do: error
 
   def cp(fs, src, dest, opts) do
     src_norm = normalize_path(src)
@@ -474,8 +478,10 @@ defmodule JustBash.FS do
   `cp/4`) rather than looping.
   """
   @spec mv(t(), resolved(), resolved()) :: {:ok, t()} | {:error, Error.t()}
-  def mv(_fs, src, _dest) when src == "" or src == {:error, :enoent}, do: empty_operand_error()
-  def mv(_fs, _src, dest) when dest == "" or dest == {:error, :enoent}, do: empty_operand_error()
+  def mv(_fs, "", _dest), do: empty_operand_error()
+  def mv(_fs, {:error, %Error{}} = error, _dest), do: error
+  def mv(_fs, _src, ""), do: empty_operand_error()
+  def mv(_fs, _src, {:error, %Error{}} = error), do: error
 
   def mv(fs, src, dest) do
     src_norm = normalize_path(src)
@@ -537,7 +543,7 @@ defmodule JustBash.FS do
 
   # The stat behind `check_directory_spelling/3`. The error names the operand
   # as it was spelled, since that spelling is what the caller reports.
-  defp require_directory(_fs, spelling, {:error, :enoent}),
+  defp require_directory(_fs, spelling, {:error, %Error{}}),
     do: {:error, Error.new(:enoent, path: spelling)}
 
   defp require_directory(fs, spelling, resolved) do
@@ -590,7 +596,7 @@ defmodule JustBash.FS do
         case readlink(fs, candidate) do
           {:ok, target, fs} ->
             case resolve_path(parent, target) do
-              {:error, :enoent} ->
+              {:error, %Error{}} ->
                 {lexical, fs}
 
               resolved ->

--- a/lib/just_bash/interpreter/executor/conditional.ex
+++ b/lib/just_bash/interpreter/executor/conditional.ex
@@ -298,8 +298,9 @@ defmodule JustBash.Interpreter.Executor.Conditional do
   end
 
   defp same_file?(bash, path1, path2) do
-    resolved1 = FS.resolve_path(bash.cwd, path1)
-    resolved2 = FS.resolve_path(bash.cwd, path2)
-    resolved1 == resolved2
+    case {FS.resolve_path(bash.cwd, path1), FS.resolve_path(bash.cwd, path2)} do
+      {resolved, resolved} when is_binary(resolved) -> true
+      _ -> false
+    end
   end
 end

--- a/test/just_bash/empty_path_test.exs
+++ b/test/just_bash/empty_path_test.exs
@@ -1,0 +1,115 @@
+defmodule JustBash.EmptyPathTest do
+  @moduledoc """
+  Regression tests for issue #79: an empty-string path operand used to
+  resolve to the cwd, so every command reported "Is a directory" for `''`.
+
+  POSIX is explicit that an empty pathname names nothing: it is `ENOENT`,
+  never the current directory. `FS.resolve_path/2` is where that decision
+  belongs — every file-operand command inherits it.
+  """
+  use ExUnit.Case, async: true
+
+  alias JustBash.FS
+
+  describe "FS.resolve_path/2" do
+    test "an empty pathname is ENOENT, not the base" do
+      assert FS.resolve_path("/home/user", "") == {:error, :enoent}
+      assert FS.resolve_path("/", "") == {:error, :enoent}
+    end
+
+    test "a real relative path still resolves against the base" do
+      assert FS.resolve_path("/home/user", "file.txt") == "/home/user/file.txt"
+      assert FS.resolve_path("/home/user", "subdir/file") == "/home/user/subdir/file"
+    end
+
+    test "a bare / is the root" do
+      assert FS.resolve_path("/home/user", "/") == "/"
+    end
+
+    test "repeated slashes collapse" do
+      assert FS.resolve_path("/home/user", "//") == "/"
+      assert FS.resolve_path("/home/user", "///") == "/"
+      assert FS.resolve_path("/home/user", "foo//bar") == "/home/user/foo/bar"
+    end
+
+    test "a trailing . is the base" do
+      assert FS.resolve_path("/home/user", ".") == "/home/user"
+      assert FS.resolve_path("/home/user", "./") == "/home/user"
+    end
+  end
+
+  describe "FS.check_directory_spelling/3" do
+    test "an empty destination names nothing" do
+      fs = FS.new(%{"/f" => "F\n", "/d/keep" => "K\n"})
+
+      assert {:error, %VFS.Error{kind: :enoent, path: ""}} =
+               FS.check_directory_spelling(fs, "/home/user", "")
+    end
+  end
+
+  describe "empty source operands" do
+    # $ cat ''
+    # cat: : Is a directory          # was
+    # gcat '': "cannot open '' for reading: No such file or directory"
+    test "cat '' is ENOENT, not Is a directory" do
+      {result, _} = JustBash.exec(JustBash.new(), "cat ''")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cat: : No such file or directory\n"
+      refute result.stderr =~ "Is a directory"
+    end
+
+    # $ sort ''
+    # sort: read failed: : Is a directory          # was
+    # gsort '': "cannot read: '': No such file or directory"
+    test "sort '' is ENOENT, not Is a directory" do
+      {result, _} = JustBash.exec(JustBash.new(), "sort ''")
+
+      assert result.exit_code == 2
+      assert result.stderr == "sort: cannot read: : No such file or directory\n"
+      refute result.stderr =~ "Is a directory"
+    end
+
+    # Reachable without anyone typing '': `sort "$f"` with f unset.
+    test "cat of an empty variable is ENOENT" do
+      {result, _} = JustBash.exec(JustBash.new(), "f= && cat \"$f\"")
+
+      assert result.exit_code == 1
+      assert result.stderr == "cat: : No such file or directory\n"
+      refute result.stderr =~ "Is a directory"
+    end
+  end
+
+  describe "empty destination operands" do
+    # $ touch ''
+    # used to touch the cwd (a directory). GNU: cannot touch '': No such file
+    test "touch '' is ENOENT, not a touch of the cwd" do
+      bash = JustBash.new()
+      {result, bash} = JustBash.exec(bash, "touch ''")
+
+      assert result.exit_code == 1
+      assert result.stderr == "touch: cannot touch '': No such file or directory\n"
+
+      {ls, _} = JustBash.exec(bash, "ls -a /home/user")
+      refute ls.stdout =~ ~r/(^|\n)''(\n|$)/
+    end
+  end
+
+  describe "non-empty paths still work" do
+    test "a real relative path still reads" do
+      bash = JustBash.new(files: %{"/home/user/file.txt" => "hello\n"})
+      {result, _} = JustBash.exec(bash, "cat file.txt")
+
+      assert result.exit_code == 0
+      assert result.stdout == "hello\n"
+    end
+
+    test "/ still names the root" do
+      bash = JustBash.new(files: %{"/home/user/file.txt" => "hello\n"})
+      {result, _} = JustBash.exec(bash, "ls /")
+
+      assert result.exit_code == 0
+      assert result.stdout =~ "home"
+    end
+  end
+end

--- a/test/just_bash/empty_path_test.exs
+++ b/test/just_bash/empty_path_test.exs
@@ -13,8 +13,8 @@ defmodule JustBash.EmptyPathTest do
 
   describe "FS.resolve_path/2" do
     test "an empty pathname is ENOENT, not the base" do
-      assert FS.resolve_path("/home/user", "") == {:error, :enoent}
-      assert FS.resolve_path("/", "") == {:error, :enoent}
+      assert {:error, %VFS.Error{kind: :enoent, path: ""}} = FS.resolve_path("/home/user", "")
+      assert {:error, %VFS.Error{kind: :enoent, path: ""}} = FS.resolve_path("/", "")
     end
 
     test "a real relative path still resolves against the base" do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
An empty-string path operand used to resolve to the current working directory, so every file-operand command reported `Is a directory` for `''`. POSIX is explicit that an empty pathname is `ENOENT`, never the cwd. This is reachable from an unquoted empty variable (`cat "$f"` with `f` unset), not only from someone typing `''`.

## Changes
- `FS.resolve_path/2` returns `{:error, %VFS.Error{kind: :enoent}}` for `""` instead of collapsing onto the base via `VPath.join/2`
- `FS.check_directory_spelling/3` reports the same error for an empty destination (the `#75` spelling check previously treated empty as “demands nothing” and let `touch ''` / `tee ''` write through the cwd)
- Filesystem operations accept that error (and a raw `""`) so `cat`, `sort`, and the other file-operand commands inherit ENOENT without per-command empty-string checks
- A few callers that treat the resolved path as a string (`cd`, `realpath`, `readlink -f`, `mv`, `tee`, `[ -ef ]`) handle the error so `JustBash.exec/2` does not raise
- Degenerate inputs that share the same normalisation (`/`, repeated slashes, trailing `.`) still resolve as before

## Related Issues
Fixes #79

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing
- [x] Added new tests
- [x] All existing tests pass
- [ ] Tested manually

`test/just_bash/empty_path_test.exs` covers:
- `resolve_path/2` for `""`, a relative path, `/`, `//`, and `.`
- `check_directory_spelling/3` for an empty destination
- `cat ''` and `sort ''` are ENOENT, not “Is a directory”
- `cat "$f"` with `f` empty
- `touch ''` as an empty destination
- A real relative path and `ls /` still work

Local verification:
- `mix test` — 2 doctests, 62 properties, 5470 tests, 0 failures
- `mix format --check-formatted`
- `mix credo` — clean
- `mix dialyzer` — passed (existing `.dialyzer_ignore.exs` skips only)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md (for non-trivial changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35188375-284f-42a1-b2a2-1db28bb68834?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35188375-284f-42a1-b2a2-1db28bb68834&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

