### PR TITLE
fix: bound ${v//pat/rep} so global replace cannot OOM the VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+* `${v//pat/rep}` / `${v/pat/rep}` refuse before allocating a result that would exceed `:max_value_bytes` ([#86](https://github.com/elixir-ai-tools/just_bash/issues/86))
 * empty-string path operands are `ENOENT`, not the current directory ([#79](https://github.com/elixir-ai-tools/just_bash/issues/79))
 * honour `--` as end-of-options for file-operand commands ([#83](https://github.com/elixir-ai-tools/just_bash/issues/83))
 * head default line count no longer emits a trailing blank line ([#80](https://github.com/elixir-ai-tools/just_bash/issues/80))

--- a/lib/just_bash/interpreter/expansion/parameter.ex
+++ b/lib/just_bash/interpreter/expansion/parameter.ex
@@ -311,11 +311,7 @@ defmodule JustBash.Interpreter.Expansion.Parameter do
     result =
       case Regex.compile(regex_pattern) do
         {:ok, regex} ->
-          if all do
-            Regex.replace(regex, str, replacement, global: true)
-          else
-            Regex.replace(regex, str, replacement, global: false)
-          end
+          Limit.replace!(bash, regex, str, replacement, global: all)
 
         {:error, _} ->
           str

--- a/lib/just_bash/limit.ex
+++ b/lib/just_bash/limit.ex
@@ -43,11 +43,12 @@ defmodule JustBash.Limit do
   expand into — see `check_expansion_words!/2`.
 
   `:max_value_bytes` bounds a single expanded value. A step like
-  `v=${v}${v}` doubles a binary with no other bound seeing inside it, so
-  without this cap the wall clock cannot fire until that allocation
-  finishes. Call `concat!/3` (or `check_value_size!/2` with a byte count)
-  before the memory is spent, the way `check_expansion_words!/2` is called
-  as a word list is produced.
+  `v=${v}${v}` doubles a binary with no other bound seeing inside it, and
+  `${v//a/$r}` can grow a value by the product of two already-capped
+  binaries, so without this cap the wall clock cannot fire until that
+  allocation finishes. Call `concat!/3` or `replace!/5` (or
+  `check_value_size!/2` with a byte count) before the memory is spent, the
+  way `check_expansion_words!/2` is called as a word list is produced.
   """
 
   defmodule ExceededError do
@@ -240,6 +241,29 @@ defmodule JustBash.Limit do
     left <> right
   end
 
+  @doc """
+  Replace matches of `regex` in `str` with `replacement`, raising
+  `ExceededError` if the result would exceed `:max_value_bytes`.
+
+  The check is on the projected size from match lengths, so the oversized
+  result is never allocated — a single `${v//a/$r}` of cap-sized `v` and
+  `r` is the hole this closes. Call this instead of `Regex.replace/4`.
+  """
+  @spec replace!(JustBash.t(), Regex.t(), binary(), binary(), keyword()) :: binary()
+  def replace!(bash, regex, str, replacement, opts \\ [])
+
+  def replace!(%{limits: nil}, %Regex{} = regex, str, replacement, opts)
+      when is_binary(str) and is_binary(replacement) and is_list(opts) do
+    Regex.replace(regex, str, replacement, opts)
+  end
+
+  def replace!(bash, %Regex{} = regex, str, replacement, opts)
+      when is_binary(str) and is_binary(replacement) and is_list(opts) do
+    global = Keyword.get(opts, :global, true)
+    check_replace_size!(bash, str, regex, replacement, global)
+    Regex.replace(regex, str, replacement, opts)
+  end
+
   @doc "Track output bytes. Raises `ExceededError` if limit is reached."
   @spec track_output!(JustBash.t(), non_neg_integer()) :: JustBash.t()
   def track_output!(%{interpreter: interp} = bash, new_bytes) do
@@ -366,7 +390,8 @@ defmodule JustBash.Limit do
   Check a value's size before keeping it. Raises `ExceededError` if too large.
 
   Accepts the data binary, or a byte count so callers can refuse a
-  concatenation before it is built — see `concat!/3`.
+  concatenation or replacement before it is built — see `concat!/3` and
+  `replace!/5`.
   """
   @spec check_value_size!(JustBash.t(), String.t() | non_neg_integer()) :: :ok
   def check_value_size!(%{limits: nil}, _data), do: :ok
@@ -422,5 +447,74 @@ defmodule JustBash.Limit do
     end
 
     :ok
+  end
+
+  # Project the size of a Regex.replace/4 before it runs, aborting as soon as
+  # the running total exceeds the cap so `${v//a/$r}` of cap-sized inputs
+  # cannot spend the wall clock (or the VM) building a terabyte-scale binary.
+  defp check_replace_size!(bash, str, regex, replacement, global) do
+    str_size = byte_size(str)
+    rep_size = byte_size(replacement)
+
+    cheap_upper =
+      if global do
+        str_size + (str_size + 1) * rep_size
+      else
+        str_size + rep_size
+      end
+
+    if cheap_upper <= bash.limits.max_value_bytes do
+      :ok
+    else
+      check_value_size!(
+        bash,
+        projected_replace_size(str, regex, replacement, global, bash.limits.max_value_bytes)
+      )
+    end
+  end
+
+  defp projected_replace_size(str, regex, replacement, global, max_bytes) do
+    do_projected_replace_size(
+      str,
+      Regex.re_pattern(regex),
+      byte_size(replacement),
+      global,
+      0,
+      byte_size(str),
+      max_bytes
+    )
+  end
+
+  defp do_projected_replace_size(_str, _re, _rep_size, _global, _offset, projected, max_bytes)
+       when projected > max_bytes,
+       do: projected
+
+  defp do_projected_replace_size(str, _re, _rep_size, _global, offset, projected, _max_bytes)
+       when offset > byte_size(str),
+       do: projected
+
+  defp do_projected_replace_size(str, re, rep_size, global, offset, projected, max_bytes) do
+    case :re.run(str, re, [{:capture, :first, :index}, {:offset, offset}]) do
+      :nomatch ->
+        projected
+
+      {:match, [{start, len} | _]} ->
+        next_projected = projected - len + rep_size
+        next_offset = start + max(len, 1)
+
+        if global do
+          do_projected_replace_size(
+            str,
+            re,
+            rep_size,
+            global,
+            next_offset,
+            next_projected,
+            max_bytes
+          )
+        else
+          next_projected
+        end
+    end
   end
 end

--- a/test/limit_resource_exhaustion_test.exs
+++ b/test/limit_resource_exhaustion_test.exs
@@ -104,6 +104,19 @@ defmodule JustBash.Limit.ResourceExhaustionTest do
       assert result.exit_code == 0
       assert result.stdout == "hello\n"
     end
+
+    test "global pattern replacement of a doubled value is bounded" do
+      bash = strict_bash(max_value_bytes: 500)
+
+      {result, _} =
+        JustBash.exec(
+          bash,
+          "v=a; r=a; for i in {1..8}; do v=${v}${v}; r=${r}${r}; done; v=${v//a/$r}"
+        )
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "value size limit"
+    end
   end
 
   describe "memory exhaustion via filesystem" do

--- a/test/limit_test.exs
+++ b/test/limit_test.exs
@@ -72,6 +72,44 @@ defmodule JustBash.LimitTest do
     end
   end
 
+  describe "Limit.replace!/5" do
+    test "replaces when the result fits" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+      assert Limit.replace!(bash, ~r/a/, "aaa", "X", global: true) == "XXX"
+    end
+
+    test "allows a result right at the bound" do
+      bash = JustBash.new(limits: [max_value_bytes: 9])
+      assert Limit.replace!(bash, ~r/a/, "aaa", "XXX", global: true) == "XXXXXXXXX"
+    end
+
+    test "raises without replacing when a global replace would exceed the bound" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+
+      assert_raise Limit.ExceededError, ~r/value size limit exceeded \(10 bytes\)/, fn ->
+        Limit.replace!(bash, ~r/a/, "aaa", "XXXX", global: true)
+      end
+    end
+
+    test "raises without replacing when a single replace would exceed the bound" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+
+      assert_raise Limit.ExceededError, ~r/value size limit exceeded \(10 bytes\)/, fn ->
+        Limit.replace!(bash, ~r/a/, "aaa", "XXXXXXXXXXXX", global: false)
+      end
+    end
+
+    test "does not refuse a non-matching replace of a cap-sized haystack" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+      assert Limit.replace!(bash, ~r/z/, "aaaaaaaaaa", "XXXX", global: true) == "aaaaaaaaaa"
+    end
+
+    test "is a no-op bound when limits are disabled" do
+      bash = JustBash.new(limits: false)
+      assert Limit.replace!(bash, ~r/a/, "aaa", "XXXX", global: true) == "XXXXXXXXXXXX"
+    end
+  end
+
   describe "Limit.check_value_size!/2" do
     test "accepts a byte count so callers can refuse before allocating" do
       bash = JustBash.new(limits: [max_value_bytes: 10])

--- a/test/sandbox_contract_test.exs
+++ b/test/sandbox_contract_test.exs
@@ -710,6 +710,42 @@ defmodule JustBash.SandboxContractTest do
       assert result.exit_code == 0
       assert result.stdout == "8\n"
     end
+
+    test "global pattern replacement is refused before a huge allocation" do
+      # #85 bounded `v=${v}${v}`. `${v//a/$r}` still allocates first:
+      # `Regex.replace/4` runs, then `concat!` sees the finished binary.
+      # 15 doublings sit `v` and `r` at the 32_768-byte cap; unbounded, the
+      # replace is |v| * |r| = 1 GiB and (measured) ~700 ms. concat! cannot
+      # refuse until that allocation finishes.
+      bash =
+        JustBash.new(limits: [max_value_bytes: 32_768, max_wall_ms: 30_000, max_steps: 10_000])
+
+      {elapsed_us, result} =
+        bounded_exec_timed(
+          bash,
+          "v=a; r=a; for i in {1..15}; do v=${v}${v}; r=${r}${r}; done; v=${v//a/$r}"
+        )
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "value size limit exceeded (32768 bytes)"
+      assert elapsed_us < 200_000
+    end
+
+    test "a single pattern replacement that would grow past the cap is refused" do
+      bash = JustBash.new(limits: [max_value_bytes: 10])
+      result = bounded_exec(bash, "v=aaa; echo ${v/a/XXXXXXXXXXXX}")
+
+      assert result.exit_code == 1
+      assert result.stderr =~ "value size limit exceeded (10 bytes)"
+    end
+
+    test "a normal-size pattern replacement is untouched" do
+      bash = JustBash.new(limits: [max_value_bytes: 1_000])
+      result = bounded_exec(bash, ~s(v="hello hello"; echo "${v/hello/hi}" "${v//hello/hi}"))
+
+      assert result.exit_code == 0
+      assert result.stdout == "hi hello hi hi\n"
+    end
   end
 
   describe "a recursive traversal" do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #86

#85 bounded `v=${v}${v}` by checking `byte_size(left) + byte_size(right)` before concatenating. `${v//pat/rep}` / `${v/pat/rep}` still allocated first: `JustBash.Interpreter.Expansion.Parameter.expand_with_operation/4` ran `Regex.replace/4` and only then returned, so `concat!` saw the finished binary.

Grow `v` and `r` to the cap with ~20 doublings, then `v=${v//a/$r}`. Result size is roughly `|v| * |r|` ≈ **1 TiB under default limits**. Same class as #77: one expansion step, no pre-size check.

## User-visible contract

Unchanged limit key **`:max_value_bytes`**. A script that grows a value past the cap via pattern replacement now terminates with a shell result, the same shape as doubling:

```
bash: value size limit exceeded (65536 bytes)
```

exit 1, script halted. `JustBash.exec/2` does not raise.

```elixir
# limits: [max_value_bytes: 32_768]

"v=a; r=a; for i in {1..15}; do v=${v}${v}; r=${r}${r}; done; v=${v//a/$r}"
# => exit 1, "bash: value size limit exceeded (32768 bytes)"
#    in well under 200 ms; no GiB-scale allocation
```

A normal-size `${v/pat/rep}` / `${v//pat/rep}` is untouched. A non-matching replace of a cap-sized haystack still succeeds. `limits: false` still disables every bound, including this one.

## What changed

- `Limit.replace!/5` projects the result size from match lengths (`str_size - match_len + replacement_size` per match) and refuses as soon as the running total would exceed `:max_value_bytes`, so `Regex.replace/4` never builds the oversized binary.
- A cheap upper bound (`str_size + (str_size + 1) * replacement_size` for global replace) skips the walk when the result clearly fits.
- Parameter expansion (`${v/pat/rep}`, `${v//pat/rep}`) goes through that helper instead of calling `Regex.replace/4` directly.

## Tests

- Doubling then global replace (`v=${v//a/$r}` after 15 doublings to a 32_768-byte cap) is refused, with an elapsed-time guard so a regression cannot spend ~700 ms / 1 GiB allocating.
- A single `${v/pat/rep}` that would grow past the cap is also refused.
- A normal-size `${v/hello/hi}` / `${v//hello/hi}` still succeeds.
- `replace!/5` covers the “refuse before allocating” API, including a non-matching replace of a cap-sized haystack and `limits: false`.

## Gates

`mix compile --warnings-as-errors`

`mix format --check-formatted`

`mix credo --strict` — the single finding is the intentional `apply/2` test fixture; identical on `main`.

`mix test`

```
Finished in 39.2 seconds (38.7s async, 0.5s sync)
2 doctests, 62 properties, 5480 tests, 0 failures (5 excluded)
```

`mix docs --warnings-as-errors`

`mix dialyzer`

```
Total errors: 13, Skipped: 13, Unnecessary Skips: 0
done (passed successfully)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-132f486f-616f-4ff2-ab61-e0b7e61b3ed0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-132f486f-616f-4ff2-ab61-e0b7e61b3ed0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

