### PR TITLE
Add test/[ alphabet matrix (`mix bash_fixtures.gen test`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `mix bash_fixtures.gen printf` enumerates a printf conversion × flag/width/precision matrix (`printf_matrix`) — #70 item 2
+* `mix bash_fixtures.gen test` enumerates a `test`/`[` operator × revealing-shape matrix (`test_matrix`) — #70 item 2
 
 ### Bug Fixes
 

--- a/lib/mix/tasks/bash_fixtures.gen.ex
+++ b/lib/mix/tasks/bash_fixtures.gen.ex
@@ -21,6 +21,10 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       mix bash_fixtures printf_matrix  # record what real bash does
       mix test --only suite:printf_matrix
 
+      mix bash_fixtures.gen test       # write the matrix
+      mix bash_fixtures test_matrix    # record what real bash does
+      mix test --only suite:test_matrix
+
   Generated suites are named `<matrix>_matrix` and are safe to regenerate: the
   digest in `JustBash.Fixtures` is content-derived, so a case that did not change
   keeps its recording.
@@ -36,6 +40,15 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       `%b`/`%q` inputs that make escapes and quoting visible, and format
       recycling with excess arguments. Oils `builtin-printf.test.sh` is a
       cross-check, not this matrix. See #70 item 2.
+    * `test` — every POSIX/`[` operator (`-b -c -d -e -f -g -h -k -L -n -p
+      -r -S -s -t -u -w -x -z`, `=` `==` `!=` `<` `>`, `-eq -ne -lt -le -gt
+      -ge`, `-nt -ot -ef`, `-a -o`, `!`, plus bash extras `-G -O -N`) crossed
+      with revealing operand shapes for that operator — file/dir/missing/empty/
+      symlink/dangling for file tests, empty/nonempty/"0" for `-z`/`-n`, equal/
+      unequal/10-vs-9 for string and integer compares. Both `test` and `[` for
+      a representative subset so they cannot drift; the full operator list is
+      on `test`. This is not the item-3 filesystem-shape × command cube. See
+      #70 item 2.
 
   A list of conversions and a list of flags are each easy to write down. The
   cross of the two is where the bugs live and is what nobody enumerates by hand:
@@ -48,6 +61,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       mix bash_fixtures.gen              # every matrix
       mix bash_fixtures.gen date         # one matrix
       mix bash_fixtures.gen printf       # one matrix
+      mix bash_fixtures.gen test         # one matrix
       mix bash_fixtures.gen --dry-run    # report counts, write nothing
   """
 
@@ -58,7 +72,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
 
   @shortdoc "Generate enumerated fixture matrices"
 
-  @matrices ["date", "printf"]
+  @matrices ["date", "printf", "test"]
 
   @doc false
   def cases_for(name), do: build(name)
@@ -379,6 +393,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
 
   defp build("date"), do: date_cases()
   defp build("printf"), do: printf_cases()
+  defp build("test"), do: test_cases()
 
   defp date_cases do
     Enum.concat([
@@ -1029,6 +1044,549 @@ defmodule Mix.Tasks.BashFixtures.Gen do
   # `%05s` is a zero flag; `%10s` and `%.0s` only happen to contain a 0.
   defp zero_pad_string?(format, conv) do
     conv in ~w(s c b) and String.match?(format, ~r/%-?0\d/)
+  end
+
+  # ---------------------------------------------------------------------------
+  # test / [
+  #
+  # The alphabet is the POSIX `test`/`[` operators plus the bash extras this
+  # shell already claims (`==`, `<`, `>`, `-G`, `-O`, `-N`). Each operator is
+  # crossed with revealing operand shapes for *that* operator — not the item-3
+  # filesystem-shape × command cube. Two or more bases per family so
+  # false-vs-missing, empty-vs-nonempty, and 10-vs-9 cannot hide behind a
+  # single value that already fills the field.
+  #
+  # The full operator list is asked of `test`. A representative subset is
+  # asked of both `test` and `[` so the two spellings cannot drift.
+  #
+  # Gaps are assigned after recording, never by omitting a cell. Marking a
+  # gap must not change the digest — the reason lives in opts.
+  # ---------------------------------------------------------------------------
+
+  # POSIX file/string unary operators, then bash extras. Enumerated rather
+  # than curated: which of these JustBash implements is exactly the fact
+  # nobody writes down.
+  @test_file_unary ~w(-e -f -d -L -h -s -r -w -x)
+  @test_type_unary ~w(-b -c -p -S)
+  @test_mode_unary ~w(-u -g -k -G -O -N)
+  @test_string_unary ~w(-z -n)
+  @test_string_binary ~w(= == != < >)
+  @test_int_binary ~w(-eq -ne -lt -le -gt -ge)
+
+  # Shapes that make file operators distinguishable. A regular file and a
+  # missing path are both "not a directory"; only asking both shows whether
+  # `-d` is false-for-file or false-for-absent. Symlink vs dangling is the
+  # same pair for `-e`/`-L`/`-h`.
+  @test_file_shapes [
+    {:regular, "file"},
+    {:empty, "empty"},
+    {:directory, "dir"},
+    {:missing, "missing"},
+    {:symlink, "link"},
+    {:dangling, "dang"}
+  ]
+
+  # -z/-n: empty vs nonempty is the definition. "0" is nonempty (unlike
+  # arithmetic); a space is nonempty too. One of those two hides if the
+  # implementation trims or truthiness-coerces.
+  @test_string_unary_bases [
+    {"empty", ""},
+    {"hi", "hi"},
+    {"zero", "0"},
+    {"space", " "}
+  ]
+
+  # One-arg `test STRING` is implicit `-n`. Operators-as-operands (`=`, `!`)
+  # are the lookahead cases Oils pins.
+  @test_one_arg_bases [
+    {"empty", ""},
+    {"hi", "hi"},
+    {"zero", "0"},
+    {"dash", "-"},
+    {"equals", "="},
+    {"bang", "!"}
+  ]
+
+  # Two families so one pair cannot hide the operator: equal vs unequal,
+  # and 10-vs-9 where string order and numeric order disagree.
+  @test_string_binary_pairs [
+    {"equal", "hi", "hi"},
+    {"unequal", "a", "b"},
+    {"empty-empty", "", ""},
+    {"empty-hi", "", "hi"},
+    {"case", "A", "a"},
+    {"digits", "10", "9"}
+  ]
+
+  # 0/1 and -1/0 make sign and zero visible. 10/9 is the order that `-lt`
+  # and `<` disagree on. Non-numeric and `08` are the Integer.parse traps.
+  @test_int_binary_pairs [
+    {"zeros", "0", "0"},
+    {"zero-one", "0", "1"},
+    {"neg-zero", "-1", "0"},
+    {"equal", "7", "7"},
+    {"order", "10", "9"},
+    {"non-numeric", "a", "b"},
+    {"octal-looking", "08", "8"},
+    {"spaces", " 7", "7"}
+  ]
+
+  # `[` is asked only on this subset so the two commands cannot drift.
+  # The full operator list stays on `test`.
+  @test_bracket_file_ops ~w(-e -f -d -L -s)
+  @test_bracket_string_unary [{"-z", "empty", ""}, {"-n", "hi", "hi"}]
+  @test_bracket_string_binary [{"=", "equal", "hi", "hi"}, {"!=", "unequal", "a", "b"}]
+  @test_bracket_int_binary [{"-eq", "zeros", "0", "0"}, {"-lt", "order", "10", "9"}]
+
+  # Gaps named after the divergence, not the operator, so a later fix of
+  # `-x` does not keep the integer-parse cells marked.
+  @unimpl_unary_gap "JustBash test treats this unary operator as unknown and returns 1; bash implements it"
+  @unimpl_file_cmp_gap "JustBash test does not implement -nt/-ot/-ef; bash compares mtimes or identity"
+  @perm_gap "JustBash -r/-w/-x are existence checks; bash tests the corresponding permission bit"
+  @devnull_file_gap "JustBash types /dev/null as a regular file; bash reports it as a character device"
+  @dir_size_gap "JustBash reports directory size 0 so test -s dir is false; bash directories have nonzero size"
+  @int_parse_gap "JustBash Integer.parse/1 does not accept the integer spelling bash test accepts"
+  @int_stderr_gap "JustBash test returns 2 on a non-integer with no diagnostic; bash writes to stderr"
+  @arity_gap "JustBash test returns 1 for extra or unparsed arguments; bash exits 2 and diagnoses"
+  @unknown_op_gap "JustBash test returns 1 for an unknown operator; bash exits 2 and diagnoses"
+  @slash_file_gap "JustBash treats a trailing slash on a regular file as the file; bash requires a directory"
+  @bracket_syntax_gap "JustBash [ without a closing ] still evaluates the expression; bash exits 2"
+  @group_gap "JustBash test does not implement ( ) grouping"
+  @andor_nary_gap "JustBash test does not implement 4+ argument -a/-o as expression AND/OR"
+  @unary_a_gap "JustBash does not implement unary -a as a synonym of -e"
+  @setup_or_op_gap "JustBash cannot construct this operand shape (fifo, setuid, sticky, dated mtime) and/or does not implement the operator"
+
+  defp test_cases do
+    Enum.concat([
+      test_file_unary_cases(),
+      test_type_mode_cases(),
+      test_string_cases(),
+      test_int_cases(),
+      test_file_binary_cases(),
+      test_logic_cases(),
+      test_syntax_cases(),
+      test_bracket_cases()
+    ])
+  end
+
+  # File unary × revealing shapes, on `test` only. Permission bits get an
+  # extra chmod'd base so `-x` on a 644 file is not the same cell as `-x`
+  # on a missing file.
+  defp test_file_unary_cases do
+    Enum.concat([
+      for op <- @test_file_unary, {shape, path} <- @test_file_shapes do
+        test_file_case("test #{op} (#{shape})", "test", [op, {:path, path}], shape)
+      end,
+      [
+        test_file_case("test -x (executable)", "test", ["-x", {:path, "exe"}], :executable),
+        test_file_case("test -r (unreadable)", "test", ["-r", {:path, "noread"}], :unreadable),
+        test_file_case("test -w (unreadable)", "test", ["-w", {:path, "noread"}], :unreadable),
+        test_file_case("test -x (unreadable)", "test", ["-x", {:path, "noread"}], :unreadable),
+        test_file_case("test -e (enotdir)", "test", ["-e", {:path, "file/x"}], :enotdir),
+        test_file_case(
+          "test -d (trailing-slash dir)",
+          "test",
+          ["-d", {:path, "dir/"}],
+          :directory
+        ),
+        test_file_case(
+          "test -f (trailing-slash file)",
+          "test",
+          ["-f", {:path, "file/"}],
+          :regular
+        ),
+        test_abs_case("test -e (/dev/null)", "test", ["-e", "/dev/null"]),
+        test_abs_case("test -f (/dev/null)", "test", ["-f", "/dev/null"]),
+        test_abs_case("test -c (/dev/null)", "test", ["-c", "/dev/null"]),
+        test_abs_case("test -s (/dev/null)", "test", ["-s", "/dev/null"])
+      ]
+    ])
+  end
+
+  # Type and mode operators. The matching type is the cell that would
+  # hide behind "false on a regular file" if we never asked it.
+  defp test_type_mode_cases do
+    Enum.concat([
+      for op <- @test_type_unary, {shape, path} <- [{:regular, "file"}, {:missing, "missing"}] do
+        test_file_case("test #{op} (#{shape})", "test", [op, {:path, path}], shape)
+      end,
+      [
+        test_file_case("test -p (fifo)", "test", ["-p", {:path, "fifo"}], :fifo)
+      ],
+      for op <- @test_mode_unary do
+        test_file_case("test #{op} (regular)", "test", [op, {:path, "file"}], :regular)
+      end,
+      [
+        test_file_case("test -u (setuid)", "test", ["-u", {:path, "suid"}], :setuid),
+        test_file_case("test -g (setgid)", "test", ["-g", {:path, "sgid"}], :setgid),
+        test_file_case("test -k (sticky)", "test", ["-k", {:path, "sticky"}], :sticky),
+        test_file_case("test -u (missing)", "test", ["-u", {:path, "missing"}], :missing),
+        test_file_case("test -O (missing)", "test", ["-O", {:path, "missing"}], :missing)
+      ],
+      for fd <- ["0", "1", "2", "99"] do
+        test_plain_case("test -t (fd #{fd})", "test", ["-t", fd])
+      end,
+      [
+        test_plain_case("test -t (invalid)", "test", ["-t", "invalid"]),
+        test_plain_case("test -t (one-arg)", "test", ["-t"])
+      ]
+    ])
+  end
+
+  defp test_string_cases do
+    Enum.concat([
+      for op <- @test_string_unary, {label, value} <- @test_string_unary_bases do
+        test_plain_case("test #{op} (#{label})", "test", [op, value])
+      end,
+      for {label, value} <- @test_one_arg_bases do
+        test_plain_case("test one-arg (#{label})", "test", [value])
+      end,
+      for op <- @test_string_binary, {label, left, right} <- @test_string_binary_pairs do
+        test_plain_case("test #{op} (#{label})", "test", [left, op, right])
+      end
+    ])
+  end
+
+  defp test_int_cases do
+    for op <- @test_int_binary, {label, left, right} <- @test_int_binary_pairs do
+      test_plain_case("test #{op} (#{label})", "test", [left, op, right])
+    end
+  end
+
+  # File compares need two operands with a known relationship. `-nt` of
+  # older-vs-newer is false; newer-vs-older is the cell that would match
+  # "unimplemented returns 1" if we only asked the false side.
+  defp test_file_binary_cases do
+    [
+      test_file_case(
+        "test -nt (older-newer)",
+        "test",
+        [{:path, "old"}, "-nt", {:path, "new"}],
+        :older_newer
+      ),
+      test_file_case(
+        "test -nt (newer-older)",
+        "test",
+        [{:path, "new"}, "-nt", {:path, "old"}],
+        :older_newer
+      ),
+      test_file_case(
+        "test -ot (older-newer)",
+        "test",
+        [{:path, "old"}, "-ot", {:path, "new"}],
+        :older_newer
+      ),
+      test_file_case(
+        "test -ot (newer-older)",
+        "test",
+        [{:path, "new"}, "-ot", {:path, "old"}],
+        :older_newer
+      ),
+      test_file_case(
+        "test -nt (same)",
+        "test",
+        [{:path, "file"}, "-nt", {:path, "file"}],
+        :regular
+      ),
+      test_file_case(
+        "test -ot (same)",
+        "test",
+        [{:path, "file"}, "-ot", {:path, "file"}],
+        :regular
+      ),
+      test_file_case(
+        "test -ef (same-path)",
+        "test",
+        [{:path, "file"}, "-ef", {:path, "file"}],
+        :regular
+      ),
+      test_file_case(
+        "test -ef (hardlink)",
+        "test",
+        [{:path, "f"}, "-ef", {:path, "hard"}],
+        :hardlink
+      ),
+      test_file_case(
+        "test -ef (distinct)",
+        "test",
+        [{:path, "a"}, "-ef", {:path, "b"}],
+        :two_files
+      ),
+      test_file_case(
+        "test -nt (missing-file)",
+        "test",
+        [{:path, "missing"}, "-nt", {:path, "file"}],
+        :regular
+      ),
+      test_file_case(
+        "test -ef (missing-file)",
+        "test",
+        [{:path, "missing"}, "-ef", {:path, "file"}],
+        :regular
+      )
+    ]
+  end
+
+  defp test_logic_cases do
+    Enum.concat([
+      [
+        test_plain_case("test -a (hi-hi)", "test", ["hi", "-a", "hi"]),
+        test_plain_case("test -a (hi-empty)", "test", ["hi", "-a", ""]),
+        test_plain_case("test -o (empty-hi)", "test", ["", "-o", "hi"]),
+        test_plain_case("test -o (empty-empty)", "test", ["", "-o", ""]),
+        test_file_case("test unary -a (regular)", "test", ["-a", {:path, "file"}], :regular),
+        test_file_case("test unary -a (missing)", "test", ["-a", {:path, "missing"}], :missing),
+        test_file_case(
+          "test -a (file-and-dir)",
+          "test",
+          ["-f", {:path, "file"}, "-a", "-d", {:path, "dir"}],
+          :file_and_dir
+        ),
+        test_file_case(
+          "test -a (missing-and-dir)",
+          "test",
+          ["-f", {:path, "missing"}, "-a", "-d", {:path, "dir"}],
+          :directory
+        ),
+        test_plain_case("test ! (empty)", "test", ["!", ""]),
+        test_plain_case("test ! (hi)", "test", ["!", "hi"]),
+        test_plain_case("test ! -z (empty)", "test", ["!", "-z", ""]),
+        test_plain_case("test ! -z (hi)", "test", ["!", "-z", "hi"]),
+        test_file_case("test ! -f (missing)", "test", ["!", "-f", {:path, "missing"}], :missing),
+        test_file_case("test ! -f (regular)", "test", ["!", "-f", {:path, "file"}], :regular),
+        test_plain_case("test ! = (equal)", "test", ["!", "a", "=", "a"]),
+        test_plain_case("test ! = (unequal)", "test", ["!", "a", "=", "b"]),
+        test_plain_case("test group (hi)", "test", ["(", "hi", ")"]),
+        test_plain_case("test group (-z empty)", "test", ["(", "-z", "", ")"]),
+        test_plain_case("test group (= equal)", "test", ["(", "a", "=", "a", ")"])
+      ]
+    ])
+  end
+
+  defp test_syntax_cases do
+    [
+      test_plain_case("test no-args", "test", []),
+      test_plain_case("test extra-args", "test", ["-n", "x", "y"]),
+      test_plain_case("test unknown unary", "test", ["-Z", "x"]),
+      test_plain_case("test unknown binary", "test", ["a", "-xx", "b"]),
+      test_plain_case("test too-many", "test", ["a", "=", "a", "=", "a"]),
+      one_test(
+        "[ no-args",
+        "LC_ALL=C LANG=C [; echo rc=$?",
+        test_gap("[ no-args")
+      ),
+      one_test(
+        "[ empty",
+        "LC_ALL=C LANG=C [ ]; echo rc=$?",
+        test_gap("[ empty")
+      ),
+      one_test(
+        "[ missing-closer",
+        "LC_ALL=C LANG=C [ -n x; echo rc=$?",
+        test_gap("[ missing-closer")
+      ),
+      one_test(
+        "[ extra-after-closer",
+        "LC_ALL=C LANG=C [ -n x ] y; echo rc=$?",
+        test_gap("[ extra-after-closer")
+      )
+    ]
+  end
+
+  # Representative `[` cells, plus the matching `test` cells already
+  # enumerated above for the same expressions. Drift between the two is
+  # a harness failure, not a known gap.
+  defp test_bracket_cases do
+    Enum.concat([
+      for op <- @test_bracket_file_ops, {shape, path} <- bracket_file_shapes(op) do
+        test_file_case("[ #{op} (#{shape})", "[", [op, {:path, path}], shape)
+      end,
+      for {op, label, value} <- @test_bracket_string_unary do
+        test_plain_case("[ #{op} (#{label})", "[", [op, value])
+      end,
+      for {label, value} <- [{"empty", ""}, {"hi", "hi"}] do
+        test_plain_case("[ one-arg (#{label})", "[", [value])
+      end,
+      for {op, label, left, right} <- @test_bracket_string_binary do
+        test_plain_case("[ #{op} (#{label})", "[", [left, op, right])
+      end,
+      for {op, label, left, right} <- @test_bracket_int_binary do
+        test_plain_case("[ #{op} (#{label})", "[", [left, op, right])
+      end,
+      [
+        test_plain_case("[ ! -z (empty)", "[", ["!", "-z", ""]),
+        test_plain_case("[ -a (hi-hi)", "[", ["hi", "-a", "hi"]),
+        test_file_case("[ -L (dangling)", "[", ["-L", {:path, "dang"}], :dangling)
+      ]
+    ])
+  end
+
+  defp bracket_file_shapes("-L"), do: [{:symlink, "link"}, {:regular, "file"}]
+  defp bracket_file_shapes("-s"), do: [{:empty, "empty"}, {:regular, "file"}]
+
+  defp bracket_file_shapes("-f"),
+    do: [{:regular, "file"}, {:directory, "dir"}, {:missing, "missing"}]
+
+  defp bracket_file_shapes("-d"),
+    do: [{:directory, "dir"}, {:regular, "file"}, {:missing, "missing"}]
+
+  defp bracket_file_shapes("-e"),
+    do: [{:regular, "file"}, {:missing, "missing"}, {:dangling, "dang"}]
+
+  defp test_file_case(name, cmd, args, shape) do
+    one_test(name, setup_script(name, cmd, args, shape), test_gap(name))
+  end
+
+  defp test_abs_case(name, cmd, args) do
+    one_test(name, expr_script(cmd, args), test_gap(name))
+  end
+
+  defp test_plain_case(name, cmd, args) do
+    one_test(name, expr_script(cmd, args), test_gap(name))
+  end
+
+  defp expr_script(cmd, args) do
+    "LC_ALL=C LANG=C #{format_cmd(cmd, args)}; echo rc=$?"
+  end
+
+  defp setup_script(name, cmd, args, shape) do
+    slug = slugify(name)
+    setup = shape_setup(shape)
+
+    "D=/tmp/jb_t_#{slug}; mkdir -p \"$D\"; #{setup}; LC_ALL=C LANG=C #{format_cmd(cmd, args)}; echo rc=$?"
+  end
+
+  defp format_cmd("test", args), do: String.trim("test #{format_args(args)}")
+  defp format_cmd("[", args), do: String.trim("[ #{format_args(args)} ]")
+
+  defp format_args(args), do: Enum.map_join(args, " ", &format_arg/1)
+
+  defp format_arg({:path, rel}), do: "\"$D/#{rel}\""
+  defp format_arg(value) when is_binary(value), do: sh_single(value)
+
+  defp slugify(name) do
+    name
+    |> String.replace("[", "br")
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "_")
+    |> String.trim("_")
+    |> String.slice(0, 60)
+  end
+
+  defp shape_setup(:regular), do: "printf 'hello\\n' > \"$D/file\""
+  defp shape_setup(:empty), do: "printf '' > \"$D/empty\""
+  defp shape_setup(:directory), do: "mkdir -p \"$D/dir\""
+  defp shape_setup(:missing), do: ":"
+
+  defp shape_setup(:symlink),
+    do: "printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\""
+
+  defp shape_setup(:dangling), do: "ln -s \"$D/nope\" \"$D/dang\""
+  defp shape_setup(:executable), do: "printf 'echo hi\\n' > \"$D/exe\"; chmod +x \"$D/exe\""
+  defp shape_setup(:unreadable), do: "printf 'x\\n' > \"$D/noread\"; chmod 000 \"$D/noread\""
+  defp shape_setup(:fifo), do: "mkfifo \"$D/fifo\" 2>/dev/null"
+
+  defp shape_setup(:older_newer),
+    do:
+      "touch -d '2017-12-31' \"$D/old\" 2>/dev/null; touch -d '2018-01-01' \"$D/new\" 2>/dev/null"
+
+  defp shape_setup(:hardlink), do: "printf 'x\\n' > \"$D/f\"; ln \"$D/f\" \"$D/hard\""
+  defp shape_setup(:two_files), do: "printf 'a\\n' > \"$D/a\"; printf 'b\\n' > \"$D/b\""
+  defp shape_setup(:setuid), do: "printf 'x\\n' > \"$D/suid\"; chmod u+s \"$D/suid\""
+  defp shape_setup(:setgid), do: "printf 'x\\n' > \"$D/sgid\"; chmod g+s \"$D/sgid\""
+  defp shape_setup(:sticky), do: "mkdir -p \"$D/sticky\"; chmod +t \"$D/sticky\""
+  defp shape_setup(:enotdir), do: "printf 'x\\n' > \"$D/file\""
+  defp shape_setup(:file_and_dir), do: "printf 'hello\\n' > \"$D/file\"; mkdir -p \"$D/dir\""
+
+  defp one_test(name, script, known_gap) do
+    fixture_case("test matrix: #{name}", script, known_gap)
+  end
+
+  # Assigned after recording. A cell that matches is left unmarked even
+  # when the operator is unimplemented — returning 1 on a non-pipe is
+  # indistinguishable from a correct `-p`, and marking it would invert a
+  # passing assertion. The revealing shape carries the gap instead.
+  defp test_gap(name) do
+    cond do
+      name in ["test -c (/dev/null)", "test -f (/dev/null)"] ->
+        @devnull_file_gap
+
+      name == "test -s (directory)" ->
+        @dir_size_gap
+
+      name == "test -p (fifo)" ->
+        @setup_or_op_gap
+
+      name in ["test -u (setuid)", "test -g (setgid)", "test -k (sticky)"] ->
+        @setup_or_op_gap
+
+      String.contains?(name, " -nt ") or String.contains?(name, " -ot ") or
+          String.contains?(name, " -ef ") ->
+        file_cmp_gap(name)
+
+      name in [
+        "test -x (regular)",
+        "test -x (empty)",
+        "test -x (unreadable)",
+        "test -x (symlink)",
+        "test -r (unreadable)",
+        "test -w (unreadable)"
+      ] ->
+        @perm_gap
+
+      name == "test -f (trailing-slash file)" ->
+        @slash_file_gap
+
+      name == "test unary -a (regular)" ->
+        @unary_a_gap
+
+      name == "test -a (file-and-dir)" ->
+        @andor_nary_gap
+
+      String.starts_with?(name, "test group ") ->
+        @group_gap
+
+      name in ["[ no-args", "[ missing-closer", "[ extra-after-closer"] ->
+        @bracket_syntax_gap
+
+      name in ["test extra-args", "test too-many"] ->
+        @arity_gap
+
+      name in ["test unknown unary", "test unknown binary"] ->
+        @unknown_op_gap
+
+      int_spelling_gap?(name) ->
+        int_spelling_reason(name)
+
+      name in ["test -O (regular)", "test -G (regular)"] ->
+        @unimpl_unary_gap
+
+      true ->
+        nil
+    end
+  end
+
+  defp file_cmp_gap(name) do
+    if name in [
+         "test -nt (newer-older)",
+         "test -ot (older-newer)",
+         "test -ef (same-path)",
+         "test -ef (hardlink)"
+       ] do
+      @unimpl_file_cmp_gap
+    end
+  end
+
+  defp int_spelling_gap?(name) do
+    String.contains?(name, "(non-numeric)") or String.contains?(name, "(spaces)")
+  end
+
+  defp int_spelling_reason(name) do
+    if String.contains?(name, "(non-numeric)") do
+      @int_stderr_gap
+    else
+      @int_parse_gap
+    end
   end
 
   defp fixture_case(name, script, known_gap) do

--- a/lib/mix/tasks/bash_fixtures.gen.ex
+++ b/lib/mix/tasks/bash_fixtures.gen.ex
@@ -1507,63 +1507,30 @@ defmodule Mix.Tasks.BashFixtures.Gen do
   # indistinguishable from a correct `-p`, and marking it would invert a
   # passing assertion. The revealing shape carries the gap instead.
   defp test_gap(name) do
-    cond do
-      name in ["test -c (/dev/null)", "test -f (/dev/null)"] ->
-        @devnull_file_gap
-
-      name == "test -s (directory)" ->
-        @dir_size_gap
-
-      name == "test -p (fifo)" ->
-        @setup_or_op_gap
-
-      name in ["test -u (setuid)", "test -g (setgid)", "test -k (sticky)"] ->
-        @setup_or_op_gap
-
-      String.contains?(name, " -nt ") or String.contains?(name, " -ot ") or
-          String.contains?(name, " -ef ") ->
-        file_cmp_gap(name)
-
-      name in [
-        "test -x (regular)",
-        "test -x (empty)",
-        "test -x (unreadable)",
-        "test -x (symlink)",
-        "test -r (unreadable)",
-        "test -w (unreadable)"
-      ] ->
-        @perm_gap
-
-      name == "test -f (trailing-slash file)" ->
-        @slash_file_gap
-
-      name == "test unary -a (regular)" ->
-        @unary_a_gap
-
-      name == "test -a (file-and-dir)" ->
-        @andor_nary_gap
-
-      String.starts_with?(name, "test group ") ->
-        @group_gap
-
-      name in ["[ no-args", "[ missing-closer", "[ extra-after-closer"] ->
-        @bracket_syntax_gap
-
-      name in ["test extra-args", "test too-many"] ->
-        @arity_gap
-
-      name in ["test unknown unary", "test unknown binary"] ->
-        @unknown_op_gap
-
-      int_spelling_gap?(name) ->
-        int_spelling_reason(name)
-
-      name in ["test -O (regular)", "test -G (regular)"] ->
-        @unimpl_unary_gap
-
-      true ->
-        nil
+    case file_shape_gap(name) do
+      :none -> operator_gap(name)
+      gap -> gap
     end
+  end
+
+  defp file_shape_gap(name) do
+    cond do
+      name in ["test -c (/dev/null)", "test -f (/dev/null)"] -> @devnull_file_gap
+      name == "test -s (directory)" -> @dir_size_gap
+      name == "test -f (trailing-slash file)" -> @slash_file_gap
+      setup_shape_gap?(name) -> @setup_or_op_gap
+      file_cmp_name?(name) -> file_cmp_gap(name)
+      true -> :none
+    end
+  end
+
+  defp setup_shape_gap?(name) do
+    name in ["test -p (fifo)", "test -u (setuid)", "test -g (setgid)", "test -k (sticky)"]
+  end
+
+  defp file_cmp_name?(name) do
+    String.contains?(name, " -nt ") or String.contains?(name, " -ot ") or
+      String.contains?(name, " -ef ")
   end
 
   defp file_cmp_gap(name) do
@@ -1574,6 +1541,40 @@ defmodule Mix.Tasks.BashFixtures.Gen do
          "test -ef (hardlink)"
        ] do
       @unimpl_file_cmp_gap
+    else
+      :none
+    end
+  end
+
+  defp operator_gap(name) do
+    cond do
+      perm_gap?(name) -> @perm_gap
+      name == "test unary -a (regular)" -> @unary_a_gap
+      name == "test -a (file-and-dir)" -> @andor_nary_gap
+      String.starts_with?(name, "test group ") -> @group_gap
+      true -> syntax_gap(name)
+    end
+  end
+
+  defp perm_gap?(name) do
+    name in [
+      "test -x (regular)",
+      "test -x (empty)",
+      "test -x (unreadable)",
+      "test -x (symlink)",
+      "test -r (unreadable)",
+      "test -w (unreadable)"
+    ]
+  end
+
+  defp syntax_gap(name) do
+    cond do
+      name in ["[ no-args", "[ missing-closer", "[ extra-after-closer"] -> @bracket_syntax_gap
+      name in ["test extra-args", "test too-many"] -> @arity_gap
+      name in ["test unknown unary", "test unknown binary"] -> @unknown_op_gap
+      int_spelling_gap?(name) -> int_spelling_reason(name)
+      name in ["test -O (regular)", "test -G (regular)"] -> @unimpl_unary_gap
+      true -> nil
     end
   end
 

--- a/test/fixtures/bash_cases/test_matrix.json
+++ b/test/fixtures/bash_cases/test_matrix.json
@@ -1,0 +1,1367 @@
+{
+  "cases": [
+    {
+      "content_hash": "11b3421a848e08ac",
+      "name": "test matrix: test -e (regular)",
+      "script": "D=/tmp/jb_t_test_e_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-e' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "92a5581a31ec6563",
+      "name": "test matrix: test -e (empty)",
+      "script": "D=/tmp/jb_t_test_e_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-e' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ad6839828947579b",
+      "name": "test matrix: test -e (directory)",
+      "script": "D=/tmp/jb_t_test_e_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-e' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ede2309f2d5fc45e",
+      "name": "test matrix: test -e (missing)",
+      "script": "D=/tmp/jb_t_test_e_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-e' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a5b476bfd49b8b57",
+      "name": "test matrix: test -e (symlink)",
+      "script": "D=/tmp/jb_t_test_e_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-e' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e55e8d8bb441cbf3",
+      "name": "test matrix: test -e (dangling)",
+      "script": "D=/tmp/jb_t_test_e_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-e' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "200f9211d9cdd434",
+      "name": "test matrix: test -f (regular)",
+      "script": "D=/tmp/jb_t_test_f_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-f' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "63e15459fc383322",
+      "name": "test matrix: test -f (empty)",
+      "script": "D=/tmp/jb_t_test_f_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-f' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9b25dd243254a423",
+      "name": "test matrix: test -f (directory)",
+      "script": "D=/tmp/jb_t_test_f_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-f' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e398c0c75ea0a5f9",
+      "name": "test matrix: test -f (missing)",
+      "script": "D=/tmp/jb_t_test_f_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-f' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "eac31d30ae2917f9",
+      "name": "test matrix: test -f (symlink)",
+      "script": "D=/tmp/jb_t_test_f_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-f' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "aeab59ce19bc2ab5",
+      "name": "test matrix: test -f (dangling)",
+      "script": "D=/tmp/jb_t_test_f_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-f' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "621c87a9c114ac37",
+      "name": "test matrix: test -d (regular)",
+      "script": "D=/tmp/jb_t_test_d_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-d' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0f0a1c11700ece26",
+      "name": "test matrix: test -d (empty)",
+      "script": "D=/tmp/jb_t_test_d_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-d' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "73a33ebd32c3550f",
+      "name": "test matrix: test -d (directory)",
+      "script": "D=/tmp/jb_t_test_d_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-d' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8a3e3460bae2bee9",
+      "name": "test matrix: test -d (missing)",
+      "script": "D=/tmp/jb_t_test_d_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-d' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a0d1a87538cee38f",
+      "name": "test matrix: test -d (symlink)",
+      "script": "D=/tmp/jb_t_test_d_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-d' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9330e1957c7ccb3e",
+      "name": "test matrix: test -d (dangling)",
+      "script": "D=/tmp/jb_t_test_d_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-d' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "88858fd6ebc9d266",
+      "name": "test matrix: test -L (regular)",
+      "script": "D=/tmp/jb_t_test_l_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-L' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e0ef011968eeaa11",
+      "name": "test matrix: test -L (empty)",
+      "script": "D=/tmp/jb_t_test_l_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-L' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "282140d314c6538b",
+      "name": "test matrix: test -L (directory)",
+      "script": "D=/tmp/jb_t_test_l_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-L' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "d72f603cf1a79968",
+      "name": "test matrix: test -L (missing)",
+      "script": "D=/tmp/jb_t_test_l_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-L' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fa528da0ece73545",
+      "name": "test matrix: test -L (symlink)",
+      "script": "D=/tmp/jb_t_test_l_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-L' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "40bbbe6b44fe5d63",
+      "name": "test matrix: test -L (dangling)",
+      "script": "D=/tmp/jb_t_test_l_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-L' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ab073038ea1daad9",
+      "name": "test matrix: test -h (regular)",
+      "script": "D=/tmp/jb_t_test_h_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-h' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "b0d4b541177011e5",
+      "name": "test matrix: test -h (empty)",
+      "script": "D=/tmp/jb_t_test_h_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-h' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "495d902920d8535b",
+      "name": "test matrix: test -h (directory)",
+      "script": "D=/tmp/jb_t_test_h_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-h' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a19f009eee763ba1",
+      "name": "test matrix: test -h (missing)",
+      "script": "D=/tmp/jb_t_test_h_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-h' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2d2e53000e0101b7",
+      "name": "test matrix: test -h (symlink)",
+      "script": "D=/tmp/jb_t_test_h_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-h' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8b361d78f30701f3",
+      "name": "test matrix: test -h (dangling)",
+      "script": "D=/tmp/jb_t_test_h_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-h' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "11deac7055abf6f4",
+      "name": "test matrix: test -s (regular)",
+      "script": "D=/tmp/jb_t_test_s_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-s' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "410f86b5835dbe31",
+      "name": "test matrix: test -s (empty)",
+      "script": "D=/tmp/jb_t_test_s_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-s' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "bf0a34c272e2b1f9",
+      "name": "test matrix: test -s (directory)",
+      "opts": {
+        "known_gap": "JustBash reports directory size 0 so test -s dir is false; bash directories have nonzero size"
+      },
+      "script": "D=/tmp/jb_t_test_s_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-s' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "abd9702e8c878b6f",
+      "name": "test matrix: test -s (missing)",
+      "script": "D=/tmp/jb_t_test_s_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-s' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "acfc164595f70781",
+      "name": "test matrix: test -s (symlink)",
+      "script": "D=/tmp/jb_t_test_s_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-s' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "7056c81bc5f5acd8",
+      "name": "test matrix: test -s (dangling)",
+      "script": "D=/tmp/jb_t_test_s_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-s' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "23b68438875dd537",
+      "name": "test matrix: test -r (regular)",
+      "script": "D=/tmp/jb_t_test_r_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-r' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3d3f1883a0907fa5",
+      "name": "test matrix: test -r (empty)",
+      "script": "D=/tmp/jb_t_test_r_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-r' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9e718d38952a0195",
+      "name": "test matrix: test -r (directory)",
+      "script": "D=/tmp/jb_t_test_r_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-r' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "cdd5d646379170c3",
+      "name": "test matrix: test -r (missing)",
+      "script": "D=/tmp/jb_t_test_r_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-r' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "177204c1b437be16",
+      "name": "test matrix: test -r (symlink)",
+      "script": "D=/tmp/jb_t_test_r_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-r' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "31762eb80293eec2",
+      "name": "test matrix: test -r (dangling)",
+      "script": "D=/tmp/jb_t_test_r_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-r' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fed7156d7e5a16fc",
+      "name": "test matrix: test -w (regular)",
+      "script": "D=/tmp/jb_t_test_w_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-w' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "71ac6a9ba114dfef",
+      "name": "test matrix: test -w (empty)",
+      "script": "D=/tmp/jb_t_test_w_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-w' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "45cf496d750ee74d",
+      "name": "test matrix: test -w (directory)",
+      "script": "D=/tmp/jb_t_test_w_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-w' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0e8a9e4353b22073",
+      "name": "test matrix: test -w (missing)",
+      "script": "D=/tmp/jb_t_test_w_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-w' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "650d110a272278ed",
+      "name": "test matrix: test -w (symlink)",
+      "script": "D=/tmp/jb_t_test_w_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-w' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ce33e9e15343d34f",
+      "name": "test matrix: test -w (dangling)",
+      "script": "D=/tmp/jb_t_test_w_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-w' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "838dae058ef8faa4",
+      "name": "test matrix: test -x (regular)",
+      "opts": {
+        "known_gap": "JustBash -r/-w/-x are existence checks; bash tests the corresponding permission bit"
+      },
+      "script": "D=/tmp/jb_t_test_x_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-x' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ec8330383441a979",
+      "name": "test matrix: test -x (empty)",
+      "opts": {
+        "known_gap": "JustBash -r/-w/-x are existence checks; bash tests the corresponding permission bit"
+      },
+      "script": "D=/tmp/jb_t_test_x_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C test '-x' \"$D/empty\"; echo rc=$?"
+    },
+    {
+      "content_hash": "364dd47d82c8c94b",
+      "name": "test matrix: test -x (directory)",
+      "script": "D=/tmp/jb_t_test_x_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-x' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f507fb6d6f41f162",
+      "name": "test matrix: test -x (missing)",
+      "script": "D=/tmp/jb_t_test_x_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-x' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "aba04df94af81416",
+      "name": "test matrix: test -x (symlink)",
+      "opts": {
+        "known_gap": "JustBash -r/-w/-x are existence checks; bash tests the corresponding permission bit"
+      },
+      "script": "D=/tmp/jb_t_test_x_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C test '-x' \"$D/link\"; echo rc=$?"
+    },
+    {
+      "content_hash": "5beefe2a9d3262f5",
+      "name": "test matrix: test -x (dangling)",
+      "script": "D=/tmp/jb_t_test_x_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C test '-x' \"$D/dang\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e51e8152f985100c",
+      "name": "test matrix: test -x (executable)",
+      "script": "D=/tmp/jb_t_test_x_executable; mkdir -p \"$D\"; printf 'echo hi\\n' > \"$D/exe\"; chmod +x \"$D/exe\"; LC_ALL=C LANG=C test '-x' \"$D/exe\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2c921fbb38c035f2",
+      "name": "test matrix: test -r (unreadable)",
+      "opts": {
+        "known_gap": "JustBash -r/-w/-x are existence checks; bash tests the corresponding permission bit"
+      },
+      "script": "D=/tmp/jb_t_test_r_unreadable; mkdir -p \"$D\"; printf 'x\\n' > \"$D/noread\"; chmod 000 \"$D/noread\"; LC_ALL=C LANG=C test '-r' \"$D/noread\"; echo rc=$?"
+    },
+    {
+      "content_hash": "56a3c534d6ec69c9",
+      "name": "test matrix: test -w (unreadable)",
+      "opts": {
+        "known_gap": "JustBash -r/-w/-x are existence checks; bash tests the corresponding permission bit"
+      },
+      "script": "D=/tmp/jb_t_test_w_unreadable; mkdir -p \"$D\"; printf 'x\\n' > \"$D/noread\"; chmod 000 \"$D/noread\"; LC_ALL=C LANG=C test '-w' \"$D/noread\"; echo rc=$?"
+    },
+    {
+      "content_hash": "b97853606a19ee14",
+      "name": "test matrix: test -x (unreadable)",
+      "opts": {
+        "known_gap": "JustBash -r/-w/-x are existence checks; bash tests the corresponding permission bit"
+      },
+      "script": "D=/tmp/jb_t_test_x_unreadable; mkdir -p \"$D\"; printf 'x\\n' > \"$D/noread\"; chmod 000 \"$D/noread\"; LC_ALL=C LANG=C test '-x' \"$D/noread\"; echo rc=$?"
+    },
+    {
+      "content_hash": "cbe7e1106e55c694",
+      "name": "test matrix: test -e (enotdir)",
+      "script": "D=/tmp/jb_t_test_e_enotdir; mkdir -p \"$D\"; printf 'x\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-e' \"$D/file/x\"; echo rc=$?"
+    },
+    {
+      "content_hash": "6dcf0122666f68e5",
+      "name": "test matrix: test -d (trailing-slash dir)",
+      "script": "D=/tmp/jb_t_test_d_trailing_slash_dir; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-d' \"$D/dir/\"; echo rc=$?"
+    },
+    {
+      "content_hash": "93233f733c518628",
+      "name": "test matrix: test -f (trailing-slash file)",
+      "opts": {
+        "known_gap": "JustBash treats a trailing slash on a regular file as the file; bash requires a directory"
+      },
+      "script": "D=/tmp/jb_t_test_f_trailing_slash_file; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-f' \"$D/file/\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e189ff7b668fe41c",
+      "name": "test matrix: test -e (/dev/null)",
+      "script": "LC_ALL=C LANG=C test '-e' '/dev/null'; echo rc=$?"
+    },
+    {
+      "content_hash": "b8bea7ca6b34090c",
+      "name": "test matrix: test -f (/dev/null)",
+      "opts": {
+        "known_gap": "JustBash types /dev/null as a regular file; bash reports it as a character device"
+      },
+      "script": "LC_ALL=C LANG=C test '-f' '/dev/null'; echo rc=$?"
+    },
+    {
+      "content_hash": "dabb9258afcdcf48",
+      "name": "test matrix: test -c (/dev/null)",
+      "opts": {
+        "known_gap": "JustBash types /dev/null as a regular file; bash reports it as a character device"
+      },
+      "script": "LC_ALL=C LANG=C test '-c' '/dev/null'; echo rc=$?"
+    },
+    {
+      "content_hash": "5cb615164044977b",
+      "name": "test matrix: test -s (/dev/null)",
+      "script": "LC_ALL=C LANG=C test '-s' '/dev/null'; echo rc=$?"
+    },
+    {
+      "content_hash": "eb8f9220be60ae26",
+      "name": "test matrix: test -b (regular)",
+      "script": "D=/tmp/jb_t_test_b_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-b' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "81a339f342aac124",
+      "name": "test matrix: test -b (missing)",
+      "script": "D=/tmp/jb_t_test_b_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-b' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "506bb46b925e5140",
+      "name": "test matrix: test -c (regular)",
+      "script": "D=/tmp/jb_t_test_c_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-c' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0b5a5dce9dbaac05",
+      "name": "test matrix: test -c (missing)",
+      "script": "D=/tmp/jb_t_test_c_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-c' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fc7a473b867eeca7",
+      "name": "test matrix: test -p (regular)",
+      "script": "D=/tmp/jb_t_test_p_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-p' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "deb43c5cad4571f0",
+      "name": "test matrix: test -p (missing)",
+      "script": "D=/tmp/jb_t_test_p_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-p' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a84760081cdc3dfb",
+      "name": "test matrix: test -S (regular)",
+      "script": "D=/tmp/jb_t_test_s_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-S' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "21cbf3316aff1cee",
+      "name": "test matrix: test -S (missing)",
+      "script": "D=/tmp/jb_t_test_s_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-S' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2f758b315ef82a82",
+      "name": "test matrix: test -p (fifo)",
+      "opts": {
+        "known_gap": "JustBash cannot construct this operand shape (fifo, setuid, sticky, dated mtime) and/or does not implement the operator"
+      },
+      "script": "D=/tmp/jb_t_test_p_fifo; mkdir -p \"$D\"; mkfifo \"$D/fifo\" 2>/dev/null; LC_ALL=C LANG=C test '-p' \"$D/fifo\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8c46ed8a15e74b02",
+      "name": "test matrix: test -u (regular)",
+      "script": "D=/tmp/jb_t_test_u_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-u' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fd6cb415f46e1db5",
+      "name": "test matrix: test -g (regular)",
+      "script": "D=/tmp/jb_t_test_g_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-g' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "6ea5112d495ee93c",
+      "name": "test matrix: test -k (regular)",
+      "script": "D=/tmp/jb_t_test_k_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-k' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0b824b2da8d97f72",
+      "name": "test matrix: test -G (regular)",
+      "opts": {
+        "known_gap": "JustBash test treats this unary operator as unknown and returns 1; bash implements it"
+      },
+      "script": "D=/tmp/jb_t_test_g_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-G' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4e9bfa3379ce6167",
+      "name": "test matrix: test -O (regular)",
+      "opts": {
+        "known_gap": "JustBash test treats this unary operator as unknown and returns 1; bash implements it"
+      },
+      "script": "D=/tmp/jb_t_test_o_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-O' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "6e6e4dea80432259",
+      "name": "test matrix: test -N (regular)",
+      "script": "D=/tmp/jb_t_test_n_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-N' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "63525aca7f521a01",
+      "name": "test matrix: test -u (setuid)",
+      "opts": {
+        "known_gap": "JustBash cannot construct this operand shape (fifo, setuid, sticky, dated mtime) and/or does not implement the operator"
+      },
+      "script": "D=/tmp/jb_t_test_u_setuid; mkdir -p \"$D\"; printf 'x\\n' > \"$D/suid\"; chmod u+s \"$D/suid\"; LC_ALL=C LANG=C test '-u' \"$D/suid\"; echo rc=$?"
+    },
+    {
+      "content_hash": "dacacc90641e41ae",
+      "name": "test matrix: test -g (setgid)",
+      "opts": {
+        "known_gap": "JustBash cannot construct this operand shape (fifo, setuid, sticky, dated mtime) and/or does not implement the operator"
+      },
+      "script": "D=/tmp/jb_t_test_g_setgid; mkdir -p \"$D\"; printf 'x\\n' > \"$D/sgid\"; chmod g+s \"$D/sgid\"; LC_ALL=C LANG=C test '-g' \"$D/sgid\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f86bf8ccee64d42a",
+      "name": "test matrix: test -k (sticky)",
+      "opts": {
+        "known_gap": "JustBash cannot construct this operand shape (fifo, setuid, sticky, dated mtime) and/or does not implement the operator"
+      },
+      "script": "D=/tmp/jb_t_test_k_sticky; mkdir -p \"$D\"; mkdir -p \"$D/sticky\"; chmod +t \"$D/sticky\"; LC_ALL=C LANG=C test '-k' \"$D/sticky\"; echo rc=$?"
+    },
+    {
+      "content_hash": "693a04e5b4517ea2",
+      "name": "test matrix: test -u (missing)",
+      "script": "D=/tmp/jb_t_test_u_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-u' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c47215d20ed96224",
+      "name": "test matrix: test -O (missing)",
+      "script": "D=/tmp/jb_t_test_o_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-O' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "66a7bcb460ad58a3",
+      "name": "test matrix: test -t (fd 0)",
+      "script": "LC_ALL=C LANG=C test '-t' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "33a726e635831976",
+      "name": "test matrix: test -t (fd 1)",
+      "script": "LC_ALL=C LANG=C test '-t' '1'; echo rc=$?"
+    },
+    {
+      "content_hash": "dc1a48835b46b237",
+      "name": "test matrix: test -t (fd 2)",
+      "script": "LC_ALL=C LANG=C test '-t' '2'; echo rc=$?"
+    },
+    {
+      "content_hash": "2348501715bd7b4e",
+      "name": "test matrix: test -t (fd 99)",
+      "script": "LC_ALL=C LANG=C test '-t' '99'; echo rc=$?"
+    },
+    {
+      "content_hash": "8bf0f2c3e87f1fac",
+      "name": "test matrix: test -t (invalid)",
+      "script": "LC_ALL=C LANG=C test '-t' 'invalid'; echo rc=$?"
+    },
+    {
+      "content_hash": "a497f4d8d77bba87",
+      "name": "test matrix: test -t (one-arg)",
+      "script": "LC_ALL=C LANG=C test '-t'; echo rc=$?"
+    },
+    {
+      "content_hash": "9a79af09920b43ff",
+      "name": "test matrix: test -z (empty)",
+      "script": "LC_ALL=C LANG=C test '-z' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "1396ccb69fda3e5c",
+      "name": "test matrix: test -z (hi)",
+      "script": "LC_ALL=C LANG=C test '-z' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "a1226c2b170b748e",
+      "name": "test matrix: test -z (zero)",
+      "script": "LC_ALL=C LANG=C test '-z' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "7f96d62d662963c8",
+      "name": "test matrix: test -z (space)",
+      "script": "LC_ALL=C LANG=C test '-z' ' '; echo rc=$?"
+    },
+    {
+      "content_hash": "41a92afd8450e342",
+      "name": "test matrix: test -n (empty)",
+      "script": "LC_ALL=C LANG=C test '-n' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "8844d6870cb415f4",
+      "name": "test matrix: test -n (hi)",
+      "script": "LC_ALL=C LANG=C test '-n' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "6c4798873e5ca047",
+      "name": "test matrix: test -n (zero)",
+      "script": "LC_ALL=C LANG=C test '-n' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "a4176f9ad68b94a3",
+      "name": "test matrix: test -n (space)",
+      "script": "LC_ALL=C LANG=C test '-n' ' '; echo rc=$?"
+    },
+    {
+      "content_hash": "a473fe750ae4aa02",
+      "name": "test matrix: test one-arg (empty)",
+      "script": "LC_ALL=C LANG=C test ''; echo rc=$?"
+    },
+    {
+      "content_hash": "bce5a5bb0f8a7283",
+      "name": "test matrix: test one-arg (hi)",
+      "script": "LC_ALL=C LANG=C test 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "a54ca5da142ff4a0",
+      "name": "test matrix: test one-arg (zero)",
+      "script": "LC_ALL=C LANG=C test '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "ebafb67ab8adc555",
+      "name": "test matrix: test one-arg (dash)",
+      "script": "LC_ALL=C LANG=C test '-'; echo rc=$?"
+    },
+    {
+      "content_hash": "b9b7dcf75acb0169",
+      "name": "test matrix: test one-arg (equals)",
+      "script": "LC_ALL=C LANG=C test '='; echo rc=$?"
+    },
+    {
+      "content_hash": "f9c5c16f3483d154",
+      "name": "test matrix: test one-arg (bang)",
+      "script": "LC_ALL=C LANG=C test '!'; echo rc=$?"
+    },
+    {
+      "content_hash": "b79b74cb76bd64c8",
+      "name": "test matrix: test = (equal)",
+      "script": "LC_ALL=C LANG=C test 'hi' '=' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "bf454c98cab3643c",
+      "name": "test matrix: test = (unequal)",
+      "script": "LC_ALL=C LANG=C test 'a' '=' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "66b0810d916e7059",
+      "name": "test matrix: test = (empty-empty)",
+      "script": "LC_ALL=C LANG=C test '' '=' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "cc786c25c41c1178",
+      "name": "test matrix: test = (empty-hi)",
+      "script": "LC_ALL=C LANG=C test '' '=' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "ed4634fa4b8e5607",
+      "name": "test matrix: test = (case)",
+      "script": "LC_ALL=C LANG=C test 'A' '=' 'a'; echo rc=$?"
+    },
+    {
+      "content_hash": "ecdc05057a6531bb",
+      "name": "test matrix: test = (digits)",
+      "script": "LC_ALL=C LANG=C test '10' '=' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "31edaaffe83a1373",
+      "name": "test matrix: test == (equal)",
+      "script": "LC_ALL=C LANG=C test 'hi' '==' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "4f859ef6d500af78",
+      "name": "test matrix: test == (unequal)",
+      "script": "LC_ALL=C LANG=C test 'a' '==' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "734ef367925afbdb",
+      "name": "test matrix: test == (empty-empty)",
+      "script": "LC_ALL=C LANG=C test '' '==' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "d0cdc0c179e52d35",
+      "name": "test matrix: test == (empty-hi)",
+      "script": "LC_ALL=C LANG=C test '' '==' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "d00fcee4dfceb288",
+      "name": "test matrix: test == (case)",
+      "script": "LC_ALL=C LANG=C test 'A' '==' 'a'; echo rc=$?"
+    },
+    {
+      "content_hash": "34dd211c4cee0588",
+      "name": "test matrix: test == (digits)",
+      "script": "LC_ALL=C LANG=C test '10' '==' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "bd0dc0afc7a9e274",
+      "name": "test matrix: test != (equal)",
+      "script": "LC_ALL=C LANG=C test 'hi' '!=' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "6a4d0f0afd953ada",
+      "name": "test matrix: test != (unequal)",
+      "script": "LC_ALL=C LANG=C test 'a' '!=' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "a9e0abe1468bcc6c",
+      "name": "test matrix: test != (empty-empty)",
+      "script": "LC_ALL=C LANG=C test '' '!=' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "4487cb365a0c42bf",
+      "name": "test matrix: test != (empty-hi)",
+      "script": "LC_ALL=C LANG=C test '' '!=' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "dcc5a093fba2edcc",
+      "name": "test matrix: test != (case)",
+      "script": "LC_ALL=C LANG=C test 'A' '!=' 'a'; echo rc=$?"
+    },
+    {
+      "content_hash": "033e373093b44bdf",
+      "name": "test matrix: test != (digits)",
+      "script": "LC_ALL=C LANG=C test '10' '!=' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "cea7df8ec581c9b0",
+      "name": "test matrix: test < (equal)",
+      "script": "LC_ALL=C LANG=C test 'hi' '<' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "8767531dae35c22e",
+      "name": "test matrix: test < (unequal)",
+      "script": "LC_ALL=C LANG=C test 'a' '<' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "b0db00462537e3aa",
+      "name": "test matrix: test < (empty-empty)",
+      "script": "LC_ALL=C LANG=C test '' '<' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "92eb39a3559a9fd7",
+      "name": "test matrix: test < (empty-hi)",
+      "script": "LC_ALL=C LANG=C test '' '<' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "a2811b782bc1c336",
+      "name": "test matrix: test < (case)",
+      "script": "LC_ALL=C LANG=C test 'A' '<' 'a'; echo rc=$?"
+    },
+    {
+      "content_hash": "354798295c4fbe6d",
+      "name": "test matrix: test < (digits)",
+      "script": "LC_ALL=C LANG=C test '10' '<' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "56c31c86ab2a47f7",
+      "name": "test matrix: test > (equal)",
+      "script": "LC_ALL=C LANG=C test 'hi' '>' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "9ca78380ac08197c",
+      "name": "test matrix: test > (unequal)",
+      "script": "LC_ALL=C LANG=C test 'a' '>' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "37bf4373f17a7b04",
+      "name": "test matrix: test > (empty-empty)",
+      "script": "LC_ALL=C LANG=C test '' '>' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "f089129339335e99",
+      "name": "test matrix: test > (empty-hi)",
+      "script": "LC_ALL=C LANG=C test '' '>' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "6a69e9dd74d2de41",
+      "name": "test matrix: test > (case)",
+      "script": "LC_ALL=C LANG=C test 'A' '>' 'a'; echo rc=$?"
+    },
+    {
+      "content_hash": "e0d37ffbc7f7af50",
+      "name": "test matrix: test > (digits)",
+      "script": "LC_ALL=C LANG=C test '10' '>' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "6b75058f99110eb0",
+      "name": "test matrix: test -eq (zeros)",
+      "script": "LC_ALL=C LANG=C test '0' '-eq' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "25d248739284d9b1",
+      "name": "test matrix: test -eq (zero-one)",
+      "script": "LC_ALL=C LANG=C test '0' '-eq' '1'; echo rc=$?"
+    },
+    {
+      "content_hash": "10f7207b6f2e86ca",
+      "name": "test matrix: test -eq (neg-zero)",
+      "script": "LC_ALL=C LANG=C test '-1' '-eq' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "02bbb3b470f62aec",
+      "name": "test matrix: test -eq (equal)",
+      "script": "LC_ALL=C LANG=C test '7' '-eq' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "27fd0cc5f010bc44",
+      "name": "test matrix: test -eq (order)",
+      "script": "LC_ALL=C LANG=C test '10' '-eq' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "8b3beb31c421ee98",
+      "name": "test matrix: test -eq (non-numeric)",
+      "opts": {
+        "known_gap": "JustBash test returns 2 on a non-integer with no diagnostic; bash writes to stderr"
+      },
+      "script": "LC_ALL=C LANG=C test 'a' '-eq' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "85522d868279b311",
+      "name": "test matrix: test -eq (octal-looking)",
+      "script": "LC_ALL=C LANG=C test '08' '-eq' '8'; echo rc=$?"
+    },
+    {
+      "content_hash": "7852f233a793511b",
+      "name": "test matrix: test -eq (spaces)",
+      "opts": {
+        "known_gap": "JustBash Integer.parse/1 does not accept the integer spelling bash test accepts"
+      },
+      "script": "LC_ALL=C LANG=C test ' 7' '-eq' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "e9cf9e42e85eb28f",
+      "name": "test matrix: test -ne (zeros)",
+      "script": "LC_ALL=C LANG=C test '0' '-ne' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "a11c99e1e1cbda28",
+      "name": "test matrix: test -ne (zero-one)",
+      "script": "LC_ALL=C LANG=C test '0' '-ne' '1'; echo rc=$?"
+    },
+    {
+      "content_hash": "ba5db5774d6c74fc",
+      "name": "test matrix: test -ne (neg-zero)",
+      "script": "LC_ALL=C LANG=C test '-1' '-ne' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "7f7732060292e2ae",
+      "name": "test matrix: test -ne (equal)",
+      "script": "LC_ALL=C LANG=C test '7' '-ne' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "b49eb7eeb72eb3eb",
+      "name": "test matrix: test -ne (order)",
+      "script": "LC_ALL=C LANG=C test '10' '-ne' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "8fb770aa46bef470",
+      "name": "test matrix: test -ne (non-numeric)",
+      "opts": {
+        "known_gap": "JustBash test returns 2 on a non-integer with no diagnostic; bash writes to stderr"
+      },
+      "script": "LC_ALL=C LANG=C test 'a' '-ne' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "1c4b3f39e9b32fd4",
+      "name": "test matrix: test -ne (octal-looking)",
+      "script": "LC_ALL=C LANG=C test '08' '-ne' '8'; echo rc=$?"
+    },
+    {
+      "content_hash": "b10179055ed7220e",
+      "name": "test matrix: test -ne (spaces)",
+      "opts": {
+        "known_gap": "JustBash Integer.parse/1 does not accept the integer spelling bash test accepts"
+      },
+      "script": "LC_ALL=C LANG=C test ' 7' '-ne' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "59ea09e9f30d03b1",
+      "name": "test matrix: test -lt (zeros)",
+      "script": "LC_ALL=C LANG=C test '0' '-lt' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "45a5c02ba4d93cbc",
+      "name": "test matrix: test -lt (zero-one)",
+      "script": "LC_ALL=C LANG=C test '0' '-lt' '1'; echo rc=$?"
+    },
+    {
+      "content_hash": "28b813975a5d8e40",
+      "name": "test matrix: test -lt (neg-zero)",
+      "script": "LC_ALL=C LANG=C test '-1' '-lt' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "535278650c5463eb",
+      "name": "test matrix: test -lt (equal)",
+      "script": "LC_ALL=C LANG=C test '7' '-lt' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "1bbcc4b480b74fff",
+      "name": "test matrix: test -lt (order)",
+      "script": "LC_ALL=C LANG=C test '10' '-lt' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "f1f22a069844336e",
+      "name": "test matrix: test -lt (non-numeric)",
+      "opts": {
+        "known_gap": "JustBash test returns 2 on a non-integer with no diagnostic; bash writes to stderr"
+      },
+      "script": "LC_ALL=C LANG=C test 'a' '-lt' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "d7530e044096f753",
+      "name": "test matrix: test -lt (octal-looking)",
+      "script": "LC_ALL=C LANG=C test '08' '-lt' '8'; echo rc=$?"
+    },
+    {
+      "content_hash": "7395d1b5945e7862",
+      "name": "test matrix: test -lt (spaces)",
+      "opts": {
+        "known_gap": "JustBash Integer.parse/1 does not accept the integer spelling bash test accepts"
+      },
+      "script": "LC_ALL=C LANG=C test ' 7' '-lt' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "3d8a6d90f43e82c3",
+      "name": "test matrix: test -le (zeros)",
+      "script": "LC_ALL=C LANG=C test '0' '-le' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "06a1dbb49036d389",
+      "name": "test matrix: test -le (zero-one)",
+      "script": "LC_ALL=C LANG=C test '0' '-le' '1'; echo rc=$?"
+    },
+    {
+      "content_hash": "9777036fd531cf9b",
+      "name": "test matrix: test -le (neg-zero)",
+      "script": "LC_ALL=C LANG=C test '-1' '-le' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "09a6dd30928c3309",
+      "name": "test matrix: test -le (equal)",
+      "script": "LC_ALL=C LANG=C test '7' '-le' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "c1dfdce332b27223",
+      "name": "test matrix: test -le (order)",
+      "script": "LC_ALL=C LANG=C test '10' '-le' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "23a61d62b083923c",
+      "name": "test matrix: test -le (non-numeric)",
+      "opts": {
+        "known_gap": "JustBash test returns 2 on a non-integer with no diagnostic; bash writes to stderr"
+      },
+      "script": "LC_ALL=C LANG=C test 'a' '-le' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "6afbf4d839ac3287",
+      "name": "test matrix: test -le (octal-looking)",
+      "script": "LC_ALL=C LANG=C test '08' '-le' '8'; echo rc=$?"
+    },
+    {
+      "content_hash": "3520a5558b2f83d4",
+      "name": "test matrix: test -le (spaces)",
+      "opts": {
+        "known_gap": "JustBash Integer.parse/1 does not accept the integer spelling bash test accepts"
+      },
+      "script": "LC_ALL=C LANG=C test ' 7' '-le' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "f50e74b47431fa48",
+      "name": "test matrix: test -gt (zeros)",
+      "script": "LC_ALL=C LANG=C test '0' '-gt' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "cf0112f1e9e40cb6",
+      "name": "test matrix: test -gt (zero-one)",
+      "script": "LC_ALL=C LANG=C test '0' '-gt' '1'; echo rc=$?"
+    },
+    {
+      "content_hash": "6e66e42a31fa8891",
+      "name": "test matrix: test -gt (neg-zero)",
+      "script": "LC_ALL=C LANG=C test '-1' '-gt' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "88740e594abd0515",
+      "name": "test matrix: test -gt (equal)",
+      "script": "LC_ALL=C LANG=C test '7' '-gt' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "c335297af187312b",
+      "name": "test matrix: test -gt (order)",
+      "script": "LC_ALL=C LANG=C test '10' '-gt' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "1e5c0cb110cc361d",
+      "name": "test matrix: test -gt (non-numeric)",
+      "opts": {
+        "known_gap": "JustBash test returns 2 on a non-integer with no diagnostic; bash writes to stderr"
+      },
+      "script": "LC_ALL=C LANG=C test 'a' '-gt' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "ef06671244d9e076",
+      "name": "test matrix: test -gt (octal-looking)",
+      "script": "LC_ALL=C LANG=C test '08' '-gt' '8'; echo rc=$?"
+    },
+    {
+      "content_hash": "204ed0e71bc9efb4",
+      "name": "test matrix: test -gt (spaces)",
+      "opts": {
+        "known_gap": "JustBash Integer.parse/1 does not accept the integer spelling bash test accepts"
+      },
+      "script": "LC_ALL=C LANG=C test ' 7' '-gt' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "7811289a93c0701e",
+      "name": "test matrix: test -ge (zeros)",
+      "script": "LC_ALL=C LANG=C test '0' '-ge' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "f8e418986b6f3d5e",
+      "name": "test matrix: test -ge (zero-one)",
+      "script": "LC_ALL=C LANG=C test '0' '-ge' '1'; echo rc=$?"
+    },
+    {
+      "content_hash": "87813b8cc2908064",
+      "name": "test matrix: test -ge (neg-zero)",
+      "script": "LC_ALL=C LANG=C test '-1' '-ge' '0'; echo rc=$?"
+    },
+    {
+      "content_hash": "30468d5afd89caf1",
+      "name": "test matrix: test -ge (equal)",
+      "script": "LC_ALL=C LANG=C test '7' '-ge' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "d498be91882a6814",
+      "name": "test matrix: test -ge (order)",
+      "script": "LC_ALL=C LANG=C test '10' '-ge' '9'; echo rc=$?"
+    },
+    {
+      "content_hash": "120e2a5c09082687",
+      "name": "test matrix: test -ge (non-numeric)",
+      "opts": {
+        "known_gap": "JustBash test returns 2 on a non-integer with no diagnostic; bash writes to stderr"
+      },
+      "script": "LC_ALL=C LANG=C test 'a' '-ge' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "1aac190d0ba4490e",
+      "name": "test matrix: test -ge (octal-looking)",
+      "script": "LC_ALL=C LANG=C test '08' '-ge' '8'; echo rc=$?"
+    },
+    {
+      "content_hash": "c943b8489f11c6b7",
+      "name": "test matrix: test -ge (spaces)",
+      "opts": {
+        "known_gap": "JustBash Integer.parse/1 does not accept the integer spelling bash test accepts"
+      },
+      "script": "LC_ALL=C LANG=C test ' 7' '-ge' '7'; echo rc=$?"
+    },
+    {
+      "content_hash": "f12484cbfdf8bf16",
+      "name": "test matrix: test -nt (older-newer)",
+      "script": "D=/tmp/jb_t_test_nt_older_newer; mkdir -p \"$D\"; touch -d '2017-12-31' \"$D/old\" 2>/dev/null; touch -d '2018-01-01' \"$D/new\" 2>/dev/null; LC_ALL=C LANG=C test \"$D/old\" '-nt' \"$D/new\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8f118226f4a3359e",
+      "name": "test matrix: test -nt (newer-older)",
+      "opts": {
+        "known_gap": "JustBash test does not implement -nt/-ot/-ef; bash compares mtimes or identity"
+      },
+      "script": "D=/tmp/jb_t_test_nt_newer_older; mkdir -p \"$D\"; touch -d '2017-12-31' \"$D/old\" 2>/dev/null; touch -d '2018-01-01' \"$D/new\" 2>/dev/null; LC_ALL=C LANG=C test \"$D/new\" '-nt' \"$D/old\"; echo rc=$?"
+    },
+    {
+      "content_hash": "71e95becd96d63c4",
+      "name": "test matrix: test -ot (older-newer)",
+      "opts": {
+        "known_gap": "JustBash test does not implement -nt/-ot/-ef; bash compares mtimes or identity"
+      },
+      "script": "D=/tmp/jb_t_test_ot_older_newer; mkdir -p \"$D\"; touch -d '2017-12-31' \"$D/old\" 2>/dev/null; touch -d '2018-01-01' \"$D/new\" 2>/dev/null; LC_ALL=C LANG=C test \"$D/old\" '-ot' \"$D/new\"; echo rc=$?"
+    },
+    {
+      "content_hash": "62bff842ddff00ac",
+      "name": "test matrix: test -ot (newer-older)",
+      "script": "D=/tmp/jb_t_test_ot_newer_older; mkdir -p \"$D\"; touch -d '2017-12-31' \"$D/old\" 2>/dev/null; touch -d '2018-01-01' \"$D/new\" 2>/dev/null; LC_ALL=C LANG=C test \"$D/new\" '-ot' \"$D/old\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3008ae480eb81203",
+      "name": "test matrix: test -nt (same)",
+      "script": "D=/tmp/jb_t_test_nt_same; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test \"$D/file\" '-nt' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f433d27bccfbed6b",
+      "name": "test matrix: test -ot (same)",
+      "script": "D=/tmp/jb_t_test_ot_same; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test \"$D/file\" '-ot' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "480c9381b4910910",
+      "name": "test matrix: test -ef (same-path)",
+      "opts": {
+        "known_gap": "JustBash test does not implement -nt/-ot/-ef; bash compares mtimes or identity"
+      },
+      "script": "D=/tmp/jb_t_test_ef_same_path; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test \"$D/file\" '-ef' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f3235e2c1acbaa88",
+      "name": "test matrix: test -ef (hardlink)",
+      "opts": {
+        "known_gap": "JustBash test does not implement -nt/-ot/-ef; bash compares mtimes or identity"
+      },
+      "script": "D=/tmp/jb_t_test_ef_hardlink; mkdir -p \"$D\"; printf 'x\\n' > \"$D/f\"; ln \"$D/f\" \"$D/hard\"; LC_ALL=C LANG=C test \"$D/f\" '-ef' \"$D/hard\"; echo rc=$?"
+    },
+    {
+      "content_hash": "7e48922d89883a22",
+      "name": "test matrix: test -ef (distinct)",
+      "script": "D=/tmp/jb_t_test_ef_distinct; mkdir -p \"$D\"; printf 'a\\n' > \"$D/a\"; printf 'b\\n' > \"$D/b\"; LC_ALL=C LANG=C test \"$D/a\" '-ef' \"$D/b\"; echo rc=$?"
+    },
+    {
+      "content_hash": "de199b3bf6860b69",
+      "name": "test matrix: test -nt (missing-file)",
+      "script": "D=/tmp/jb_t_test_nt_missing_file; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test \"$D/missing\" '-nt' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "30d7e900afb4c4b6",
+      "name": "test matrix: test -ef (missing-file)",
+      "script": "D=/tmp/jb_t_test_ef_missing_file; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test \"$D/missing\" '-ef' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "63102ce2541ee48f",
+      "name": "test matrix: test -a (hi-hi)",
+      "script": "LC_ALL=C LANG=C test 'hi' '-a' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "75f27272d3952964",
+      "name": "test matrix: test -a (hi-empty)",
+      "script": "LC_ALL=C LANG=C test 'hi' '-a' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "7b3045183f2ef8b7",
+      "name": "test matrix: test -o (empty-hi)",
+      "script": "LC_ALL=C LANG=C test '' '-o' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "679597fb11c55346",
+      "name": "test matrix: test -o (empty-empty)",
+      "script": "LC_ALL=C LANG=C test '' '-o' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "433027aeec703bcc",
+      "name": "test matrix: test unary -a (regular)",
+      "opts": {
+        "known_gap": "JustBash does not implement unary -a as a synonym of -e"
+      },
+      "script": "D=/tmp/jb_t_test_unary_a_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '-a' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "b5f40d280255c8a2",
+      "name": "test matrix: test unary -a (missing)",
+      "script": "D=/tmp/jb_t_test_unary_a_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '-a' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "5661b3650bb001be",
+      "name": "test matrix: test -a (file-and-dir)",
+      "opts": {
+        "known_gap": "JustBash test does not implement 4+ argument -a/-o as expression AND/OR"
+      },
+      "script": "D=/tmp/jb_t_test_a_file_and_dir; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-f' \"$D/file\" '-a' '-d' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "cba161c19e141df6",
+      "name": "test matrix: test -a (missing-and-dir)",
+      "script": "D=/tmp/jb_t_test_a_missing_and_dir; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C test '-f' \"$D/missing\" '-a' '-d' \"$D/dir\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e1b86612f800eea2",
+      "name": "test matrix: test ! (empty)",
+      "script": "LC_ALL=C LANG=C test '!' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "368028dc443b6567",
+      "name": "test matrix: test ! (hi)",
+      "script": "LC_ALL=C LANG=C test '!' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "71f41916c36935f0",
+      "name": "test matrix: test ! -z (empty)",
+      "script": "LC_ALL=C LANG=C test '!' '-z' ''; echo rc=$?"
+    },
+    {
+      "content_hash": "f29330e77eccdee8",
+      "name": "test matrix: test ! -z (hi)",
+      "script": "LC_ALL=C LANG=C test '!' '-z' 'hi'; echo rc=$?"
+    },
+    {
+      "content_hash": "55317aa4d180f910",
+      "name": "test matrix: test ! -f (missing)",
+      "script": "D=/tmp/jb_t_test_f_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C test '!' '-f' \"$D/missing\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4e9bfdec87413da9",
+      "name": "test matrix: test ! -f (regular)",
+      "script": "D=/tmp/jb_t_test_f_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C test '!' '-f' \"$D/file\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0220acd80b0f689d",
+      "name": "test matrix: test ! = (equal)",
+      "script": "LC_ALL=C LANG=C test '!' 'a' '=' 'a'; echo rc=$?"
+    },
+    {
+      "content_hash": "c50b71e34c0c5dcf",
+      "name": "test matrix: test ! = (unequal)",
+      "script": "LC_ALL=C LANG=C test '!' 'a' '=' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "9a4094534ddf0e08",
+      "name": "test matrix: test group (hi)",
+      "opts": {
+        "known_gap": "JustBash test does not implement ( ) grouping"
+      },
+      "script": "LC_ALL=C LANG=C test '(' 'hi' ')'; echo rc=$?"
+    },
+    {
+      "content_hash": "d342a487e25226fc",
+      "name": "test matrix: test group (-z empty)",
+      "opts": {
+        "known_gap": "JustBash test does not implement ( ) grouping"
+      },
+      "script": "LC_ALL=C LANG=C test '(' '-z' '' ')'; echo rc=$?"
+    },
+    {
+      "content_hash": "9d1a7b7684d6a092",
+      "name": "test matrix: test group (= equal)",
+      "opts": {
+        "known_gap": "JustBash test does not implement ( ) grouping"
+      },
+      "script": "LC_ALL=C LANG=C test '(' 'a' '=' 'a' ')'; echo rc=$?"
+    },
+    {
+      "content_hash": "4d004c777376c270",
+      "name": "test matrix: test no-args",
+      "script": "LC_ALL=C LANG=C test; echo rc=$?"
+    },
+    {
+      "content_hash": "1634d0464bc61996",
+      "name": "test matrix: test extra-args",
+      "opts": {
+        "known_gap": "JustBash test returns 1 for extra or unparsed arguments; bash exits 2 and diagnoses"
+      },
+      "script": "LC_ALL=C LANG=C test '-n' 'x' 'y'; echo rc=$?"
+    },
+    {
+      "content_hash": "3af9fd005020d893",
+      "name": "test matrix: test unknown unary",
+      "opts": {
+        "known_gap": "JustBash test returns 1 for an unknown operator; bash exits 2 and diagnoses"
+      },
+      "script": "LC_ALL=C LANG=C test '-Z' 'x'; echo rc=$?"
+    },
+    {
+      "content_hash": "99aed5d20f2d38c2",
+      "name": "test matrix: test unknown binary",
+      "opts": {
+        "known_gap": "JustBash test returns 1 for an unknown operator; bash exits 2 and diagnoses"
+      },
+      "script": "LC_ALL=C LANG=C test 'a' '-xx' 'b'; echo rc=$?"
+    },
+    {
+      "content_hash": "7b0552e916548d84",
+      "name": "test matrix: test too-many",
+      "opts": {
+        "known_gap": "JustBash test returns 1 for extra or unparsed arguments; bash exits 2 and diagnoses"
+      },
+      "script": "LC_ALL=C LANG=C test 'a' '=' 'a' '=' 'a'; echo rc=$?"
+    },
+    {
+      "content_hash": "26c481b04cb90446",
+      "name": "test matrix: [ no-args",
+      "opts": {
+        "known_gap": "JustBash [ without a closing ] still evaluates the expression; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C [; echo rc=$?"
+    },
+    {
+      "content_hash": "6dec3178774b0bd7",
+      "name": "test matrix: [ empty",
+      "script": "LC_ALL=C LANG=C [ ]; echo rc=$?"
+    },
+    {
+      "content_hash": "7f383c06e09bd8d4",
+      "name": "test matrix: [ missing-closer",
+      "opts": {
+        "known_gap": "JustBash [ without a closing ] still evaluates the expression; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C [ -n x; echo rc=$?"
+    },
+    {
+      "content_hash": "086fc4eda65a8e6b",
+      "name": "test matrix: [ extra-after-closer",
+      "opts": {
+        "known_gap": "JustBash [ without a closing ] still evaluates the expression; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C [ -n x ] y; echo rc=$?"
+    },
+    {
+      "content_hash": "97f547bd455048d6",
+      "name": "test matrix: [ -e (regular)",
+      "script": "D=/tmp/jb_t_br_e_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C [ '-e' \"$D/file\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "cb96ee7daef0e1be",
+      "name": "test matrix: [ -e (missing)",
+      "script": "D=/tmp/jb_t_br_e_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C [ '-e' \"$D/missing\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "5cff075a2bccd5e7",
+      "name": "test matrix: [ -e (dangling)",
+      "script": "D=/tmp/jb_t_br_e_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C [ '-e' \"$D/dang\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "4a51fa0b080318f9",
+      "name": "test matrix: [ -f (regular)",
+      "script": "D=/tmp/jb_t_br_f_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C [ '-f' \"$D/file\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "169373d486c8f1bb",
+      "name": "test matrix: [ -f (directory)",
+      "script": "D=/tmp/jb_t_br_f_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C [ '-f' \"$D/dir\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "83b00f8e4314a799",
+      "name": "test matrix: [ -f (missing)",
+      "script": "D=/tmp/jb_t_br_f_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C [ '-f' \"$D/missing\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "aac02e5a015d4d1a",
+      "name": "test matrix: [ -d (directory)",
+      "script": "D=/tmp/jb_t_br_d_directory; mkdir -p \"$D\"; mkdir -p \"$D/dir\"; LC_ALL=C LANG=C [ '-d' \"$D/dir\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "de1dada540df812e",
+      "name": "test matrix: [ -d (regular)",
+      "script": "D=/tmp/jb_t_br_d_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C [ '-d' \"$D/file\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "622c6b2820de64ac",
+      "name": "test matrix: [ -d (missing)",
+      "script": "D=/tmp/jb_t_br_d_missing; mkdir -p \"$D\"; :; LC_ALL=C LANG=C [ '-d' \"$D/missing\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "69a32be73117a70e",
+      "name": "test matrix: [ -L (symlink)",
+      "script": "D=/tmp/jb_t_br_l_symlink; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/target\"; ln -s \"$D/target\" \"$D/link\"; LC_ALL=C LANG=C [ '-L' \"$D/link\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "58dfa70b230d0cca",
+      "name": "test matrix: [ -L (regular)",
+      "script": "D=/tmp/jb_t_br_l_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C [ '-L' \"$D/file\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "b03e3b9ef8c56e9d",
+      "name": "test matrix: [ -s (empty)",
+      "script": "D=/tmp/jb_t_br_s_empty; mkdir -p \"$D\"; printf '' > \"$D/empty\"; LC_ALL=C LANG=C [ '-s' \"$D/empty\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "b5c8c9ee21e2ed27",
+      "name": "test matrix: [ -s (regular)",
+      "script": "D=/tmp/jb_t_br_s_regular; mkdir -p \"$D\"; printf 'hello\\n' > \"$D/file\"; LC_ALL=C LANG=C [ '-s' \"$D/file\" ]; echo rc=$?"
+    },
+    {
+      "content_hash": "624d79ea24a3ee27",
+      "name": "test matrix: [ -z (empty)",
+      "script": "LC_ALL=C LANG=C [ '-z' '' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "b7ea1deaf9d970df",
+      "name": "test matrix: [ -n (hi)",
+      "script": "LC_ALL=C LANG=C [ '-n' 'hi' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "e195945a4213a1b5",
+      "name": "test matrix: [ one-arg (empty)",
+      "script": "LC_ALL=C LANG=C [ '' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "49d40598087baa4e",
+      "name": "test matrix: [ one-arg (hi)",
+      "script": "LC_ALL=C LANG=C [ 'hi' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "c2b0444d5f07b307",
+      "name": "test matrix: [ = (equal)",
+      "script": "LC_ALL=C LANG=C [ 'hi' '=' 'hi' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "ca8fa324c0c415ff",
+      "name": "test matrix: [ != (unequal)",
+      "script": "LC_ALL=C LANG=C [ 'a' '!=' 'b' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "be6d629b0aeb2edb",
+      "name": "test matrix: [ -eq (zeros)",
+      "script": "LC_ALL=C LANG=C [ '0' '-eq' '0' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "a8c01eead13c86cb",
+      "name": "test matrix: [ -lt (order)",
+      "script": "LC_ALL=C LANG=C [ '10' '-lt' '9' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "e663499301c04c6f",
+      "name": "test matrix: [ ! -z (empty)",
+      "script": "LC_ALL=C LANG=C [ '!' '-z' '' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "bb715cce0ab11d4d",
+      "name": "test matrix: [ -a (hi-hi)",
+      "script": "LC_ALL=C LANG=C [ 'hi' '-a' 'hi' ]; echo rc=$?"
+    },
+    {
+      "content_hash": "b193019fa298f159",
+      "name": "test matrix: [ -L (dangling)",
+      "script": "D=/tmp/jb_t_br_l_dangling; mkdir -p \"$D\"; ln -s \"$D/nope\" \"$D/dang\"; LC_ALL=C LANG=C [ '-L' \"$D/dang\" ]; echo rc=$?"
+    }
+  ],
+  "suite": "test_matrix"
+}

--- a/test/fixtures/bash_expected/test_matrix.json
+++ b/test/fixtures/bash_expected/test_matrix.json
@@ -1,0 +1,1734 @@
+{
+  "results": [
+    {
+      "content_hash": "11b3421a848e08ac",
+      "exit_code": 0,
+      "name": "test matrix: test -e (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "92a5581a31ec6563",
+      "exit_code": 0,
+      "name": "test matrix: test -e (empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ad6839828947579b",
+      "exit_code": 0,
+      "name": "test matrix: test -e (directory)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ede2309f2d5fc45e",
+      "exit_code": 0,
+      "name": "test matrix: test -e (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a5b476bfd49b8b57",
+      "exit_code": 0,
+      "name": "test matrix: test -e (symlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e55e8d8bb441cbf3",
+      "exit_code": 0,
+      "name": "test matrix: test -e (dangling)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "200f9211d9cdd434",
+      "exit_code": 0,
+      "name": "test matrix: test -f (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "63e15459fc383322",
+      "exit_code": 0,
+      "name": "test matrix: test -f (empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "9b25dd243254a423",
+      "exit_code": 0,
+      "name": "test matrix: test -f (directory)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e398c0c75ea0a5f9",
+      "exit_code": 0,
+      "name": "test matrix: test -f (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "eac31d30ae2917f9",
+      "exit_code": 0,
+      "name": "test matrix: test -f (symlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "aeab59ce19bc2ab5",
+      "exit_code": 0,
+      "name": "test matrix: test -f (dangling)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "621c87a9c114ac37",
+      "exit_code": 0,
+      "name": "test matrix: test -d (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "0f0a1c11700ece26",
+      "exit_code": 0,
+      "name": "test matrix: test -d (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "73a33ebd32c3550f",
+      "exit_code": 0,
+      "name": "test matrix: test -d (directory)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "8a3e3460bae2bee9",
+      "exit_code": 0,
+      "name": "test matrix: test -d (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a0d1a87538cee38f",
+      "exit_code": 0,
+      "name": "test matrix: test -d (symlink)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "9330e1957c7ccb3e",
+      "exit_code": 0,
+      "name": "test matrix: test -d (dangling)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "88858fd6ebc9d266",
+      "exit_code": 0,
+      "name": "test matrix: test -L (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e0ef011968eeaa11",
+      "exit_code": 0,
+      "name": "test matrix: test -L (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "282140d314c6538b",
+      "exit_code": 0,
+      "name": "test matrix: test -L (directory)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "d72f603cf1a79968",
+      "exit_code": 0,
+      "name": "test matrix: test -L (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "fa528da0ece73545",
+      "exit_code": 0,
+      "name": "test matrix: test -L (symlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "40bbbe6b44fe5d63",
+      "exit_code": 0,
+      "name": "test matrix: test -L (dangling)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ab073038ea1daad9",
+      "exit_code": 0,
+      "name": "test matrix: test -h (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b0d4b541177011e5",
+      "exit_code": 0,
+      "name": "test matrix: test -h (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "495d902920d8535b",
+      "exit_code": 0,
+      "name": "test matrix: test -h (directory)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a19f009eee763ba1",
+      "exit_code": 0,
+      "name": "test matrix: test -h (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "2d2e53000e0101b7",
+      "exit_code": 0,
+      "name": "test matrix: test -h (symlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "8b361d78f30701f3",
+      "exit_code": 0,
+      "name": "test matrix: test -h (dangling)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "11deac7055abf6f4",
+      "exit_code": 0,
+      "name": "test matrix: test -s (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "410f86b5835dbe31",
+      "exit_code": 0,
+      "name": "test matrix: test -s (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "bf0a34c272e2b1f9",
+      "exit_code": 0,
+      "name": "test matrix: test -s (directory)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "abd9702e8c878b6f",
+      "exit_code": 0,
+      "name": "test matrix: test -s (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "acfc164595f70781",
+      "exit_code": 0,
+      "name": "test matrix: test -s (symlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "7056c81bc5f5acd8",
+      "exit_code": 0,
+      "name": "test matrix: test -s (dangling)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "23b68438875dd537",
+      "exit_code": 0,
+      "name": "test matrix: test -r (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "3d3f1883a0907fa5",
+      "exit_code": 0,
+      "name": "test matrix: test -r (empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "9e718d38952a0195",
+      "exit_code": 0,
+      "name": "test matrix: test -r (directory)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "cdd5d646379170c3",
+      "exit_code": 0,
+      "name": "test matrix: test -r (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "177204c1b437be16",
+      "exit_code": 0,
+      "name": "test matrix: test -r (symlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "31762eb80293eec2",
+      "exit_code": 0,
+      "name": "test matrix: test -r (dangling)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "fed7156d7e5a16fc",
+      "exit_code": 0,
+      "name": "test matrix: test -w (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "71ac6a9ba114dfef",
+      "exit_code": 0,
+      "name": "test matrix: test -w (empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "45cf496d750ee74d",
+      "exit_code": 0,
+      "name": "test matrix: test -w (directory)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "0e8a9e4353b22073",
+      "exit_code": 0,
+      "name": "test matrix: test -w (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "650d110a272278ed",
+      "exit_code": 0,
+      "name": "test matrix: test -w (symlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ce33e9e15343d34f",
+      "exit_code": 0,
+      "name": "test matrix: test -w (dangling)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "838dae058ef8faa4",
+      "exit_code": 0,
+      "name": "test matrix: test -x (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "ec8330383441a979",
+      "exit_code": 0,
+      "name": "test matrix: test -x (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "364dd47d82c8c94b",
+      "exit_code": 0,
+      "name": "test matrix: test -x (directory)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f507fb6d6f41f162",
+      "exit_code": 0,
+      "name": "test matrix: test -x (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "aba04df94af81416",
+      "exit_code": 0,
+      "name": "test matrix: test -x (symlink)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "5beefe2a9d3262f5",
+      "exit_code": 0,
+      "name": "test matrix: test -x (dangling)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e51e8152f985100c",
+      "exit_code": 0,
+      "name": "test matrix: test -x (executable)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "2c921fbb38c035f2",
+      "exit_code": 0,
+      "name": "test matrix: test -r (unreadable)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "56a3c534d6ec69c9",
+      "exit_code": 0,
+      "name": "test matrix: test -w (unreadable)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b97853606a19ee14",
+      "exit_code": 0,
+      "name": "test matrix: test -x (unreadable)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "cbe7e1106e55c694",
+      "exit_code": 0,
+      "name": "test matrix: test -e (enotdir)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6dcf0122666f68e5",
+      "exit_code": 0,
+      "name": "test matrix: test -d (trailing-slash dir)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "93233f733c518628",
+      "exit_code": 0,
+      "name": "test matrix: test -f (trailing-slash file)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "bf0a34c272e2b1f9",
+      "exit_code": 0,
+      "name": "test matrix: test -s (directory)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e189ff7b668fe41c",
+      "exit_code": 0,
+      "name": "test matrix: test -e (/dev/null)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b8bea7ca6b34090c",
+      "exit_code": 0,
+      "name": "test matrix: test -f (/dev/null)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "dabb9258afcdcf48",
+      "exit_code": 0,
+      "name": "test matrix: test -c (/dev/null)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "5cb615164044977b",
+      "exit_code": 0,
+      "name": "test matrix: test -s (/dev/null)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "eb8f9220be60ae26",
+      "exit_code": 0,
+      "name": "test matrix: test -b (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "81a339f342aac124",
+      "exit_code": 0,
+      "name": "test matrix: test -b (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "506bb46b925e5140",
+      "exit_code": 0,
+      "name": "test matrix: test -c (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "0b5a5dce9dbaac05",
+      "exit_code": 0,
+      "name": "test matrix: test -c (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "fc7a473b867eeca7",
+      "exit_code": 0,
+      "name": "test matrix: test -p (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "deb43c5cad4571f0",
+      "exit_code": 0,
+      "name": "test matrix: test -p (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a84760081cdc3dfb",
+      "exit_code": 0,
+      "name": "test matrix: test -S (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "21cbf3316aff1cee",
+      "exit_code": 0,
+      "name": "test matrix: test -S (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "2f758b315ef82a82",
+      "exit_code": 0,
+      "name": "test matrix: test -p (fifo)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "8c46ed8a15e74b02",
+      "exit_code": 0,
+      "name": "test matrix: test -u (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "fd6cb415f46e1db5",
+      "exit_code": 0,
+      "name": "test matrix: test -g (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6ea5112d495ee93c",
+      "exit_code": 0,
+      "name": "test matrix: test -k (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "0b824b2da8d97f72",
+      "exit_code": 0,
+      "name": "test matrix: test -G (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "4e9bfa3379ce6167",
+      "exit_code": 0,
+      "name": "test matrix: test -O (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "6e6e4dea80432259",
+      "exit_code": 0,
+      "name": "test matrix: test -N (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "63525aca7f521a01",
+      "exit_code": 0,
+      "name": "test matrix: test -u (setuid)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "dacacc90641e41ae",
+      "exit_code": 0,
+      "name": "test matrix: test -g (setgid)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f86bf8ccee64d42a",
+      "exit_code": 0,
+      "name": "test matrix: test -k (sticky)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "693a04e5b4517ea2",
+      "exit_code": 0,
+      "name": "test matrix: test -u (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c47215d20ed96224",
+      "exit_code": 0,
+      "name": "test matrix: test -O (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "66a7bcb460ad58a3",
+      "exit_code": 0,
+      "name": "test matrix: test -t (fd 0)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "33a726e635831976",
+      "exit_code": 0,
+      "name": "test matrix: test -t (fd 1)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "dc1a48835b46b237",
+      "exit_code": 0,
+      "name": "test matrix: test -t (fd 2)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "2348501715bd7b4e",
+      "exit_code": 0,
+      "name": "test matrix: test -t (fd 99)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8bf0f2c3e87f1fac",
+      "exit_code": 0,
+      "name": "test matrix: test -t (invalid)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a497f4d8d77bba87",
+      "exit_code": 0,
+      "name": "test matrix: test -t (one-arg)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "9a79af09920b43ff",
+      "exit_code": 0,
+      "name": "test matrix: test -z (empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "1396ccb69fda3e5c",
+      "exit_code": 0,
+      "name": "test matrix: test -z (hi)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a1226c2b170b748e",
+      "exit_code": 0,
+      "name": "test matrix: test -z (zero)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "7f96d62d662963c8",
+      "exit_code": 0,
+      "name": "test matrix: test -z (space)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "41a92afd8450e342",
+      "exit_code": 0,
+      "name": "test matrix: test -n (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8844d6870cb415f4",
+      "exit_code": 0,
+      "name": "test matrix: test -n (hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "6c4798873e5ca047",
+      "exit_code": 0,
+      "name": "test matrix: test -n (zero)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a4176f9ad68b94a3",
+      "exit_code": 0,
+      "name": "test matrix: test -n (space)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a473fe750ae4aa02",
+      "exit_code": 0,
+      "name": "test matrix: test one-arg (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "bce5a5bb0f8a7283",
+      "exit_code": 0,
+      "name": "test matrix: test one-arg (hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a54ca5da142ff4a0",
+      "exit_code": 0,
+      "name": "test matrix: test one-arg (zero)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ebafb67ab8adc555",
+      "exit_code": 0,
+      "name": "test matrix: test one-arg (dash)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b9b7dcf75acb0169",
+      "exit_code": 0,
+      "name": "test matrix: test one-arg (equals)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f9c5c16f3483d154",
+      "exit_code": 0,
+      "name": "test matrix: test one-arg (bang)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b79b74cb76bd64c8",
+      "exit_code": 0,
+      "name": "test matrix: test = (equal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "bf454c98cab3643c",
+      "exit_code": 0,
+      "name": "test matrix: test = (unequal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "66b0810d916e7059",
+      "exit_code": 0,
+      "name": "test matrix: test = (empty-empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "cc786c25c41c1178",
+      "exit_code": 0,
+      "name": "test matrix: test = (empty-hi)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "ed4634fa4b8e5607",
+      "exit_code": 0,
+      "name": "test matrix: test = (case)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "ecdc05057a6531bb",
+      "exit_code": 0,
+      "name": "test matrix: test = (digits)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "31edaaffe83a1373",
+      "exit_code": 0,
+      "name": "test matrix: test == (equal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "4f859ef6d500af78",
+      "exit_code": 0,
+      "name": "test matrix: test == (unequal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "734ef367925afbdb",
+      "exit_code": 0,
+      "name": "test matrix: test == (empty-empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "d0cdc0c179e52d35",
+      "exit_code": 0,
+      "name": "test matrix: test == (empty-hi)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "d00fcee4dfceb288",
+      "exit_code": 0,
+      "name": "test matrix: test == (case)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "34dd211c4cee0588",
+      "exit_code": 0,
+      "name": "test matrix: test == (digits)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "bd0dc0afc7a9e274",
+      "exit_code": 0,
+      "name": "test matrix: test != (equal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6a4d0f0afd953ada",
+      "exit_code": 0,
+      "name": "test matrix: test != (unequal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a9e0abe1468bcc6c",
+      "exit_code": 0,
+      "name": "test matrix: test != (empty-empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "4487cb365a0c42bf",
+      "exit_code": 0,
+      "name": "test matrix: test != (empty-hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "dcc5a093fba2edcc",
+      "exit_code": 0,
+      "name": "test matrix: test != (case)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "033e373093b44bdf",
+      "exit_code": 0,
+      "name": "test matrix: test != (digits)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "cea7df8ec581c9b0",
+      "exit_code": 0,
+      "name": "test matrix: test < (equal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8767531dae35c22e",
+      "exit_code": 0,
+      "name": "test matrix: test < (unequal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b0db00462537e3aa",
+      "exit_code": 0,
+      "name": "test matrix: test < (empty-empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "92eb39a3559a9fd7",
+      "exit_code": 0,
+      "name": "test matrix: test < (empty-hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a2811b782bc1c336",
+      "exit_code": 0,
+      "name": "test matrix: test < (case)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "354798295c4fbe6d",
+      "exit_code": 0,
+      "name": "test matrix: test < (digits)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "56c31c86ab2a47f7",
+      "exit_code": 0,
+      "name": "test matrix: test > (equal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "9ca78380ac08197c",
+      "exit_code": 0,
+      "name": "test matrix: test > (unequal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "37bf4373f17a7b04",
+      "exit_code": 0,
+      "name": "test matrix: test > (empty-empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f089129339335e99",
+      "exit_code": 0,
+      "name": "test matrix: test > (empty-hi)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6a69e9dd74d2de41",
+      "exit_code": 0,
+      "name": "test matrix: test > (case)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e0d37ffbc7f7af50",
+      "exit_code": 0,
+      "name": "test matrix: test > (digits)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6b75058f99110eb0",
+      "exit_code": 0,
+      "name": "test matrix: test -eq (zeros)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "25d248739284d9b1",
+      "exit_code": 0,
+      "name": "test matrix: test -eq (zero-one)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "10f7207b6f2e86ca",
+      "exit_code": 0,
+      "name": "test matrix: test -eq (neg-zero)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "02bbb3b470f62aec",
+      "exit_code": 0,
+      "name": "test matrix: test -eq (equal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "27fd0cc5f010bc44",
+      "exit_code": 0,
+      "name": "test matrix: test -eq (order)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8b3beb31c421ee98",
+      "exit_code": 0,
+      "name": "test matrix: test -eq (non-numeric)",
+      "stderr": "bash: line 1: test: a: integer expression expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "85522d868279b311",
+      "exit_code": 0,
+      "name": "test matrix: test -eq (octal-looking)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "7852f233a793511b",
+      "exit_code": 0,
+      "name": "test matrix: test -eq (spaces)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e9cf9e42e85eb28f",
+      "exit_code": 0,
+      "name": "test matrix: test -ne (zeros)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a11c99e1e1cbda28",
+      "exit_code": 0,
+      "name": "test matrix: test -ne (zero-one)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ba5db5774d6c74fc",
+      "exit_code": 0,
+      "name": "test matrix: test -ne (neg-zero)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "7f7732060292e2ae",
+      "exit_code": 0,
+      "name": "test matrix: test -ne (equal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b49eb7eeb72eb3eb",
+      "exit_code": 0,
+      "name": "test matrix: test -ne (order)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "8fb770aa46bef470",
+      "exit_code": 0,
+      "name": "test matrix: test -ne (non-numeric)",
+      "stderr": "bash: line 1: test: a: integer expression expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "1c4b3f39e9b32fd4",
+      "exit_code": 0,
+      "name": "test matrix: test -ne (octal-looking)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b10179055ed7220e",
+      "exit_code": 0,
+      "name": "test matrix: test -ne (spaces)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "59ea09e9f30d03b1",
+      "exit_code": 0,
+      "name": "test matrix: test -lt (zeros)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "45a5c02ba4d93cbc",
+      "exit_code": 0,
+      "name": "test matrix: test -lt (zero-one)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "28b813975a5d8e40",
+      "exit_code": 0,
+      "name": "test matrix: test -lt (neg-zero)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "535278650c5463eb",
+      "exit_code": 0,
+      "name": "test matrix: test -lt (equal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "1bbcc4b480b74fff",
+      "exit_code": 0,
+      "name": "test matrix: test -lt (order)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f1f22a069844336e",
+      "exit_code": 0,
+      "name": "test matrix: test -lt (non-numeric)",
+      "stderr": "bash: line 1: test: a: integer expression expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "d7530e044096f753",
+      "exit_code": 0,
+      "name": "test matrix: test -lt (octal-looking)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "7395d1b5945e7862",
+      "exit_code": 0,
+      "name": "test matrix: test -lt (spaces)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "3d8a6d90f43e82c3",
+      "exit_code": 0,
+      "name": "test matrix: test -le (zeros)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "06a1dbb49036d389",
+      "exit_code": 0,
+      "name": "test matrix: test -le (zero-one)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "9777036fd531cf9b",
+      "exit_code": 0,
+      "name": "test matrix: test -le (neg-zero)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "09a6dd30928c3309",
+      "exit_code": 0,
+      "name": "test matrix: test -le (equal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "c1dfdce332b27223",
+      "exit_code": 0,
+      "name": "test matrix: test -le (order)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "23a61d62b083923c",
+      "exit_code": 0,
+      "name": "test matrix: test -le (non-numeric)",
+      "stderr": "bash: line 1: test: a: integer expression expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "6afbf4d839ac3287",
+      "exit_code": 0,
+      "name": "test matrix: test -le (octal-looking)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "3520a5558b2f83d4",
+      "exit_code": 0,
+      "name": "test matrix: test -le (spaces)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f50e74b47431fa48",
+      "exit_code": 0,
+      "name": "test matrix: test -gt (zeros)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "cf0112f1e9e40cb6",
+      "exit_code": 0,
+      "name": "test matrix: test -gt (zero-one)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6e66e42a31fa8891",
+      "exit_code": 0,
+      "name": "test matrix: test -gt (neg-zero)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "88740e594abd0515",
+      "exit_code": 0,
+      "name": "test matrix: test -gt (equal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c335297af187312b",
+      "exit_code": 0,
+      "name": "test matrix: test -gt (order)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "1e5c0cb110cc361d",
+      "exit_code": 0,
+      "name": "test matrix: test -gt (non-numeric)",
+      "stderr": "bash: line 1: test: a: integer expression expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "ef06671244d9e076",
+      "exit_code": 0,
+      "name": "test matrix: test -gt (octal-looking)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "204ed0e71bc9efb4",
+      "exit_code": 0,
+      "name": "test matrix: test -gt (spaces)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "7811289a93c0701e",
+      "exit_code": 0,
+      "name": "test matrix: test -ge (zeros)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f8e418986b6f3d5e",
+      "exit_code": 0,
+      "name": "test matrix: test -ge (zero-one)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "87813b8cc2908064",
+      "exit_code": 0,
+      "name": "test matrix: test -ge (neg-zero)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "30468d5afd89caf1",
+      "exit_code": 0,
+      "name": "test matrix: test -ge (equal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "d498be91882a6814",
+      "exit_code": 0,
+      "name": "test matrix: test -ge (order)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "120e2a5c09082687",
+      "exit_code": 0,
+      "name": "test matrix: test -ge (non-numeric)",
+      "stderr": "bash: line 1: test: a: integer expression expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "1aac190d0ba4490e",
+      "exit_code": 0,
+      "name": "test matrix: test -ge (octal-looking)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "c943b8489f11c6b7",
+      "exit_code": 0,
+      "name": "test matrix: test -ge (spaces)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f12484cbfdf8bf16",
+      "exit_code": 0,
+      "name": "test matrix: test -nt (older-newer)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8f118226f4a3359e",
+      "exit_code": 0,
+      "name": "test matrix: test -nt (newer-older)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "71e95becd96d63c4",
+      "exit_code": 0,
+      "name": "test matrix: test -ot (older-newer)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "62bff842ddff00ac",
+      "exit_code": 0,
+      "name": "test matrix: test -ot (newer-older)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "3008ae480eb81203",
+      "exit_code": 0,
+      "name": "test matrix: test -nt (same)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f433d27bccfbed6b",
+      "exit_code": 0,
+      "name": "test matrix: test -ot (same)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "480c9381b4910910",
+      "exit_code": 0,
+      "name": "test matrix: test -ef (same-path)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f3235e2c1acbaa88",
+      "exit_code": 0,
+      "name": "test matrix: test -ef (hardlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "7e48922d89883a22",
+      "exit_code": 0,
+      "name": "test matrix: test -ef (distinct)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "de199b3bf6860b69",
+      "exit_code": 0,
+      "name": "test matrix: test -nt (missing-file)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "30d7e900afb4c4b6",
+      "exit_code": 0,
+      "name": "test matrix: test -ef (missing-file)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "63102ce2541ee48f",
+      "exit_code": 0,
+      "name": "test matrix: test -a (hi-hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "75f27272d3952964",
+      "exit_code": 0,
+      "name": "test matrix: test -a (hi-empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "7b3045183f2ef8b7",
+      "exit_code": 0,
+      "name": "test matrix: test -o (empty-hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "679597fb11c55346",
+      "exit_code": 0,
+      "name": "test matrix: test -o (empty-empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "433027aeec703bcc",
+      "exit_code": 0,
+      "name": "test matrix: test unary -a (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b5f40d280255c8a2",
+      "exit_code": 0,
+      "name": "test matrix: test unary -a (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "5661b3650bb001be",
+      "exit_code": 0,
+      "name": "test matrix: test -a (file-and-dir)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "cba161c19e141df6",
+      "exit_code": 0,
+      "name": "test matrix: test -a (missing-and-dir)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e1b86612f800eea2",
+      "exit_code": 0,
+      "name": "test matrix: test ! (empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "368028dc443b6567",
+      "exit_code": 0,
+      "name": "test matrix: test ! (hi)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "71f41916c36935f0",
+      "exit_code": 0,
+      "name": "test matrix: test ! -z (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f29330e77eccdee8",
+      "exit_code": 0,
+      "name": "test matrix: test ! -z (hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "55317aa4d180f910",
+      "exit_code": 0,
+      "name": "test matrix: test ! -f (missing)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "4e9bfdec87413da9",
+      "exit_code": 0,
+      "name": "test matrix: test ! -f (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "0220acd80b0f689d",
+      "exit_code": 0,
+      "name": "test matrix: test ! = (equal)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c50b71e34c0c5dcf",
+      "exit_code": 0,
+      "name": "test matrix: test ! = (unequal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "9a4094534ddf0e08",
+      "exit_code": 0,
+      "name": "test matrix: test group (hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "d342a487e25226fc",
+      "exit_code": 0,
+      "name": "test matrix: test group (-z empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "9d1a7b7684d6a092",
+      "exit_code": 0,
+      "name": "test matrix: test group (= equal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "4d004c777376c270",
+      "exit_code": 0,
+      "name": "test matrix: test no-args",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "1634d0464bc61996",
+      "exit_code": 0,
+      "name": "test matrix: test extra-args",
+      "stderr": "bash: line 1: test: x: binary operator expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "3af9fd005020d893",
+      "exit_code": 0,
+      "name": "test matrix: test unknown unary",
+      "stderr": "bash: line 1: test: -Z: unary operator expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "99aed5d20f2d38c2",
+      "exit_code": 0,
+      "name": "test matrix: test unknown binary",
+      "stderr": "bash: line 1: test: -xx: binary operator expected\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "7b0552e916548d84",
+      "exit_code": 0,
+      "name": "test matrix: test too-many",
+      "stderr": "bash: line 1: test: too many arguments\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "26c481b04cb90446",
+      "exit_code": 0,
+      "name": "test matrix: [ no-args",
+      "stderr": "bash: line 1: [: missing `]'\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "6dec3178774b0bd7",
+      "exit_code": 0,
+      "name": "test matrix: [ empty",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "7f383c06e09bd8d4",
+      "exit_code": 0,
+      "name": "test matrix: [ missing-closer",
+      "stderr": "bash: line 1: [: missing `]'\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "086fc4eda65a8e6b",
+      "exit_code": 0,
+      "name": "test matrix: [ extra-after-closer",
+      "stderr": "bash: line 1: [: missing `]'\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "97f547bd455048d6",
+      "exit_code": 0,
+      "name": "test matrix: [ -e (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "cb96ee7daef0e1be",
+      "exit_code": 0,
+      "name": "test matrix: [ -e (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "5cff075a2bccd5e7",
+      "exit_code": 0,
+      "name": "test matrix: [ -e (dangling)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "4a51fa0b080318f9",
+      "exit_code": 0,
+      "name": "test matrix: [ -f (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "169373d486c8f1bb",
+      "exit_code": 0,
+      "name": "test matrix: [ -f (directory)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "83b00f8e4314a799",
+      "exit_code": 0,
+      "name": "test matrix: [ -f (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "aac02e5a015d4d1a",
+      "exit_code": 0,
+      "name": "test matrix: [ -d (directory)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "de1dada540df812e",
+      "exit_code": 0,
+      "name": "test matrix: [ -d (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "622c6b2820de64ac",
+      "exit_code": 0,
+      "name": "test matrix: [ -d (missing)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "69a32be73117a70e",
+      "exit_code": 0,
+      "name": "test matrix: [ -L (symlink)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "58dfa70b230d0cca",
+      "exit_code": 0,
+      "name": "test matrix: [ -L (regular)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b03e3b9ef8c56e9d",
+      "exit_code": 0,
+      "name": "test matrix: [ -s (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b5c8c9ee21e2ed27",
+      "exit_code": 0,
+      "name": "test matrix: [ -s (regular)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "624d79ea24a3ee27",
+      "exit_code": 0,
+      "name": "test matrix: [ -z (empty)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b7ea1deaf9d970df",
+      "exit_code": 0,
+      "name": "test matrix: [ -n (hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e195945a4213a1b5",
+      "exit_code": 0,
+      "name": "test matrix: [ one-arg (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "49d40598087baa4e",
+      "exit_code": 0,
+      "name": "test matrix: [ one-arg (hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "c2b0444d5f07b307",
+      "exit_code": 0,
+      "name": "test matrix: [ = (equal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ca8fa324c0c415ff",
+      "exit_code": 0,
+      "name": "test matrix: [ != (unequal)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "be6d629b0aeb2edb",
+      "exit_code": 0,
+      "name": "test matrix: [ -eq (zeros)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a8c01eead13c86cb",
+      "exit_code": 0,
+      "name": "test matrix: [ -lt (order)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e663499301c04c6f",
+      "exit_code": 0,
+      "name": "test matrix: [ ! -z (empty)",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "bb715cce0ab11d4d",
+      "exit_code": 0,
+      "name": "test matrix: [ -a (hi-hi)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b193019fa298f159",
+      "exit_code": 0,
+      "name": "test matrix: [ -L (dangling)",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    }
+  ],
+  "suite": "test_matrix"
+}

--- a/test/mix/tasks/bash_fixtures_gen_test.exs
+++ b/test/mix/tasks/bash_fixtures_gen_test.exs
@@ -64,6 +64,80 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
     end
   end
 
+  describe "test matrix" do
+    test "enumerates every operator, not a sample" do
+      cases = Gen.cases_for("test")
+      names = Enum.map(cases, & &1["name"])
+
+      assert length(cases) > 150
+
+      for op <- ~w(-e -f -d -L -h -s -r -w -x -z -n -b -c -p -S -t -u -g -k -G -O -N) do
+        assert Enum.any?(names, &String.contains?(&1, " #{op} ")),
+               "missing unary #{op}"
+      end
+
+      for op <- ~w(= == != < > -eq -ne -lt -le -gt -ge -nt -ot -ef -a -o) do
+        assert Enum.any?(names, &String.contains?(&1, " #{op} ")),
+               "missing binary #{op}"
+      end
+
+      assert Enum.any?(names, &String.contains?(&1, "test ! "))
+      assert Enum.any?(names, &String.contains?(&1, "test group "))
+    end
+
+    test "uses two or more bases so false-vs-missing and 10-vs-9 are visible" do
+      names = Gen.cases_for("test") |> Enum.map(& &1["name"])
+
+      assert Enum.any?(names, &(&1 =~ "test -e (regular)"))
+      assert Enum.any?(names, &(&1 =~ "test -e (missing)"))
+      assert Enum.any?(names, &(&1 =~ "test -L (symlink)"))
+      assert Enum.any?(names, &(&1 =~ "test -L (dangling)"))
+      assert Enum.any?(names, &(&1 =~ "test -z (empty)"))
+      assert Enum.any?(names, &(&1 =~ "test -z (hi)"))
+      assert Enum.any?(names, &(&1 =~ "test -eq (zeros)"))
+      assert Enum.any?(names, &(&1 =~ "test -eq (order)"))
+      assert Enum.any?(names, &(&1 =~ "test -lt (order)"))
+      assert Enum.any?(names, &(&1 =~ "test < (digits)"))
+    end
+
+    test "covers both test and [ for a representative subset" do
+      names = Gen.cases_for("test") |> Enum.map(& &1["name"])
+
+      for fragment <- ["-e (regular)", "-z (empty)", "= (equal)", "-eq (zeros)", "! -z (empty)"] do
+        assert Enum.any?(names, &String.contains?(&1, "test #{fragment}")),
+               "missing test #{fragment}"
+
+        assert Enum.any?(names, &String.contains?(&1, "[ #{fragment}")),
+               "missing [ #{fragment}"
+      end
+    end
+
+    test "every case hashes from its script, not its name or gap" do
+      cases = Gen.cases_for("test")
+
+      Enum.each(cases, fn test_case ->
+        assert test_case["content_hash"] == JustBash.Fixtures.hash_case(test_case)
+      end)
+    end
+
+    test "known_gap lives in opts and does not change the digest" do
+      cases = Gen.cases_for("test")
+      gapped = Enum.filter(cases, &get_in(&1, ["opts", "known_gap"]))
+
+      assert length(gapped) > 10
+      assert length(gapped) < length(cases)
+
+      Enum.each(gapped, fn test_case ->
+        reason = test_case["opts"]["known_gap"]
+        assert is_binary(reason)
+        assert String.length(reason) > 10
+
+        assert JustBash.Fixtures.hash_case(test_case) ==
+                 JustBash.Fixtures.hash_case(Map.delete(test_case, "opts"))
+      end)
+    end
+  end
+
   describe "run/1" do
     test "printf --dry-run reports a count and writes nothing" do
       output =
@@ -72,6 +146,16 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
         end)
 
       assert output =~ ~r/printf_matrix: \d+ cases/
+      refute output =~ "wrote"
+    end
+
+    test "test --dry-run reports a count and writes nothing" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Task.rerun("bash_fixtures.gen", ["test", "--dry-run"])
+        end)
+
+      assert output =~ ~r/test_matrix: \d+ cases/
       refute output =~ "wrote"
     end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #70 item 2 for **test / [ only**: a generated `test_matrix` suite in the same generate / record / test path as `date_matrix` and `printf_matrix`.

This is not the item-3 filesystem-shape × command cube (~480 cells). Operators are crossed with **revealing operand shapes for that operator** so padding/boundaries/false-vs-missing stay visible — the date lesson — without enumerating every FS command.

## What was enumerated

`mix bash_fixtures.gen test` writes **246** cases:

- Full POSIX/`[` operator list on `test`: `-b -c -d -e -f -g -h -k -L -n -p -r -S -s -t -u -w -x -z`, `=` `==` `!=` `<` `>`, `-eq -ne -lt -le -gt -ge`, `-nt -ot -ef`, `-a -o`, `!`, plus bash extras `-G -O -N`
- File operators × file / empty / dir / missing / symlink / dangling, plus chmod'd, fifo, `/dev/null`, trailing-slash and ENOTDIR boundaries
- `-z`/`-n` and one-arg forms at empty / `hi` / `0` / space (and operator-as-operand)
- String and integer compares at two or more pairs per family so one value cannot hide the bug (`hi`/`hi` vs `a`/`b`, `0`/`1` vs `10`/`9`)
- Both `test` and `[` on a representative subset (`-e/-f/-d/-L/-s`, `-z/-n`, `=`/`!=`, `-eq/-lt`, `!`, one-arg) so the two spellings cannot drift
- Syntax cells: no args, extra args, unknown operators, missing `]`, grouping

`mix bash_fixtures.gen test --dry-run` reports `test_matrix: 246 cases`. `mix bash_fixtures.gen` now generates date, printf, and test.

## Recording

Docker was not available on the agent VM. Oracle output was recorded with the same `test/fixtures/runner.sh` the Docker task runs, under GNU bash 5.2.21 / Ubuntu 24.04 (uid `ubuntu`, not root — so `chmod 000` permission cells are meaningful), then pretty-printed through `Mix.Tasks.BashFixtures.write_json!/2`:

```bash
mix bash_fixtures.gen test
bash test/fixtures/runner.sh < test/fixtures/bash_cases/test_matrix.json > /tmp/test_matrix_raw.json
# then Jason-pretty-print + Fixtures.validate, as `mix bash_fixtures` does
```

To re-record through Docker when it is available:

```bash
mix bash_fixtures test_matrix
```

## Known gaps (44 of 246)

No cell was omitted. Divergences are `opts.known_gap` (excluded from the digest). The fixture runner still executes them with the assertion inverted.

| Count | Reason |
|------:|--------|
| 6 | `-r`/`-w`/`-x` are existence checks; bash tests the permission bit (`-x` on a 644 file, `-r`/`-w` on `chmod 000`) |
| 6 | Leading-space integer operands (` 7`) — `Integer.parse/1` rejects them |
| 6 | Non-numeric `-eq` family: JustBash exits 2 with no diagnostic; bash writes stderr |
| 4 | Cannot construct fifo / setuid / sticky / dated-mtime shapes, and/or the operator is unimplemented |
| 4 | `-nt`/`-ot`/`-ef` unimplemented (revealing true side: newer-than, older-than, same-file, hardlink) |
| 3 | `[` without a closing `]` still evaluates; bash exits 2 |
| 3 | `( )` grouping unimplemented |
| 2 | `/dev/null` typed as a regular file; bash reports a character device (`-f`, `-c`) |
| 2 | Extra / too-many arguments: exit 1 vs bash exit 2 + diagnostic |
| 2 | Unknown operator (`-Z`, `-xx`): exit 1 vs bash exit 2 + diagnostic |
| 2 | `-O`/`-G` unimplemented (true on a file we own) |
| 1 | Directory size 0 so `test -s dir` is false |
| 1 | Trailing slash on a regular file treated as the file; bash requires a directory |
| 1 | Unary `-a` is not a synonym of `-e` |
| 1 | 4-arg `-f file -a -d dir` is not expression AND/OR |

JustBash.exec/2 did not raise on any cell. No `test`/`[` implementation bugs were fixed in this PR — it is the enumeration + harness.

## Cheap follow-ups the matrix now makes un-skippable

- `-x`/`-r`/`-w` should consult mode bits, not existence
- `-c` / character-device type for `/dev/null` (and stop reporting it as `-f`)
- `-nt`/`-ot`/`-ef`
- `[` missing-`]` and unknown-operator diagnostics (exit 2)
- Integer operands: leading spaces, and a stderr diagnostic on non-numeric
- Unary `-a` as `-e`; 4-arg `-a`/`-o` as expression AND/OR
- Directory size so `test -s dir` is true

Not in this PR: the item-3 FS-shape × command cube, Oils activation, CI topology changes.

## Tests

All local quality gates passed:

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict` (only the existing intentional `banned_fixture_apply` finding)
- `mix dialyzer` (zero new errors)
- `mix test` — 6346 tests, 0 failures
- `mix test --only suite:test_matrix` — 246 tests, 0 failures
- `mix bash_fixtures.gen test --dry-run` — `test_matrix: 246 cases`

## Related Issues
Related to #70 (item 2, test/[ only; not closing the issue)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Added new tests
- [x] All existing tests pass
- [x] Tested manually (`mix bash_fixtures.gen test --dry-run`, local runner.sh recording, JustBash vs oracle classification)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md (for non-trivial changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f55465-6f5a-4718-b639-22656119c59e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f55465-6f5a-4718-b639-22656119c59e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

