### PR TITLE
fix: Special table owns readdir merge and write-redirect paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * head default line count no longer emits a trailing blank line ([#80](https://github.com/elixir-ai-tools/just_bash/issues/80))
 * tac no longer invents a newline on an unterminated last record ([#82](https://github.com/elixir-ai-tools/just_bash/issues/82))
 * `/dev/null` exists as a filesystem node, so operands agree with redirects ([#78](https://github.com/elixir-ai-tools/just_bash/issues/78))
+* `FS.readdir/2` only uniq-sorts directories that contribute special children, and write redirects to `/dev/./null` skip the file-size cap ([#94](https://github.com/elixir-ai-tools/just_bash/issues/94))
 
 ## [0.1.0] - 2026-01-11
 

--- a/lib/just_bash/fs/special.ex
+++ b/lib/just_bash/fs/special.ex
@@ -50,12 +50,25 @@ defmodule JustBash.FS.Special do
   def children(@dev), do: ["null"]
   def children(_path), do: []
 
+  @doc """
+  Merge special children into a backend listing.
+
+  Only paths that contribute children (`/` and `/dev`) are uniq-sorted.
+  Every other directory returns `entries` in the backend's order, so
+  `ls` of an unrelated path is not a drive-by sort.
+  """
   @spec merge_children(String.t(), [String.t()]) :: [String.t()]
   def merge_children(path, entries) do
-    entries
-    |> Enum.concat(children(path))
-    |> Enum.uniq()
-    |> Enum.sort()
+    case children(path) do
+      [] ->
+        entries
+
+      extra ->
+        entries
+        |> Enum.concat(extra)
+        |> Enum.uniq()
+        |> Enum.sort()
+    end
   end
 
   @spec read_file(term(), kind(), String.t()) :: {:ok, binary(), term()} | {:error, Error.t()}

--- a/lib/just_bash/interpreter/executor/redirection.ex
+++ b/lib/just_bash/interpreter/executor/redirection.ex
@@ -14,17 +14,11 @@ defmodule JustBash.Interpreter.Executor.Redirection do
 
   alias JustBash.AST
   alias JustBash.FS
+  alias JustBash.FS.Special
   alias JustBash.Interpreter.Expansion
   alias JustBash.Limit
 
   @type result :: %{stdout: String.t(), stderr: String.t(), exit_code: non_neg_integer()}
-
-  # The one path the shell discards on the write side instead of opening in
-  # the filesystem. The read side (`< /dev/null`) and every command operand
-  # go through `JustBash.FS`, which services the same path as a special file.
-  # Both layers have to name the same set: `> /dev/null` discards, so
-  # `< /dev/null` and `cat /dev/null` read empty.
-  @null_device "/dev/null"
 
   @typedoc """
   A redirection whose target has already been expanded, resolved, and opened
@@ -65,8 +59,9 @@ defmodule JustBash.Interpreter.Executor.Redirection do
 
   Opening follows the `open/2` flags bash uses: `>`, `2>` and `&>` create or
   truncate (`O_CREAT | O_TRUNC`), `>>` and `&>>` create only if missing
-  (`O_CREAT | O_APPEND`). Redirections that touch no file — `/dev/null`,
-  `>&`, `<` — are classified and passed through untouched.
+  (`O_CREAT | O_APPEND`). Redirections that touch no file — the
+  special-file table's null device (`/dev/null`, `/dev/./null`), `>&`,
+  `<` — are classified and passed through untouched.
 
   Targets to the left of a failing one are still created or truncated, and
   targets to its right are never expanded, so a command substitution in one
@@ -127,8 +122,8 @@ defmodule JustBash.Interpreter.Executor.Redirection do
     %AST.Redirection{fd: fd, operator: operator, target: target} = redirection
 
     target_path = Expansion.expand_redirect_target(bash, target)
-    redir_type = classify_redirection(fd, operator, target_path)
     resolved = FS.resolve_path(bash.cwd, target_path)
+    redir_type = classify_redirection(fd, operator, target_path, resolved)
 
     case open_target(bash, redir_type, target_path, resolved) do
       {:ok, bash} ->
@@ -231,25 +226,46 @@ defmodule JustBash.Interpreter.Executor.Redirection do
     end
   end
 
-  @spec classify_redirection(non_neg_integer(), atom(), String.t()) :: redir_type()
-  # Combined redirection &> must be checked before /dev/null catch-all
-  defp classify_redirection(_fd, :"&>", @null_device), do: :combined_dev_null
-  defp classify_redirection(_fd, :"&>>", @null_device), do: :combined_dev_null
-  defp classify_redirection(_fd, :"&>", _target), do: :combined_write
-  defp classify_redirection(_fd, :"&>>", _target), do: :combined_append
-  defp classify_redirection(2, :>, @null_device), do: :stderr_dev_null
-  defp classify_redirection(2, :">>", @null_device), do: :stderr_dev_null
-  defp classify_redirection(_fd, _operator, @null_device), do: :stdout_dev_null
-  defp classify_redirection(2, :>, _target), do: :stderr_write
-  defp classify_redirection(2, :">>", _target), do: :stderr_append
-  defp classify_redirection(_fd, :>, _target), do: :stdout_write
-  defp classify_redirection(_fd, :">>", _target), do: :stdout_append
+  @spec classify_redirection(non_neg_integer() | nil, atom(), String.t(), FS.resolved()) ::
+          redir_type()
+  defp classify_redirection(fd, operator, target, resolved) do
+    if null_redirect?(target, resolved) do
+      classify_null_redirection(fd, operator)
+    else
+      classify_ordinary_redirection(fd, operator, target)
+    end
+  end
+
+  # Write redirects consult the special-file table after resolve/normalize,
+  # so `> /dev/./null` is the same node as `> /dev/null` and skips the
+  # file-size cap. A trailing slash is a directory assertion, not another
+  # spelling of the device — bash rejects `> /dev/null/` — so those stay
+  # on the ordinary open path.
+  defp null_redirect?(target, resolved) when is_binary(resolved) do
+    Special.null?(resolved) and not FS.directory_spelling?(target)
+  end
+
+  defp null_redirect?(_target, _resolved), do: false
+
+  defp classify_null_redirection(_fd, :"&>"), do: :combined_dev_null
+  defp classify_null_redirection(_fd, :"&>>"), do: :combined_dev_null
+  defp classify_null_redirection(2, :>), do: :stderr_dev_null
+  defp classify_null_redirection(2, :">>"), do: :stderr_dev_null
+  defp classify_null_redirection(_fd, _operator), do: :stdout_dev_null
+
+  # Combined redirection &> must be checked before the fd-2 write clauses.
+  defp classify_ordinary_redirection(_fd, :"&>", _target), do: :combined_write
+  defp classify_ordinary_redirection(_fd, :"&>>", _target), do: :combined_append
+  defp classify_ordinary_redirection(2, :>, _target), do: :stderr_write
+  defp classify_ordinary_redirection(2, :">>", _target), do: :stderr_append
+  defp classify_ordinary_redirection(_fd, :>, _target), do: :stdout_write
+  defp classify_ordinary_redirection(_fd, :">>", _target), do: :stdout_append
   # >&2 without explicit fd defaults to 1>&2 (stdout to stderr)
-  defp classify_redirection(fd, :">&", "2") when fd in [nil, 1], do: :stdout_to_stderr
-  defp classify_redirection(fd, :">&", "1") when fd in [nil, 2], do: :stderr_to_stdout
-  defp classify_redirection(_fd, :">&", "-"), do: :close_fd
-  defp classify_redirection(_fd, :<, _target), do: :stdin_read
-  defp classify_redirection(_fd, _operator, _target), do: :noop
+  defp classify_ordinary_redirection(fd, :">&", "2") when fd in [nil, 1], do: :stdout_to_stderr
+  defp classify_ordinary_redirection(fd, :">&", "1") when fd in [nil, 2], do: :stderr_to_stdout
+  defp classify_ordinary_redirection(_fd, :">&", "-"), do: :close_fd
+  defp classify_ordinary_redirection(_fd, :<, _target), do: :stdin_read
+  defp classify_ordinary_redirection(_fd, _operator, _target), do: :noop
 
   defp apply_classified_redirection(:stdout_dev_null, result, bash, _resolved) do
     {%{result | stdout: ""}, bash}

--- a/test/just_bash/fs_test.exs
+++ b/test/just_bash/fs_test.exs
@@ -282,6 +282,7 @@ defmodule JustBash.FSTest do
     end
 
     test "does not sort a directory that has no special children" do
+      # The backend yields a Stream so VFS does not sort the listing first.
       fs =
         VFS.new()
         |> VFS.mount("/data", %OrderedReaddirBackend{entries: ["z", "a", "m"]})

--- a/test/just_bash/fs_test.exs
+++ b/test/just_bash/fs_test.exs
@@ -2,6 +2,8 @@ defmodule JustBash.FSTest do
   use ExUnit.Case, async: true
 
   alias JustBash.FS
+  alias JustBash.FS.Special
+  alias JustBash.Test.OrderedReaddirBackend
 
   describe "new/1" do
     test "creates filesystem with root directory" do
@@ -277,6 +279,20 @@ defmodule JustBash.FSTest do
       {:ok, entries, _fs} = FS.readdir(fs, "/")
       assert "file.txt" in entries
       assert "dir" in entries
+    end
+
+    test "does not sort a directory that has no special children" do
+      fs =
+        VFS.new()
+        |> VFS.mount("/data", %OrderedReaddirBackend{entries: ["z", "a", "m"]})
+
+      assert {:ok, ["z", "a", "m"], _fs} = FS.readdir(fs, "/data")
+    end
+
+    test "still uniq-sorts root after merging special children" do
+      fs = VFS.new() |> VFS.mount("/", %OrderedReaddirBackend{entries: ["z", "a"]})
+
+      assert {:ok, ["a", "dev", "z"], _fs} = FS.readdir(fs, "/")
     end
   end
 
@@ -837,6 +853,15 @@ defmodule JustBash.FSTest do
       fs = FS.new()
       {:ok, entries, _fs} = FS.readdir(fs, "/")
       assert "dev" in Enum.to_list(entries)
+    end
+
+    test "merge_children preserves backend order when a path has no special children" do
+      assert Special.merge_children("/dir", ["z", "a", "m"]) == ["z", "a", "m"]
+    end
+
+    test "merge_children uniq-sorts only directories that contribute children" do
+      assert Special.merge_children("/", ["z", "a"]) == ["a", "dev", "z"]
+      assert Special.merge_children("/dev", ["foo"]) == ["foo", "null"]
     end
 
     test "cp from /dev/null writes an empty destination" do

--- a/test/limit_test.exs
+++ b/test/limit_test.exs
@@ -216,6 +216,19 @@ defmodule JustBash.LimitTest do
       {result, _bash} = JustBash.exec(bash, ~s(echo "hello" > /tmp/small.txt))
       assert result.exit_code == 0
     end
+
+    test "> /dev/./null skips the file-size cap" do
+      bash = JustBash.new(limits: [max_file_bytes: 10])
+      big = String.duplicate("x", 100)
+      {result, bash} = JustBash.exec(bash, ~s(echo -n "#{big}" > /dev/./null))
+
+      assert result.exit_code == 0
+      assert result.stdout == ""
+      assert result.stderr == ""
+
+      {cat, _} = JustBash.exec(bash, "cat /dev/null")
+      assert cat.stdout == ""
+    end
   end
 
   describe "value size limit" do

--- a/test/support/ordered_readdir_backend.ex
+++ b/test/support/ordered_readdir_backend.ex
@@ -1,6 +1,7 @@
 # A mountable backend whose `readdir/2` returns names in a caller-chosen
-# order. The in-memory backend uniq-sorts, so the only way to see whether
-# `FS.readdir/2` re-sorts an unrelated directory is a backend that does not.
+# order, as a Stream. VFS uniq-sorts bounded *list* listings itself, so a
+# list would hide whether `FS.readdir/2` / `Special.merge_children/2`
+# re-sorts an unrelated directory.
 defmodule JustBash.Test.OrderedReaddirBackend do
   @moduledoc false
   defstruct entries: []
@@ -17,10 +18,15 @@ defimpl VFS.Mountable, for: JustBash.Test.OrderedReaddirBackend do
   def exists?(b, _path), do: {false, b}
 
   def stat(b, "/"), do: {:ok, Stat.directory(@mtime), b}
-  def stat(b, path), do: {:error, Error.new(:enoent, path: path)}
+  def stat(_b, path), do: {:error, Error.new(:enoent, path: path)}
 
-  def readdir(b, "/"), do: {:ok, b.entries, b}
-  def readdir(b, path), do: {:error, Error.new(:enoent, path: path)}
+  def readdir(b, "/"), do: {:ok, Stream.map(b.entries, &Function.identity/1), b}
+  def readdir(_b, path), do: {:error, Error.new(:enoent, path: path)}
+
+  def stream_read(_b, path, _opts), do: {:error, Error.new(:enoent, path: path)}
+  def write_file(_b, path, _content, _opts), do: {:error, Error.new(:erofs, path: path)}
+  def mkdir(_b, path, _opts), do: {:error, Error.new(:erofs, path: path)}
+  def rm(_b, path, _opts), do: {:error, Error.new(:erofs, path: path)}
 
   def capabilities(_), do: MapSet.new([:read])
 end

--- a/test/support/ordered_readdir_backend.ex
+++ b/test/support/ordered_readdir_backend.ex
@@ -1,0 +1,26 @@
+# A mountable backend whose `readdir/2` returns names in a caller-chosen
+# order. The in-memory backend uniq-sorts, so the only way to see whether
+# `FS.readdir/2` re-sorts an unrelated directory is a backend that does not.
+defmodule JustBash.Test.OrderedReaddirBackend do
+  @moduledoc false
+  defstruct entries: []
+end
+
+defimpl VFS.Mountable, for: JustBash.Test.OrderedReaddirBackend do
+  use VFS.Skeleton
+
+  alias VFS.{Error, Stat}
+
+  @mtime ~U[1970-01-01 00:00:00Z]
+
+  def exists?(b, "/"), do: {true, b}
+  def exists?(b, _path), do: {false, b}
+
+  def stat(b, "/"), do: {:ok, Stat.directory(@mtime), b}
+  def stat(b, path), do: {:error, Error.new(:enoent, path: path)}
+
+  def readdir(b, "/"), do: {:ok, b.entries, b}
+  def readdir(b, path), do: {:error, Error.new(:enoent, path: path)}
+
+  def capabilities(_), do: MapSet.new([:read])
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Leftover nits from #93 / #78 (`JustBash.FS.Special`). The special-file table is the right layer; these edges were still using a drive-by sort and a literal `/dev/null` match.

## Changes
- `Special.merge_children/2` only uniq-sorts when `children(path)` is non-empty. Ordinary `FS.readdir/2` / `ls` order is the backend's again.
- Write redirects classify through `Special.null?/1` after `FS.resolve_path/2`, so `> /dev/./null` is the same node as `> /dev/null` and skips `Limit.check_file_size!`. `exec/2` still returns a shell result.
- Trailing-slash spellings (`> /dev/null/`) stay on the ordinary open path (bash: not a directory).
- No character-device type. `test -f /dev/null` remains true (`VFS.Stat` is still `:regular`).

## Out of scope (investigated, not changed)
- `ln -s /dev/null /link` succeeds; `cat /link` is `ENOENT`. Special lookup is on the operand path, not after symlink follow, so the VFS backend sees no node.
- `mv /dev/null /out` is still cp-then-rm. `rm` is `:eacces`; the failed `with` drops the copied fs, so `/out` is not left behind. GNU `rename` fails without attempting the copy. Same user-visible result, different mechanism.
- `test -f /dev/null` is true. A char-device type is not needed for the two nits above.

## Related Issues
Fixes #94

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing
- [x] Added new tests
  - `FS.readdir/2` of an unrelated dir preserves backend order (stream backend; VFS already sorts bounded lists)
  - `merge_children/2` only sorts `/` and `/dev`
  - `> /dev/./null` with a payload over `max_file_bytes` exits 0 and does not raise
- [x] All existing tests pass (`mix test`: 2 doctests, 62 properties, 5493 tests, 0 failures)
- [x] `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo`, `mix dialyzer`, `mix docs --warnings-as-errors`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md (for non-trivial changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca315b97-96aa-4eb0-8760-ebf6cc7a9e47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca315b97-96aa-4eb0-8760-ebf6cc7a9e47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

