### PR TITLE
Add `${var op word}` alphabet matrix (`mix bash_fixtures.gen varop`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `mix bash_fixtures.gen printf` enumerates a printf conversion × flag/width/precision matrix (`printf_matrix`) — #70 item 2
 * `mix bash_fixtures.gen test` enumerates a `test`/`[` operator × revealing-shape matrix (`test_matrix`) — #70 item 2
+* `mix bash_fixtures.gen varop` enumerates a `${var op word}` parameter-expansion matrix (`varop_matrix`) — #70 item 2
 
 ### Bug Fixes
 

--- a/lib/mix/tasks/bash_fixtures.gen.ex
+++ b/lib/mix/tasks/bash_fixtures.gen.ex
@@ -25,6 +25,10 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       mix bash_fixtures test_matrix    # record what real bash does
       mix test --only suite:test_matrix
 
+      mix bash_fixtures.gen varop      # write the matrix
+      mix bash_fixtures varop_matrix   # record what real bash does
+      mix test --only suite:varop_matrix
+
   Generated suites are named `<matrix>_matrix` and are safe to regenerate: the
   digest in `JustBash.Fixtures` is content-derived, so a case that did not change
   keeps its recording.
@@ -49,6 +53,14 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       a representative subset so they cannot drift; the full operator list is
       on `test`. This is not the item-3 filesystem-shape × command cube. See
       #70 item 2.
+    * `varop` — every POSIX/bash `${var op word}` form (`-` `:-` `=` `:=` `+`
+      `:+` `?` `:?`, `#` `##` `%` `%%`, `${#var}`, `${var:offset}`,
+      `${var:offset:len}`, `${var/pat/rep}`, `${var//pat/rep}`) crossed with
+      unset / set-empty / set-nonempty, and with a nonempty vs empty word
+      where that changes the answer. Two nonempty bases (`foo` vs `foobar`,
+      plus `foofoo` where shortest vs longest or first vs all would otherwise
+      hide) so one value cannot hide the bug. Suite `varop_matrix`. See #70
+      item 2.
 
   A list of conversions and a list of flags are each easy to write down. The
   cross of the two is where the bugs live and is what nobody enumerates by hand:
@@ -62,6 +74,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       mix bash_fixtures.gen date         # one matrix
       mix bash_fixtures.gen printf       # one matrix
       mix bash_fixtures.gen test         # one matrix
+      mix bash_fixtures.gen varop        # one matrix
       mix bash_fixtures.gen --dry-run    # report counts, write nothing
   """
 
@@ -72,7 +85,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
 
   @shortdoc "Generate enumerated fixture matrices"
 
-  @matrices ["date", "printf", "test"]
+  @matrices ["date", "printf", "test", "varop"]
 
   @doc false
   def cases_for(name), do: build(name)
@@ -394,6 +407,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
   defp build("date"), do: date_cases()
   defp build("printf"), do: printf_cases()
   defp build("test"), do: test_cases()
+  defp build("varop"), do: varop_cases()
 
   defp date_cases do
     Enum.concat([
@@ -1587,6 +1601,284 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       @int_stderr_gap
     else
       @int_parse_gap
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # varop — `${var op word}` parameter expansion
+  #
+  # The alphabet is the POSIX/bash forms JustBash implements: defaults and
+  # alternatives (`-` `:-` `=` `:=` `+` `:+` `?` `:?`), length (`${#var}`),
+  # prefix/suffix removal (`#` `##` `%` `%%`), substring (`${var:offset}` /
+  # `${var:offset:len}`), and pattern replacement (`/` `//`). Each operator
+  # is crossed with unset / set-empty / set-nonempty rather than sampled:
+  # `-` vs `:-` is invisible unless empty and unset are both asked, and
+  # `+` vs `:+` is the same fact from the other side.
+  #
+  # Two nonempty bases — `foo` and `foobar` — so a substring, prefix or
+  # suffix that happens to agree on one value cannot hide. `foofoo` is the
+  # extra base for `#`/`##`/`%`/`%%` and `/`/`//`, where shortest vs
+  # longest and first vs all are otherwise the same cell.
+  #
+  # Every expansion is double-quoted (`"${v-word}"`) so the script is what
+  # bash sees: empty results stay empty, and `*` in a pattern is not a
+  # pathname. `set +u` is explicit except for the nounset cells, which
+  # use `set -u` so we record which operators are unset-safe (`-` `:-`
+  # and the other word-ops) and which still fire (`${#v}`, substring,
+  # removal, replacement).
+  # ---------------------------------------------------------------------------
+
+  # Word-taking operators. The colon forms treat empty as unset; the
+  # non-colon forms do not. That distinction is the whole reason to
+  # enumerate empty and unset separately.
+  @varop_word_ops [
+    {"-", "default-unset"},
+    {":-", "default-null"},
+    {"=", "assign-unset"},
+    {":=", "assign-null"},
+    {"+", "alt-set"},
+    {":+", "alt-null"},
+    {"?", "error-unset"},
+    {":?", "error-null"}
+  ]
+
+  # Empty vs nonempty word. For `-`/`:-`/`=`/`:=` the empty word is the
+  # cell that would hide behind "uses the default" if we only asked
+  # `word`. For `+`/`:+` the nonempty word is what the expansion *is*.
+  # For `?`/`:?` the word is the diagnostic (or bash's "parameter null
+  # or not set" when it is empty).
+  @varop_words [{"word", "word"}, {"empty", ""}]
+
+  @varop_states [
+    {"unset", :unset},
+    {"empty", :empty},
+    {"foo", {:set, "foo"}},
+    {"foobar", {:set, "foobar"}}
+  ]
+
+  # Prefix/suffix patterns. `foo` matches both nonempty bases as a
+  # prefix and only `foo` as a suffix; `bar` matches only `foobar` as a
+  # suffix. `f*` / `*r` / `*` are where `#` vs `##` and `%` vs `%%`
+  # disagree; the empty pattern is the no-op that a generator which
+  # required a word would omit.
+  @varop_prefix_pats ["foo", "f*", "bar", "*", ""]
+  @varop_suffix_pats ["foo", "bar", "*r", "*", ""]
+
+  # Offsets and lengths that distinguish `foo` from `foobar`: `:3` is
+  # empty vs `bar`, `:1:3` is `oo` vs `oob`, `: -1` is `o` vs `r`.
+  # `: -N` needs the space so bash does not parse it as `:-`. `::2` is
+  # the empty-offset spelling; `:0:-1` is a negative length.
+  @varop_slices [
+    ":0",
+    ":1",
+    ":3",
+    ":6",
+    ": -1",
+    ": -3",
+    ":0:0",
+    ":1:2",
+    ":1:3",
+    ":3:2",
+    ": -2:1",
+    ":0:-1",
+    "::2"
+  ]
+
+  # First-vs-all replacements. `o` occurs twice in both nonempty bases,
+  # so `/` and `//` disagree; `foo`/`bar` are the literal match and
+  # miss; empty replacement is deletion.
+  @varop_replaces [
+    {"o", "X"},
+    {"o", ""},
+    {"foo", "X"},
+    {"bar", "X"}
+  ]
+
+  defp varop_cases do
+    Enum.concat([
+      varop_word_cases(),
+      varop_nounset_cases(),
+      varop_length_cases(),
+      varop_slice_cases(),
+      varop_remove_cases(),
+      varop_replace_cases()
+    ])
+  end
+
+  # 8 operators × 2 words × 4 states. The colon/non-colon pair is only
+  # visible when empty and unset are both present; the two nonempty
+  # bases are only visible when the operator returns the value (`-` on
+  # a set var, or `+` wrongly returning it).
+  defp varop_word_cases do
+    extra_default_one =
+      for {label, state} <- @varop_states do
+        # `${v:-1}` is default-null with word `1`, not substring. Asked
+        # next to `${v: -1}` so a parser that drops the colon/space
+        # distinction cannot hide behind `word`.
+        varop_case("${v:-1} (#{label})", varop_setup(state), "${v:-1}", [])
+      end
+
+    word_cross =
+      for {op, _kind} <- @varop_word_ops,
+          {word_label, word} <- @varop_words,
+          {state_label, state} <- @varop_states do
+        expansion = "${v#{op}#{word}}"
+        name = "#{expansion} (#{state_label}, #{word_label})"
+        after_lines = varop_after_lines(op)
+        varop_case(name, varop_setup(state), expansion, after_lines)
+      end
+
+    extra_default_one ++ word_cross
+  end
+
+  # Nounset must not fire on the operators that exist to handle unset.
+  # One revealing cell per family, plus the word-ops on unset (and on
+  # empty for the colon forms, where empty is the other trigger).
+  defp varop_nounset_cases do
+    Enum.concat([
+      for {op, _kind} <- @varop_word_ops,
+          {state_label, state} <- [{"unset", :unset}, {"empty", :empty}] do
+        expansion = "${v#{op}word}"
+
+        varop_case(
+          "set -u #{expansion} (#{state_label})",
+          varop_setup_u(state),
+          expansion,
+          varop_after_lines(op)
+        )
+      end,
+      [
+        varop_case("set -u ${#v} (unset)", varop_setup_u(:unset), "${#v}", []),
+        varop_case("set -u ${v:0} (unset)", varop_setup_u(:unset), "${v:0}", []),
+        varop_case("set -u ${v#x} (unset)", varop_setup_u(:unset), "${v#x}", []),
+        varop_case("set -u ${v/x/y} (unset)", varop_setup_u(:unset), "${v/x/y}", [])
+      ]
+    ])
+  end
+
+  defp varop_length_cases do
+    for {label, state} <- @varop_states do
+      varop_case("${#v} (#{label})", varop_setup(state), "${#v}", [])
+    end
+  end
+
+  defp varop_slice_cases do
+    for slice <- @varop_slices, {label, state} <- @varop_states do
+      expansion = "${v#{slice}}"
+      varop_case("#{expansion} (#{label})", varop_setup(state), expansion, [])
+    end
+  end
+
+  defp varop_remove_cases do
+    Enum.concat([
+      for {op, pats} <- [
+            {"#", @varop_prefix_pats},
+            {"##", @varop_prefix_pats},
+            {"%", @varop_suffix_pats},
+            {"%%", @varop_suffix_pats}
+          ],
+          pat <- pats,
+          {label, state} <- @varop_states do
+        expansion = "${v#{op}#{pat}}"
+        varop_case("#{expansion} (#{label})", varop_setup(state), expansion, [])
+      end,
+      # `foofoo` is where `#` vs `##` and `%` vs `%%` actually split
+      # on a repeated literal, not only on `*`.
+      for {op, pat} <- [
+            {"#", "f*"},
+            {"##", "f*"},
+            {"#", "foo*"},
+            {"##", "foo*"},
+            {"%", "*o"},
+            {"%%", "*o"},
+            {"%", "*foo"},
+            {"%%", "*foo"}
+          ] do
+        expansion = "${v#{op}#{pat}}"
+        varop_case("#{expansion} (foofoo)", varop_setup({:set, "foofoo"}), expansion, [])
+      end
+    ])
+  end
+
+  defp varop_replace_cases do
+    Enum.concat([
+      for all? <- [false, true],
+          {pat, rep} <- @varop_replaces,
+          {label, state} <- @varop_states do
+        slash = if all?, do: "//", else: "/"
+        expansion = "${v#{slash}#{pat}/#{rep}}"
+        varop_case("#{expansion} (#{label})", varop_setup(state), expansion, [])
+      end,
+      [
+        varop_case("${v/foo/X} (foofoo)", varop_setup({:set, "foofoo"}), "${v/foo/X}", []),
+        varop_case("${v//foo/X} (foofoo)", varop_setup({:set, "foofoo"}), "${v//foo/X}", []),
+        varop_case("${v/} (foo)", varop_setup({:set, "foo"}), "${v/}", []),
+        varop_case("${v//} (foo)", varop_setup({:set, "foo"}), "${v//}", []),
+        varop_case("${v/o} (foo)", varop_setup({:set, "foo"}), "${v/o}", []),
+        varop_case("${v//o} (foo)", varop_setup({:set, "foo"}), "${v//o}", [])
+      ]
+    ])
+  end
+
+  defp varop_setup(:unset), do: "set +u; unset v"
+  defp varop_setup(:empty), do: "set +u; v="
+  defp varop_setup({:set, value}), do: "set +u; v=#{value}"
+
+  defp varop_setup_u(:unset), do: "set -u; unset v"
+  defp varop_setup_u(:empty), do: "set -u; v="
+
+  defp varop_after_lines(op) when op in ["=", ":="], do: ["echo \"[$v]\""]
+  defp varop_after_lines(op) when op in ["?", ":?"], do: ["echo after"]
+  defp varop_after_lines(_op), do: []
+
+  defp varop_case(name, setup, expansion, after_lines) do
+    echoes = ["echo \"[#{expansion}]\"" | after_lines]
+    script = Enum.join([setup | echoes] ++ ["echo rc=$?"], "; ")
+    fixture_case("varop matrix: #{name}", script, varop_gap(name))
+  end
+
+  # Assigned after recording. A cell that matches is left unmarked even
+  # when a sibling of the same operator diverges — marking a match
+  # inverts a passing assertion. `${v?}` on a set or empty value is
+  # correct; only the unset (and, for `:?`, empty) triggers are gaps.
+  @error_op_gap "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+  @nounset_other_gap "JustBash set -u treats unset as empty for ${#v}/${v:offset}/${v#pat}/${v/pat}; bash errors unbound variable"
+  @slice_neg_empty_gap "JustBash ${v:0:-1} on empty is empty at exit 0; bash errors substring expression < 0"
+  @shortest_star_gap "JustBash shortest #/*/% of * consumes one character; bash's shortest * match is empty so the value is unchanged"
+
+  @error_op_names [
+    "${v?word} (unset, word)",
+    "${v?} (unset, empty)",
+    "${v:?word} (unset, word)",
+    "${v:?word} (empty, word)",
+    "${v:?} (unset, empty)",
+    "${v:?} (empty, empty)",
+    "set -u ${v?word} (unset)",
+    "set -u ${v:?word} (unset)",
+    "set -u ${v:?word} (empty)"
+  ]
+
+  @nounset_other_names [
+    "set -u ${#v} (unset)",
+    "set -u ${v:0} (unset)",
+    "set -u ${v#x} (unset)",
+    "set -u ${v/x/y} (unset)"
+  ]
+
+  @shortest_star_names [
+    "${v#*} (foo)",
+    "${v#*} (foobar)",
+    "${v%*} (foo)",
+    "${v%*} (foobar)"
+  ]
+
+  defp varop_gap(name) do
+    cond do
+      name in @error_op_names -> @error_op_gap
+      name in @nounset_other_names -> @nounset_other_gap
+      name == "${v:0:-1} (empty)" -> @slice_neg_empty_gap
+      name in @shortest_star_names -> @shortest_star_gap
+      true -> nil
     end
   end
 

--- a/test/fixtures/bash_cases/varop_matrix.json
+++ b/test/fixtures/bash_cases/varop_matrix.json
@@ -1,0 +1,1409 @@
+{
+  "cases": [
+    {
+      "content_hash": "e8d84f47ac46a868",
+      "name": "varop matrix: ${v:-1} (unset)",
+      "script": "set +u; unset v; echo \"[${v:-1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9fd65e3201eed796",
+      "name": "varop matrix: ${v:-1} (empty)",
+      "script": "set +u; v=; echo \"[${v:-1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9317cf807f6d010c",
+      "name": "varop matrix: ${v:-1} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:-1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "778f8d0079e20a91",
+      "name": "varop matrix: ${v:-1} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:-1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "23958776ce32c943",
+      "name": "varop matrix: ${v-word} (unset, word)",
+      "script": "set +u; unset v; echo \"[${v-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9428e1c42530c0ea",
+      "name": "varop matrix: ${v-word} (empty, word)",
+      "script": "set +u; v=; echo \"[${v-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "6e6cdbc00c09e1e2",
+      "name": "varop matrix: ${v-word} (foo, word)",
+      "script": "set +u; v=foo; echo \"[${v-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2b471b7a34d0e473",
+      "name": "varop matrix: ${v-word} (foobar, word)",
+      "script": "set +u; v=foobar; echo \"[${v-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "d7aec96a472ab3b2",
+      "name": "varop matrix: ${v-} (unset, empty)",
+      "script": "set +u; unset v; echo \"[${v-}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9b9a802ce10d478f",
+      "name": "varop matrix: ${v-} (empty, empty)",
+      "script": "set +u; v=; echo \"[${v-}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "431f1093e92ef37d",
+      "name": "varop matrix: ${v-} (foo, empty)",
+      "script": "set +u; v=foo; echo \"[${v-}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a2bf48364826dc7e",
+      "name": "varop matrix: ${v-} (foobar, empty)",
+      "script": "set +u; v=foobar; echo \"[${v-}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9261b41b692f2611",
+      "name": "varop matrix: ${v:-word} (unset, word)",
+      "script": "set +u; unset v; echo \"[${v:-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fe333ed10bec8470",
+      "name": "varop matrix: ${v:-word} (empty, word)",
+      "script": "set +u; v=; echo \"[${v:-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "71fea0b9cb5e56da",
+      "name": "varop matrix: ${v:-word} (foo, word)",
+      "script": "set +u; v=foo; echo \"[${v:-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9669f7fcdc9eaded",
+      "name": "varop matrix: ${v:-word} (foobar, word)",
+      "script": "set +u; v=foobar; echo \"[${v:-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "45ddc02e75af9fb6",
+      "name": "varop matrix: ${v:-} (unset, empty)",
+      "script": "set +u; unset v; echo \"[${v:-}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0e7eb668bbc8643c",
+      "name": "varop matrix: ${v:-} (empty, empty)",
+      "script": "set +u; v=; echo \"[${v:-}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3e9c50a7cb413ad0",
+      "name": "varop matrix: ${v:-} (foo, empty)",
+      "script": "set +u; v=foo; echo \"[${v:-}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2331fdf553aea870",
+      "name": "varop matrix: ${v:-} (foobar, empty)",
+      "script": "set +u; v=foobar; echo \"[${v:-}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "be0a3f837efcb32b",
+      "name": "varop matrix: ${v=word} (unset, word)",
+      "script": "set +u; unset v; echo \"[${v=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "b6c2dbdae80b0323",
+      "name": "varop matrix: ${v=word} (empty, word)",
+      "script": "set +u; v=; echo \"[${v=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "b34e46564d13a8ef",
+      "name": "varop matrix: ${v=word} (foo, word)",
+      "script": "set +u; v=foo; echo \"[${v=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4f24d9c63e68356a",
+      "name": "varop matrix: ${v=word} (foobar, word)",
+      "script": "set +u; v=foobar; echo \"[${v=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8019cf4d56f0dcf3",
+      "name": "varop matrix: ${v=} (unset, empty)",
+      "script": "set +u; unset v; echo \"[${v=}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4b46a7db16cbbb31",
+      "name": "varop matrix: ${v=} (empty, empty)",
+      "script": "set +u; v=; echo \"[${v=}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "dc0853403d45587e",
+      "name": "varop matrix: ${v=} (foo, empty)",
+      "script": "set +u; v=foo; echo \"[${v=}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1a33ce9aac478d73",
+      "name": "varop matrix: ${v=} (foobar, empty)",
+      "script": "set +u; v=foobar; echo \"[${v=}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c7f7a0c5f4149edc",
+      "name": "varop matrix: ${v:=word} (unset, word)",
+      "script": "set +u; unset v; echo \"[${v:=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c859998a0592891c",
+      "name": "varop matrix: ${v:=word} (empty, word)",
+      "script": "set +u; v=; echo \"[${v:=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "aca1add05289ecb6",
+      "name": "varop matrix: ${v:=word} (foo, word)",
+      "script": "set +u; v=foo; echo \"[${v:=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4db3fb1b31536c31",
+      "name": "varop matrix: ${v:=word} (foobar, word)",
+      "script": "set +u; v=foobar; echo \"[${v:=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "64d8527906cd72df",
+      "name": "varop matrix: ${v:=} (unset, empty)",
+      "script": "set +u; unset v; echo \"[${v:=}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c25477eb6795346d",
+      "name": "varop matrix: ${v:=} (empty, empty)",
+      "script": "set +u; v=; echo \"[${v:=}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1c4b16b105a44495",
+      "name": "varop matrix: ${v:=} (foo, empty)",
+      "script": "set +u; v=foo; echo \"[${v:=}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "94baaa18f7797396",
+      "name": "varop matrix: ${v:=} (foobar, empty)",
+      "script": "set +u; v=foobar; echo \"[${v:=}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "924c2fce828fbd21",
+      "name": "varop matrix: ${v+word} (unset, word)",
+      "script": "set +u; unset v; echo \"[${v+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a5226a7e7dd6adfa",
+      "name": "varop matrix: ${v+word} (empty, word)",
+      "script": "set +u; v=; echo \"[${v+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "cf01c326697f9f50",
+      "name": "varop matrix: ${v+word} (foo, word)",
+      "script": "set +u; v=foo; echo \"[${v+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e0c8fd9f239c6270",
+      "name": "varop matrix: ${v+word} (foobar, word)",
+      "script": "set +u; v=foobar; echo \"[${v+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "cae76e7eeafec0a3",
+      "name": "varop matrix: ${v+} (unset, empty)",
+      "script": "set +u; unset v; echo \"[${v+}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "7d09190b2abdd785",
+      "name": "varop matrix: ${v+} (empty, empty)",
+      "script": "set +u; v=; echo \"[${v+}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "775a34a9af6bd853",
+      "name": "varop matrix: ${v+} (foo, empty)",
+      "script": "set +u; v=foo; echo \"[${v+}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f385e501c3f5441f",
+      "name": "varop matrix: ${v+} (foobar, empty)",
+      "script": "set +u; v=foobar; echo \"[${v+}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3c266f5a1fd043b5",
+      "name": "varop matrix: ${v:+word} (unset, word)",
+      "script": "set +u; unset v; echo \"[${v:+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f6b7c6e1381e5b63",
+      "name": "varop matrix: ${v:+word} (empty, word)",
+      "script": "set +u; v=; echo \"[${v:+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e77c691611228480",
+      "name": "varop matrix: ${v:+word} (foo, word)",
+      "script": "set +u; v=foo; echo \"[${v:+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "450426a459a41467",
+      "name": "varop matrix: ${v:+word} (foobar, word)",
+      "script": "set +u; v=foobar; echo \"[${v:+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "327a91b1e326974a",
+      "name": "varop matrix: ${v:+} (unset, empty)",
+      "script": "set +u; unset v; echo \"[${v:+}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a742d7b1fee298e2",
+      "name": "varop matrix: ${v:+} (empty, empty)",
+      "script": "set +u; v=; echo \"[${v:+}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "111ab251f6056594",
+      "name": "varop matrix: ${v:+} (foo, empty)",
+      "script": "set +u; v=foo; echo \"[${v:+}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "bec2203f40e0127e",
+      "name": "varop matrix: ${v:+} (foobar, empty)",
+      "script": "set +u; v=foobar; echo \"[${v:+}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "65a37da8dbd9e560",
+      "name": "varop matrix: ${v?word} (unset, word)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set +u; unset v; echo \"[${v?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "2496f2b2515400e4",
+      "name": "varop matrix: ${v?word} (empty, word)",
+      "script": "set +u; v=; echo \"[${v?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "afb21a25a75e3a1a",
+      "name": "varop matrix: ${v?word} (foo, word)",
+      "script": "set +u; v=foo; echo \"[${v?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "63f9a5bd76ff6b91",
+      "name": "varop matrix: ${v?word} (foobar, word)",
+      "script": "set +u; v=foobar; echo \"[${v?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "5cbcf5f47770bffc",
+      "name": "varop matrix: ${v?} (unset, empty)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set +u; unset v; echo \"[${v?}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "f74b894c96136fce",
+      "name": "varop matrix: ${v?} (empty, empty)",
+      "script": "set +u; v=; echo \"[${v?}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "579c538bc9bc5753",
+      "name": "varop matrix: ${v?} (foo, empty)",
+      "script": "set +u; v=foo; echo \"[${v?}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "a61267d7211fbc76",
+      "name": "varop matrix: ${v?} (foobar, empty)",
+      "script": "set +u; v=foobar; echo \"[${v?}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "a236e6b73a4950a5",
+      "name": "varop matrix: ${v:?word} (unset, word)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set +u; unset v; echo \"[${v:?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "7952b8c22a73b086",
+      "name": "varop matrix: ${v:?word} (empty, word)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set +u; v=; echo \"[${v:?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "619d98676c666a77",
+      "name": "varop matrix: ${v:?word} (foo, word)",
+      "script": "set +u; v=foo; echo \"[${v:?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "6774c3a35ceb6fcb",
+      "name": "varop matrix: ${v:?word} (foobar, word)",
+      "script": "set +u; v=foobar; echo \"[${v:?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "54bb680964a03e86",
+      "name": "varop matrix: ${v:?} (unset, empty)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set +u; unset v; echo \"[${v:?}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "bc3e2f3135362669",
+      "name": "varop matrix: ${v:?} (empty, empty)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set +u; v=; echo \"[${v:?}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "ccd08f8ca5f63069",
+      "name": "varop matrix: ${v:?} (foo, empty)",
+      "script": "set +u; v=foo; echo \"[${v:?}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "b56e8edf3d71f353",
+      "name": "varop matrix: ${v:?} (foobar, empty)",
+      "script": "set +u; v=foobar; echo \"[${v:?}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "de35c240a2f395e5",
+      "name": "varop matrix: set -u ${v-word} (unset)",
+      "script": "set -u; unset v; echo \"[${v-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "32b60682dee4c9dd",
+      "name": "varop matrix: set -u ${v-word} (empty)",
+      "script": "set -u; v=; echo \"[${v-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "39769032586567b2",
+      "name": "varop matrix: set -u ${v:-word} (unset)",
+      "script": "set -u; unset v; echo \"[${v:-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "36283dc6c5ffd527",
+      "name": "varop matrix: set -u ${v:-word} (empty)",
+      "script": "set -u; v=; echo \"[${v:-word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f01d8d211fc1a36b",
+      "name": "varop matrix: set -u ${v=word} (unset)",
+      "script": "set -u; unset v; echo \"[${v=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "da9590195e27257f",
+      "name": "varop matrix: set -u ${v=word} (empty)",
+      "script": "set -u; v=; echo \"[${v=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fdb7e488cb562d54",
+      "name": "varop matrix: set -u ${v:=word} (unset)",
+      "script": "set -u; unset v; echo \"[${v:=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "dade6d948f229b31",
+      "name": "varop matrix: set -u ${v:=word} (empty)",
+      "script": "set -u; v=; echo \"[${v:=word}]\"; echo \"[$v]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "b36bc64cfc644221",
+      "name": "varop matrix: set -u ${v+word} (unset)",
+      "script": "set -u; unset v; echo \"[${v+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2d6c5f73d3caabcd",
+      "name": "varop matrix: set -u ${v+word} (empty)",
+      "script": "set -u; v=; echo \"[${v+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "7240cde0183b05f2",
+      "name": "varop matrix: set -u ${v:+word} (unset)",
+      "script": "set -u; unset v; echo \"[${v:+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "36798059419fd814",
+      "name": "varop matrix: set -u ${v:+word} (empty)",
+      "script": "set -u; v=; echo \"[${v:+word}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "073da5ce458d0bf7",
+      "name": "varop matrix: set -u ${v?word} (unset)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set -u; unset v; echo \"[${v?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "dfaad0cee53f94b1",
+      "name": "varop matrix: set -u ${v?word} (empty)",
+      "script": "set -u; v=; echo \"[${v?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "5bfa3380fef546d9",
+      "name": "varop matrix: set -u ${v:?word} (unset)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set -u; unset v; echo \"[${v:?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "60762b0fd9eae924",
+      "name": "varop matrix: set -u ${v:?word} (empty)",
+      "opts": {
+        "known_gap": "JustBash ${v?}/${v:?} returns empty and continues; bash writes a diagnostic to stderr and aborts"
+      },
+      "script": "set -u; v=; echo \"[${v:?word}]\"; echo after; echo rc=$?"
+    },
+    {
+      "content_hash": "ad5dab775b0b5590",
+      "name": "varop matrix: set -u ${#v} (unset)",
+      "opts": {
+        "known_gap": "JustBash set -u treats unset as empty for ${#v}/${v:offset}/${v#pat}/${v/pat}; bash errors unbound variable"
+      },
+      "script": "set -u; unset v; echo \"[${#v}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "29be4b20eec6a6eb",
+      "name": "varop matrix: set -u ${v:0} (unset)",
+      "opts": {
+        "known_gap": "JustBash set -u treats unset as empty for ${#v}/${v:offset}/${v#pat}/${v/pat}; bash errors unbound variable"
+      },
+      "script": "set -u; unset v; echo \"[${v:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a481f53d9e7b9ecd",
+      "name": "varop matrix: set -u ${v#x} (unset)",
+      "opts": {
+        "known_gap": "JustBash set -u treats unset as empty for ${#v}/${v:offset}/${v#pat}/${v/pat}; bash errors unbound variable"
+      },
+      "script": "set -u; unset v; echo \"[${v#x}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "46da344ce21ec60e",
+      "name": "varop matrix: set -u ${v/x/y} (unset)",
+      "opts": {
+        "known_gap": "JustBash set -u treats unset as empty for ${#v}/${v:offset}/${v#pat}/${v/pat}; bash errors unbound variable"
+      },
+      "script": "set -u; unset v; echo \"[${v/x/y}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "71aaa2a58947df8b",
+      "name": "varop matrix: ${#v} (unset)",
+      "script": "set +u; unset v; echo \"[${#v}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3c93fe95c75a0f55",
+      "name": "varop matrix: ${#v} (empty)",
+      "script": "set +u; v=; echo \"[${#v}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f49aee16bef187db",
+      "name": "varop matrix: ${#v} (foo)",
+      "script": "set +u; v=foo; echo \"[${#v}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "22bea81097a846ed",
+      "name": "varop matrix: ${#v} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${#v}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3a58efedb99dd94b",
+      "name": "varop matrix: ${v:0} (unset)",
+      "script": "set +u; unset v; echo \"[${v:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "579660560b7e2eee",
+      "name": "varop matrix: ${v:0} (empty)",
+      "script": "set +u; v=; echo \"[${v:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a48273b5ffab90da",
+      "name": "varop matrix: ${v:0} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f86302f756c5d459",
+      "name": "varop matrix: ${v:0} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "5bc66020ae307108",
+      "name": "varop matrix: ${v:1} (unset)",
+      "script": "set +u; unset v; echo \"[${v:1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a48e28d365ca930b",
+      "name": "varop matrix: ${v:1} (empty)",
+      "script": "set +u; v=; echo \"[${v:1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f668c46f5070d2fb",
+      "name": "varop matrix: ${v:1} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3c818d44016810dc",
+      "name": "varop matrix: ${v:1} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e465ca7123784d18",
+      "name": "varop matrix: ${v:3} (unset)",
+      "script": "set +u; unset v; echo \"[${v:3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "01a58c54f153bcdb",
+      "name": "varop matrix: ${v:3} (empty)",
+      "script": "set +u; v=; echo \"[${v:3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "5101ac255f09d506",
+      "name": "varop matrix: ${v:3} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1cfe0cb916dfa7d6",
+      "name": "varop matrix: ${v:3} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c8608020b2f25b8f",
+      "name": "varop matrix: ${v:6} (unset)",
+      "script": "set +u; unset v; echo \"[${v:6}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "028480c1b09d05dd",
+      "name": "varop matrix: ${v:6} (empty)",
+      "script": "set +u; v=; echo \"[${v:6}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "68cb2ac7de63fc86",
+      "name": "varop matrix: ${v:6} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:6}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ecc637f652dbe132",
+      "name": "varop matrix: ${v:6} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:6}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "b83e2e374e731c7d",
+      "name": "varop matrix: ${v: -1} (unset)",
+      "script": "set +u; unset v; echo \"[${v: -1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fab14cd86b74fbc8",
+      "name": "varop matrix: ${v: -1} (empty)",
+      "script": "set +u; v=; echo \"[${v: -1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "479a20aee2b8c504",
+      "name": "varop matrix: ${v: -1} (foo)",
+      "script": "set +u; v=foo; echo \"[${v: -1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0565124e45a410e2",
+      "name": "varop matrix: ${v: -1} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v: -1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1b9f2207a6b35e52",
+      "name": "varop matrix: ${v: -3} (unset)",
+      "script": "set +u; unset v; echo \"[${v: -3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "88b90f7a46248ab3",
+      "name": "varop matrix: ${v: -3} (empty)",
+      "script": "set +u; v=; echo \"[${v: -3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "7597947e2420406c",
+      "name": "varop matrix: ${v: -3} (foo)",
+      "script": "set +u; v=foo; echo \"[${v: -3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "5b42cf4f3e0f2623",
+      "name": "varop matrix: ${v: -3} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v: -3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "07cebb5f3cf752db",
+      "name": "varop matrix: ${v:0:0} (unset)",
+      "script": "set +u; unset v; echo \"[${v:0:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2cc193fa18e3f35c",
+      "name": "varop matrix: ${v:0:0} (empty)",
+      "script": "set +u; v=; echo \"[${v:0:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "beec8978b86ae9c3",
+      "name": "varop matrix: ${v:0:0} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:0:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8d56cbc8516b0cc3",
+      "name": "varop matrix: ${v:0:0} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:0:0}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "904039a61554a223",
+      "name": "varop matrix: ${v:1:2} (unset)",
+      "script": "set +u; unset v; echo \"[${v:1:2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a8458f5d4f73e4ba",
+      "name": "varop matrix: ${v:1:2} (empty)",
+      "script": "set +u; v=; echo \"[${v:1:2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1a5b26637768e62a",
+      "name": "varop matrix: ${v:1:2} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:1:2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "086ff63a291a04b4",
+      "name": "varop matrix: ${v:1:2} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:1:2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ddd3c3482e3e25ba",
+      "name": "varop matrix: ${v:1:3} (unset)",
+      "script": "set +u; unset v; echo \"[${v:1:3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ffdc70d344349d9d",
+      "name": "varop matrix: ${v:1:3} (empty)",
+      "script": "set +u; v=; echo \"[${v:1:3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2660c2afc18256cb",
+      "name": "varop matrix: ${v:1:3} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:1:3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "cacacd5a060217bc",
+      "name": "varop matrix: ${v:1:3} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:1:3}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "b2c5080813d761a0",
+      "name": "varop matrix: ${v:3:2} (unset)",
+      "script": "set +u; unset v; echo \"[${v:3:2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4d7a9c4fa625781e",
+      "name": "varop matrix: ${v:3:2} (empty)",
+      "script": "set +u; v=; echo \"[${v:3:2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "d55d6779a0c6a23f",
+      "name": "varop matrix: ${v:3:2} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:3:2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ebc019835437a18e",
+      "name": "varop matrix: ${v:3:2} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:3:2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "74226759fe70de4d",
+      "name": "varop matrix: ${v: -2:1} (unset)",
+      "script": "set +u; unset v; echo \"[${v: -2:1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4c8de583a1af59b6",
+      "name": "varop matrix: ${v: -2:1} (empty)",
+      "script": "set +u; v=; echo \"[${v: -2:1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a3362807f17747c6",
+      "name": "varop matrix: ${v: -2:1} (foo)",
+      "script": "set +u; v=foo; echo \"[${v: -2:1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a091d8b7775e7cfc",
+      "name": "varop matrix: ${v: -2:1} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v: -2:1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "7a275f0640e8310e",
+      "name": "varop matrix: ${v:0:-1} (unset)",
+      "script": "set +u; unset v; echo \"[${v:0:-1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "27d8938db69fecfa",
+      "name": "varop matrix: ${v:0:-1} (empty)",
+      "opts": {
+        "known_gap": "JustBash ${v:0:-1} on empty is empty at exit 0; bash errors substring expression < 0"
+      },
+      "script": "set +u; v=; echo \"[${v:0:-1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "95c78ea4950c8406",
+      "name": "varop matrix: ${v:0:-1} (foo)",
+      "script": "set +u; v=foo; echo \"[${v:0:-1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2e6390107969d95d",
+      "name": "varop matrix: ${v:0:-1} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v:0:-1}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9760eaa73a898cd4",
+      "name": "varop matrix: ${v::2} (unset)",
+      "script": "set +u; unset v; echo \"[${v::2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1f05504309640337",
+      "name": "varop matrix: ${v::2} (empty)",
+      "script": "set +u; v=; echo \"[${v::2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f4248d793abb49ea",
+      "name": "varop matrix: ${v::2} (foo)",
+      "script": "set +u; v=foo; echo \"[${v::2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f8348c981aff44d7",
+      "name": "varop matrix: ${v::2} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v::2}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "63ba2c810c935aa6",
+      "name": "varop matrix: ${v#foo} (unset)",
+      "script": "set +u; unset v; echo \"[${v#foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c16dc8d99396113a",
+      "name": "varop matrix: ${v#foo} (empty)",
+      "script": "set +u; v=; echo \"[${v#foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "74aef8b513a36472",
+      "name": "varop matrix: ${v#foo} (foo)",
+      "script": "set +u; v=foo; echo \"[${v#foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "700f2cf68ff5bf9a",
+      "name": "varop matrix: ${v#foo} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v#foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "995ef9d1b3b05be4",
+      "name": "varop matrix: ${v#f*} (unset)",
+      "script": "set +u; unset v; echo \"[${v#f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4c80c201bcffcde5",
+      "name": "varop matrix: ${v#f*} (empty)",
+      "script": "set +u; v=; echo \"[${v#f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9c3c22cb12dc1e0d",
+      "name": "varop matrix: ${v#f*} (foo)",
+      "script": "set +u; v=foo; echo \"[${v#f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "29b65f0ce7edef37",
+      "name": "varop matrix: ${v#f*} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v#f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "bf608d76be23a2d9",
+      "name": "varop matrix: ${v#bar} (unset)",
+      "script": "set +u; unset v; echo \"[${v#bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "81a602079a751cc2",
+      "name": "varop matrix: ${v#bar} (empty)",
+      "script": "set +u; v=; echo \"[${v#bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "75f4f1790e78ad9b",
+      "name": "varop matrix: ${v#bar} (foo)",
+      "script": "set +u; v=foo; echo \"[${v#bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3294b498bf6a7ed4",
+      "name": "varop matrix: ${v#bar} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v#bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "62e77b7ad3af63c2",
+      "name": "varop matrix: ${v#*} (unset)",
+      "script": "set +u; unset v; echo \"[${v#*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e9bd2cacc9d54314",
+      "name": "varop matrix: ${v#*} (empty)",
+      "script": "set +u; v=; echo \"[${v#*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8445492401cde5c3",
+      "name": "varop matrix: ${v#*} (foo)",
+      "opts": {
+        "known_gap": "JustBash shortest #/*/% of * consumes one character; bash's shortest * match is empty so the value is unchanged"
+      },
+      "script": "set +u; v=foo; echo \"[${v#*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f6bb59d2bcdab7c7",
+      "name": "varop matrix: ${v#*} (foobar)",
+      "opts": {
+        "known_gap": "JustBash shortest #/*/% of * consumes one character; bash's shortest * match is empty so the value is unchanged"
+      },
+      "script": "set +u; v=foobar; echo \"[${v#*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "dd4225bf0bee4503",
+      "name": "varop matrix: ${v#} (unset)",
+      "script": "set +u; unset v; echo \"[${v#}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "576e8a8beea2805e",
+      "name": "varop matrix: ${v#} (empty)",
+      "script": "set +u; v=; echo \"[${v#}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fbcf2efde37c87ee",
+      "name": "varop matrix: ${v#} (foo)",
+      "script": "set +u; v=foo; echo \"[${v#}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f93392f3ed895c1e",
+      "name": "varop matrix: ${v#} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v#}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "542e51800103540b",
+      "name": "varop matrix: ${v##foo} (unset)",
+      "script": "set +u; unset v; echo \"[${v##foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f99de91a1a725d05",
+      "name": "varop matrix: ${v##foo} (empty)",
+      "script": "set +u; v=; echo \"[${v##foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "69aa8230bcb16403",
+      "name": "varop matrix: ${v##foo} (foo)",
+      "script": "set +u; v=foo; echo \"[${v##foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "d62c6804c0d2eecb",
+      "name": "varop matrix: ${v##foo} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v##foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ea6a49aca7b53e09",
+      "name": "varop matrix: ${v##f*} (unset)",
+      "script": "set +u; unset v; echo \"[${v##f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8a20b059818bdb92",
+      "name": "varop matrix: ${v##f*} (empty)",
+      "script": "set +u; v=; echo \"[${v##f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "2ca5dd5afa31d1e9",
+      "name": "varop matrix: ${v##f*} (foo)",
+      "script": "set +u; v=foo; echo \"[${v##f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "5130505512b1ae7e",
+      "name": "varop matrix: ${v##f*} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v##f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1d18e6b47da9a645",
+      "name": "varop matrix: ${v##bar} (unset)",
+      "script": "set +u; unset v; echo \"[${v##bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9257384da5d07bc8",
+      "name": "varop matrix: ${v##bar} (empty)",
+      "script": "set +u; v=; echo \"[${v##bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "266ac2df9dcf6c76",
+      "name": "varop matrix: ${v##bar} (foo)",
+      "script": "set +u; v=foo; echo \"[${v##bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "33f5fae9f63eac64",
+      "name": "varop matrix: ${v##bar} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v##bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "60a4eb3a44877127",
+      "name": "varop matrix: ${v##*} (unset)",
+      "script": "set +u; unset v; echo \"[${v##*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ceed23da8c8134c1",
+      "name": "varop matrix: ${v##*} (empty)",
+      "script": "set +u; v=; echo \"[${v##*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "192605b629c4bbfc",
+      "name": "varop matrix: ${v##*} (foo)",
+      "script": "set +u; v=foo; echo \"[${v##*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f96e902573c3cda2",
+      "name": "varop matrix: ${v##*} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v##*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9eb461db2ea05053",
+      "name": "varop matrix: ${v##} (unset)",
+      "script": "set +u; unset v; echo \"[${v##}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "aaa954dceb312f9b",
+      "name": "varop matrix: ${v##} (empty)",
+      "script": "set +u; v=; echo \"[${v##}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4f44b8606bcca06f",
+      "name": "varop matrix: ${v##} (foo)",
+      "script": "set +u; v=foo; echo \"[${v##}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "596e625f053a5f53",
+      "name": "varop matrix: ${v##} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v##}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e3eb5cf3fba9d193",
+      "name": "varop matrix: ${v%foo} (unset)",
+      "script": "set +u; unset v; echo \"[${v%foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "08a0a0bf602db55d",
+      "name": "varop matrix: ${v%foo} (empty)",
+      "script": "set +u; v=; echo \"[${v%foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9bffb3dcdf54c207",
+      "name": "varop matrix: ${v%foo} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9dfdc36b43168cf8",
+      "name": "varop matrix: ${v%foo} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e0021ce11921b46a",
+      "name": "varop matrix: ${v%bar} (unset)",
+      "script": "set +u; unset v; echo \"[${v%bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3ea7e95bc4041f41",
+      "name": "varop matrix: ${v%bar} (empty)",
+      "script": "set +u; v=; echo \"[${v%bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c1446834edb63c86",
+      "name": "varop matrix: ${v%bar} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "d38c168021f42eeb",
+      "name": "varop matrix: ${v%bar} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c75095446bc39e5b",
+      "name": "varop matrix: ${v%*r} (unset)",
+      "script": "set +u; unset v; echo \"[${v%*r}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "403d21b8ab5c1045",
+      "name": "varop matrix: ${v%*r} (empty)",
+      "script": "set +u; v=; echo \"[${v%*r}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "25c2263a0e824900",
+      "name": "varop matrix: ${v%*r} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%*r}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f563eef5308d28a2",
+      "name": "varop matrix: ${v%*r} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%*r}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "af0a5c6e7b6b581a",
+      "name": "varop matrix: ${v%*} (unset)",
+      "script": "set +u; unset v; echo \"[${v%*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "51512a3c8e12d3a4",
+      "name": "varop matrix: ${v%*} (empty)",
+      "script": "set +u; v=; echo \"[${v%*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0c5d3d1b5f397860",
+      "name": "varop matrix: ${v%*} (foo)",
+      "opts": {
+        "known_gap": "JustBash shortest #/*/% of * consumes one character; bash's shortest * match is empty so the value is unchanged"
+      },
+      "script": "set +u; v=foo; echo \"[${v%*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fc78f01b29234dc8",
+      "name": "varop matrix: ${v%*} (foobar)",
+      "opts": {
+        "known_gap": "JustBash shortest #/*/% of * consumes one character; bash's shortest * match is empty so the value is unchanged"
+      },
+      "script": "set +u; v=foobar; echo \"[${v%*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "97881f640f8562d7",
+      "name": "varop matrix: ${v%} (unset)",
+      "script": "set +u; unset v; echo \"[${v%}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f845afef09007a85",
+      "name": "varop matrix: ${v%} (empty)",
+      "script": "set +u; v=; echo \"[${v%}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "476d748bc33abf87",
+      "name": "varop matrix: ${v%} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f6815bddf75e23c0",
+      "name": "varop matrix: ${v%} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a4e8bcb427847bcb",
+      "name": "varop matrix: ${v%%foo} (unset)",
+      "script": "set +u; unset v; echo \"[${v%%foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c336b7e9401b962b",
+      "name": "varop matrix: ${v%%foo} (empty)",
+      "script": "set +u; v=; echo \"[${v%%foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a073c5c0f241bad1",
+      "name": "varop matrix: ${v%%foo} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%%foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "6d08f8d3cc4ed570",
+      "name": "varop matrix: ${v%%foo} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%%foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "d5e7779057e4261e",
+      "name": "varop matrix: ${v%%bar} (unset)",
+      "script": "set +u; unset v; echo \"[${v%%bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "36e652f72cc58c9d",
+      "name": "varop matrix: ${v%%bar} (empty)",
+      "script": "set +u; v=; echo \"[${v%%bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "77e0dfa57d72c074",
+      "name": "varop matrix: ${v%%bar} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%%bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f5f549f5b351a417",
+      "name": "varop matrix: ${v%%bar} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%%bar}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "536e069896157e5f",
+      "name": "varop matrix: ${v%%*r} (unset)",
+      "script": "set +u; unset v; echo \"[${v%%*r}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "20a12ce18bcb3188",
+      "name": "varop matrix: ${v%%*r} (empty)",
+      "script": "set +u; v=; echo \"[${v%%*r}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "29a45e03cf63151f",
+      "name": "varop matrix: ${v%%*r} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%%*r}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4146d4b069ac0b29",
+      "name": "varop matrix: ${v%%*r} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%%*r}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "980d92a33ea89e54",
+      "name": "varop matrix: ${v%%*} (unset)",
+      "script": "set +u; unset v; echo \"[${v%%*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3b34b63c26e47fba",
+      "name": "varop matrix: ${v%%*} (empty)",
+      "script": "set +u; v=; echo \"[${v%%*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "dac60e08169d4c47",
+      "name": "varop matrix: ${v%%*} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%%*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "07b0486257603985",
+      "name": "varop matrix: ${v%%*} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%%*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "57f06c3ad4567d17",
+      "name": "varop matrix: ${v%%} (unset)",
+      "script": "set +u; unset v; echo \"[${v%%}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "090972ae3e64a2c8",
+      "name": "varop matrix: ${v%%} (empty)",
+      "script": "set +u; v=; echo \"[${v%%}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8633f9823e056dca",
+      "name": "varop matrix: ${v%%} (foo)",
+      "script": "set +u; v=foo; echo \"[${v%%}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3cb1270765bb9977",
+      "name": "varop matrix: ${v%%} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v%%}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fdf43c9cbed68636",
+      "name": "varop matrix: ${v#f*} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v#f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "fc2c01ac980b87ee",
+      "name": "varop matrix: ${v##f*} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v##f*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a9be89ac6534a241",
+      "name": "varop matrix: ${v#foo*} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v#foo*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f565d373ff2da9b3",
+      "name": "varop matrix: ${v##foo*} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v##foo*}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c20e188cc78504bc",
+      "name": "varop matrix: ${v%*o} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v%*o}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8672db2368491e0c",
+      "name": "varop matrix: ${v%%*o} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v%%*o}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "4f892e317b3d17ff",
+      "name": "varop matrix: ${v%*foo} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v%*foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "dac343f001a55509",
+      "name": "varop matrix: ${v%%*foo} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v%%*foo}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1bd22f65afb31156",
+      "name": "varop matrix: ${v/o/X} (unset)",
+      "script": "set +u; unset v; echo \"[${v/o/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f712fdd5938fc1c7",
+      "name": "varop matrix: ${v/o/X} (empty)",
+      "script": "set +u; v=; echo \"[${v/o/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "09a90cf48833b483",
+      "name": "varop matrix: ${v/o/X} (foo)",
+      "script": "set +u; v=foo; echo \"[${v/o/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "3df9b0b451a367f3",
+      "name": "varop matrix: ${v/o/X} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v/o/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "8bbd1bcacc386d53",
+      "name": "varop matrix: ${v/o/} (unset)",
+      "script": "set +u; unset v; echo \"[${v/o/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "e763d78ac6ae5706",
+      "name": "varop matrix: ${v/o/} (empty)",
+      "script": "set +u; v=; echo \"[${v/o/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9b07c111c2c05c64",
+      "name": "varop matrix: ${v/o/} (foo)",
+      "script": "set +u; v=foo; echo \"[${v/o/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "242e7ee84a4bbfed",
+      "name": "varop matrix: ${v/o/} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v/o/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0da2dcc84d5d3cc4",
+      "name": "varop matrix: ${v/foo/X} (unset)",
+      "script": "set +u; unset v; echo \"[${v/foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "25d508183918c3af",
+      "name": "varop matrix: ${v/foo/X} (empty)",
+      "script": "set +u; v=; echo \"[${v/foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "dce20fadcfa98d9d",
+      "name": "varop matrix: ${v/foo/X} (foo)",
+      "script": "set +u; v=foo; echo \"[${v/foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "6afeb9e958bf3a75",
+      "name": "varop matrix: ${v/foo/X} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v/foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c14686ec25540567",
+      "name": "varop matrix: ${v/bar/X} (unset)",
+      "script": "set +u; unset v; echo \"[${v/bar/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "7db1dd2908f62e36",
+      "name": "varop matrix: ${v/bar/X} (empty)",
+      "script": "set +u; v=; echo \"[${v/bar/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "66edbcf0a2afe5ae",
+      "name": "varop matrix: ${v/bar/X} (foo)",
+      "script": "set +u; v=foo; echo \"[${v/bar/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1cd93358f73bd034",
+      "name": "varop matrix: ${v/bar/X} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v/bar/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f25c8482fa6bba17",
+      "name": "varop matrix: ${v//o/X} (unset)",
+      "script": "set +u; unset v; echo \"[${v//o/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "85ce062c6905af8b",
+      "name": "varop matrix: ${v//o/X} (empty)",
+      "script": "set +u; v=; echo \"[${v//o/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "a47d5c2d18ba000c",
+      "name": "varop matrix: ${v//o/X} (foo)",
+      "script": "set +u; v=foo; echo \"[${v//o/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "161832266f47db6b",
+      "name": "varop matrix: ${v//o/X} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v//o/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "41cf642d7764f0dd",
+      "name": "varop matrix: ${v//o/} (unset)",
+      "script": "set +u; unset v; echo \"[${v//o/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "21008468d8f6e610",
+      "name": "varop matrix: ${v//o/} (empty)",
+      "script": "set +u; v=; echo \"[${v//o/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "10040d958c0c6d84",
+      "name": "varop matrix: ${v//o/} (foo)",
+      "script": "set +u; v=foo; echo \"[${v//o/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "ef7ff9c5247aa96e",
+      "name": "varop matrix: ${v//o/} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v//o/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f04ff74cd37ac1b7",
+      "name": "varop matrix: ${v//foo/X} (unset)",
+      "script": "set +u; unset v; echo \"[${v//foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "394e2baacc9ffa31",
+      "name": "varop matrix: ${v//foo/X} (empty)",
+      "script": "set +u; v=; echo \"[${v//foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "87b0bdaa5dd987f2",
+      "name": "varop matrix: ${v//foo/X} (foo)",
+      "script": "set +u; v=foo; echo \"[${v//foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "da50a048c1f8b6f6",
+      "name": "varop matrix: ${v//foo/X} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v//foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "adc97f11c76318c4",
+      "name": "varop matrix: ${v//bar/X} (unset)",
+      "script": "set +u; unset v; echo \"[${v//bar/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "7ed0ed0e08486ee0",
+      "name": "varop matrix: ${v//bar/X} (empty)",
+      "script": "set +u; v=; echo \"[${v//bar/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "1a7111b5a8c48fc1",
+      "name": "varop matrix: ${v//bar/X} (foo)",
+      "script": "set +u; v=foo; echo \"[${v//bar/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "621bfe00424f9b12",
+      "name": "varop matrix: ${v//bar/X} (foobar)",
+      "script": "set +u; v=foobar; echo \"[${v//bar/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "f4eabe602394edc8",
+      "name": "varop matrix: ${v/foo/X} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v/foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "868ea60f372c7085",
+      "name": "varop matrix: ${v//foo/X} (foofoo)",
+      "script": "set +u; v=foofoo; echo \"[${v//foo/X}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "0c85894fe0b55ba1",
+      "name": "varop matrix: ${v/} (foo)",
+      "script": "set +u; v=foo; echo \"[${v/}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "16437e278cd1e4ef",
+      "name": "varop matrix: ${v//} (foo)",
+      "script": "set +u; v=foo; echo \"[${v//}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "c6c1d89eb92a54c1",
+      "name": "varop matrix: ${v/o} (foo)",
+      "script": "set +u; v=foo; echo \"[${v/o}]\"; echo rc=$?"
+    },
+    {
+      "content_hash": "9b2b75af31a88627",
+      "name": "varop matrix: ${v//o} (foo)",
+      "script": "set +u; v=foo; echo \"[${v//o}]\"; echo rc=$?"
+    }
+  ],
+  "suite": "varop_matrix"
+}

--- a/test/fixtures/bash_expected/varop_matrix.json
+++ b/test/fixtures/bash_expected/varop_matrix.json
@@ -1,0 +1,1895 @@
+{
+  "results": [
+    {
+      "content_hash": "e8d84f47ac46a868",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-1} (unset)",
+      "stderr": "",
+      "stdout": "[1]\nrc=0\n"
+    },
+    {
+      "content_hash": "9fd65e3201eed796",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-1} (empty)",
+      "stderr": "",
+      "stdout": "[1]\nrc=0\n"
+    },
+    {
+      "content_hash": "9317cf807f6d010c",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-1} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "778f8d0079e20a91",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-1} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "23958776ce32c943",
+      "exit_code": 0,
+      "name": "varop matrix: ${v-word} (unset, word)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "9428e1c42530c0ea",
+      "exit_code": 0,
+      "name": "varop matrix: ${v-word} (empty, word)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "6e6cdbc00c09e1e2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v-word} (foo, word)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "2b471b7a34d0e473",
+      "exit_code": 0,
+      "name": "varop matrix: ${v-word} (foobar, word)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "d7aec96a472ab3b2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v-} (unset, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "9b9a802ce10d478f",
+      "exit_code": 0,
+      "name": "varop matrix: ${v-} (empty, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "431f1093e92ef37d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v-} (foo, empty)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "a2bf48364826dc7e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v-} (foobar, empty)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "9261b41b692f2611",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-word} (unset, word)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "fe333ed10bec8470",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-word} (empty, word)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "71fea0b9cb5e56da",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-word} (foo, word)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "9669f7fcdc9eaded",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-word} (foobar, word)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "45ddc02e75af9fb6",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-} (unset, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "0e7eb668bbc8643c",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-} (empty, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "3e9c50a7cb413ad0",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-} (foo, empty)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "2331fdf553aea870",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:-} (foobar, empty)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "be0a3f837efcb32b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v=word} (unset, word)",
+      "stderr": "",
+      "stdout": "[word]\n[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "b6c2dbdae80b0323",
+      "exit_code": 0,
+      "name": "varop matrix: ${v=word} (empty, word)",
+      "stderr": "",
+      "stdout": "[]\n[]\nrc=0\n"
+    },
+    {
+      "content_hash": "b34e46564d13a8ef",
+      "exit_code": 0,
+      "name": "varop matrix: ${v=word} (foo, word)",
+      "stderr": "",
+      "stdout": "[foo]\n[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "4f24d9c63e68356a",
+      "exit_code": 0,
+      "name": "varop matrix: ${v=word} (foobar, word)",
+      "stderr": "",
+      "stdout": "[foobar]\n[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "8019cf4d56f0dcf3",
+      "exit_code": 0,
+      "name": "varop matrix: ${v=} (unset, empty)",
+      "stderr": "",
+      "stdout": "[]\n[]\nrc=0\n"
+    },
+    {
+      "content_hash": "4b46a7db16cbbb31",
+      "exit_code": 0,
+      "name": "varop matrix: ${v=} (empty, empty)",
+      "stderr": "",
+      "stdout": "[]\n[]\nrc=0\n"
+    },
+    {
+      "content_hash": "dc0853403d45587e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v=} (foo, empty)",
+      "stderr": "",
+      "stdout": "[foo]\n[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "1a33ce9aac478d73",
+      "exit_code": 0,
+      "name": "varop matrix: ${v=} (foobar, empty)",
+      "stderr": "",
+      "stdout": "[foobar]\n[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "c7f7a0c5f4149edc",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:=word} (unset, word)",
+      "stderr": "",
+      "stdout": "[word]\n[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "c859998a0592891c",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:=word} (empty, word)",
+      "stderr": "",
+      "stdout": "[word]\n[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "aca1add05289ecb6",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:=word} (foo, word)",
+      "stderr": "",
+      "stdout": "[foo]\n[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "4db3fb1b31536c31",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:=word} (foobar, word)",
+      "stderr": "",
+      "stdout": "[foobar]\n[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "64d8527906cd72df",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:=} (unset, empty)",
+      "stderr": "",
+      "stdout": "[]\n[]\nrc=0\n"
+    },
+    {
+      "content_hash": "c25477eb6795346d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:=} (empty, empty)",
+      "stderr": "",
+      "stdout": "[]\n[]\nrc=0\n"
+    },
+    {
+      "content_hash": "1c4b16b105a44495",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:=} (foo, empty)",
+      "stderr": "",
+      "stdout": "[foo]\n[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "94baaa18f7797396",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:=} (foobar, empty)",
+      "stderr": "",
+      "stdout": "[foobar]\n[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "924c2fce828fbd21",
+      "exit_code": 0,
+      "name": "varop matrix: ${v+word} (unset, word)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a5226a7e7dd6adfa",
+      "exit_code": 0,
+      "name": "varop matrix: ${v+word} (empty, word)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "cf01c326697f9f50",
+      "exit_code": 0,
+      "name": "varop matrix: ${v+word} (foo, word)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "e0c8fd9f239c6270",
+      "exit_code": 0,
+      "name": "varop matrix: ${v+word} (foobar, word)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "cae76e7eeafec0a3",
+      "exit_code": 0,
+      "name": "varop matrix: ${v+} (unset, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "7d09190b2abdd785",
+      "exit_code": 0,
+      "name": "varop matrix: ${v+} (empty, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "775a34a9af6bd853",
+      "exit_code": 0,
+      "name": "varop matrix: ${v+} (foo, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "f385e501c3f5441f",
+      "exit_code": 0,
+      "name": "varop matrix: ${v+} (foobar, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "3c266f5a1fd043b5",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:+word} (unset, word)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "f6b7c6e1381e5b63",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:+word} (empty, word)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "e77c691611228480",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:+word} (foo, word)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "450426a459a41467",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:+word} (foobar, word)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "327a91b1e326974a",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:+} (unset, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a742d7b1fee298e2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:+} (empty, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "111ab251f6056594",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:+} (foo, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "bec2203f40e0127e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:+} (foobar, empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "65a37da8dbd9e560",
+      "exit_code": 127,
+      "name": "varop matrix: ${v?word} (unset, word)",
+      "stderr": "bash: line 1: v: word\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "2496f2b2515400e4",
+      "exit_code": 0,
+      "name": "varop matrix: ${v?word} (empty, word)",
+      "stderr": "",
+      "stdout": "[]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "afb21a25a75e3a1a",
+      "exit_code": 0,
+      "name": "varop matrix: ${v?word} (foo, word)",
+      "stderr": "",
+      "stdout": "[foo]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "63f9a5bd76ff6b91",
+      "exit_code": 0,
+      "name": "varop matrix: ${v?word} (foobar, word)",
+      "stderr": "",
+      "stdout": "[foobar]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "5cbcf5f47770bffc",
+      "exit_code": 127,
+      "name": "varop matrix: ${v?} (unset, empty)",
+      "stderr": "bash: line 1: v: parameter not set\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "f74b894c96136fce",
+      "exit_code": 0,
+      "name": "varop matrix: ${v?} (empty, empty)",
+      "stderr": "",
+      "stdout": "[]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "579c538bc9bc5753",
+      "exit_code": 0,
+      "name": "varop matrix: ${v?} (foo, empty)",
+      "stderr": "",
+      "stdout": "[foo]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "a61267d7211fbc76",
+      "exit_code": 0,
+      "name": "varop matrix: ${v?} (foobar, empty)",
+      "stderr": "",
+      "stdout": "[foobar]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "a236e6b73a4950a5",
+      "exit_code": 127,
+      "name": "varop matrix: ${v:?word} (unset, word)",
+      "stderr": "bash: line 1: v: word\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "7952b8c22a73b086",
+      "exit_code": 127,
+      "name": "varop matrix: ${v:?word} (empty, word)",
+      "stderr": "bash: line 1: v: word\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "619d98676c666a77",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:?word} (foo, word)",
+      "stderr": "",
+      "stdout": "[foo]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "6774c3a35ceb6fcb",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:?word} (foobar, word)",
+      "stderr": "",
+      "stdout": "[foobar]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "54bb680964a03e86",
+      "exit_code": 127,
+      "name": "varop matrix: ${v:?} (unset, empty)",
+      "stderr": "bash: line 1: v: parameter null or not set\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "bc3e2f3135362669",
+      "exit_code": 127,
+      "name": "varop matrix: ${v:?} (empty, empty)",
+      "stderr": "bash: line 1: v: parameter null or not set\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "ccd08f8ca5f63069",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:?} (foo, empty)",
+      "stderr": "",
+      "stdout": "[foo]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "b56e8edf3d71f353",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:?} (foobar, empty)",
+      "stderr": "",
+      "stdout": "[foobar]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "de35c240a2f395e5",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v-word} (unset)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "32b60682dee4c9dd",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v-word} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "39769032586567b2",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v:-word} (unset)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "36283dc6c5ffd527",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v:-word} (empty)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "f01d8d211fc1a36b",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v=word} (unset)",
+      "stderr": "",
+      "stdout": "[word]\n[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "da9590195e27257f",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v=word} (empty)",
+      "stderr": "",
+      "stdout": "[]\n[]\nrc=0\n"
+    },
+    {
+      "content_hash": "fdb7e488cb562d54",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v:=word} (unset)",
+      "stderr": "",
+      "stdout": "[word]\n[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "dade6d948f229b31",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v:=word} (empty)",
+      "stderr": "",
+      "stdout": "[word]\n[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "b36bc64cfc644221",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v+word} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "2d6c5f73d3caabcd",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v+word} (empty)",
+      "stderr": "",
+      "stdout": "[word]\nrc=0\n"
+    },
+    {
+      "content_hash": "7240cde0183b05f2",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v:+word} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "36798059419fd814",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v:+word} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "073da5ce458d0bf7",
+      "exit_code": 127,
+      "name": "varop matrix: set -u ${v?word} (unset)",
+      "stderr": "bash: line 1: v: word\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "dfaad0cee53f94b1",
+      "exit_code": 0,
+      "name": "varop matrix: set -u ${v?word} (empty)",
+      "stderr": "",
+      "stdout": "[]\nafter\nrc=0\n"
+    },
+    {
+      "content_hash": "5bfa3380fef546d9",
+      "exit_code": 127,
+      "name": "varop matrix: set -u ${v:?word} (unset)",
+      "stderr": "bash: line 1: v: word\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "60762b0fd9eae924",
+      "exit_code": 127,
+      "name": "varop matrix: set -u ${v:?word} (empty)",
+      "stderr": "bash: line 1: v: word\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "ad5dab775b0b5590",
+      "exit_code": 127,
+      "name": "varop matrix: set -u ${#v} (unset)",
+      "stderr": "bash: line 1: v: unbound variable\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "29be4b20eec6a6eb",
+      "exit_code": 127,
+      "name": "varop matrix: set -u ${v:0} (unset)",
+      "stderr": "bash: line 1: v: unbound variable\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "a481f53d9e7b9ecd",
+      "exit_code": 127,
+      "name": "varop matrix: set -u ${v#x} (unset)",
+      "stderr": "bash: line 1: v: unbound variable\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "46da344ce21ec60e",
+      "exit_code": 127,
+      "name": "varop matrix: set -u ${v/x/y} (unset)",
+      "stderr": "bash: line 1: v: unbound variable\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "71aaa2a58947df8b",
+      "exit_code": 0,
+      "name": "varop matrix: ${#v} (unset)",
+      "stderr": "",
+      "stdout": "[0]\nrc=0\n"
+    },
+    {
+      "content_hash": "3c93fe95c75a0f55",
+      "exit_code": 0,
+      "name": "varop matrix: ${#v} (empty)",
+      "stderr": "",
+      "stdout": "[0]\nrc=0\n"
+    },
+    {
+      "content_hash": "f49aee16bef187db",
+      "exit_code": 0,
+      "name": "varop matrix: ${#v} (foo)",
+      "stderr": "",
+      "stdout": "[3]\nrc=0\n"
+    },
+    {
+      "content_hash": "22bea81097a846ed",
+      "exit_code": 0,
+      "name": "varop matrix: ${#v} (foobar)",
+      "stderr": "",
+      "stdout": "[6]\nrc=0\n"
+    },
+    {
+      "content_hash": "3a58efedb99dd94b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "579660560b7e2eee",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a48273b5ffab90da",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "f86302f756c5d459",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "5bc66020ae307108",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a48e28d365ca930b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "f668c46f5070d2fb",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1} (foo)",
+      "stderr": "",
+      "stdout": "[oo]\nrc=0\n"
+    },
+    {
+      "content_hash": "3c818d44016810dc",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1} (foobar)",
+      "stderr": "",
+      "stdout": "[oobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "e465ca7123784d18",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:3} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "01a58c54f153bcdb",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:3} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "5101ac255f09d506",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:3} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "1cfe0cb916dfa7d6",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:3} (foobar)",
+      "stderr": "",
+      "stdout": "[bar]\nrc=0\n"
+    },
+    {
+      "content_hash": "c8608020b2f25b8f",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:6} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "028480c1b09d05dd",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:6} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "68cb2ac7de63fc86",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:6} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "ecc637f652dbe132",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:6} (foobar)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "b83e2e374e731c7d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -1} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "fab14cd86b74fbc8",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -1} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "479a20aee2b8c504",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -1} (foo)",
+      "stderr": "",
+      "stdout": "[o]\nrc=0\n"
+    },
+    {
+      "content_hash": "0565124e45a410e2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -1} (foobar)",
+      "stderr": "",
+      "stdout": "[r]\nrc=0\n"
+    },
+    {
+      "content_hash": "1b9f2207a6b35e52",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -3} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "88b90f7a46248ab3",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -3} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "7597947e2420406c",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -3} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "5b42cf4f3e0f2623",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -3} (foobar)",
+      "stderr": "",
+      "stdout": "[bar]\nrc=0\n"
+    },
+    {
+      "content_hash": "07cebb5f3cf752db",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0:0} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "2cc193fa18e3f35c",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0:0} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "beec8978b86ae9c3",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0:0} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "8d56cbc8516b0cc3",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0:0} (foobar)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "904039a61554a223",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1:2} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a8458f5d4f73e4ba",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1:2} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "1a5b26637768e62a",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1:2} (foo)",
+      "stderr": "",
+      "stdout": "[oo]\nrc=0\n"
+    },
+    {
+      "content_hash": "086ff63a291a04b4",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1:2} (foobar)",
+      "stderr": "",
+      "stdout": "[oo]\nrc=0\n"
+    },
+    {
+      "content_hash": "ddd3c3482e3e25ba",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1:3} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "ffdc70d344349d9d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1:3} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "2660c2afc18256cb",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1:3} (foo)",
+      "stderr": "",
+      "stdout": "[oo]\nrc=0\n"
+    },
+    {
+      "content_hash": "cacacd5a060217bc",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:1:3} (foobar)",
+      "stderr": "",
+      "stdout": "[oob]\nrc=0\n"
+    },
+    {
+      "content_hash": "b2c5080813d761a0",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:3:2} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "4d7a9c4fa625781e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:3:2} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "d55d6779a0c6a23f",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:3:2} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "ebc019835437a18e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:3:2} (foobar)",
+      "stderr": "",
+      "stdout": "[ba]\nrc=0\n"
+    },
+    {
+      "content_hash": "74226759fe70de4d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -2:1} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "4c8de583a1af59b6",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -2:1} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a3362807f17747c6",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -2:1} (foo)",
+      "stderr": "",
+      "stdout": "[o]\nrc=0\n"
+    },
+    {
+      "content_hash": "a091d8b7775e7cfc",
+      "exit_code": 0,
+      "name": "varop matrix: ${v: -2:1} (foobar)",
+      "stderr": "",
+      "stdout": "[a]\nrc=0\n"
+    },
+    {
+      "content_hash": "7a275f0640e8310e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0:-1} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "27d8938db69fecfa",
+      "exit_code": 1,
+      "name": "varop matrix: ${v:0:-1} (empty)",
+      "stderr": "bash: line 1: -1: substring expression < 0\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "95c78ea4950c8406",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0:-1} (foo)",
+      "stderr": "",
+      "stdout": "[fo]\nrc=0\n"
+    },
+    {
+      "content_hash": "2e6390107969d95d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v:0:-1} (foobar)",
+      "stderr": "",
+      "stdout": "[fooba]\nrc=0\n"
+    },
+    {
+      "content_hash": "9760eaa73a898cd4",
+      "exit_code": 0,
+      "name": "varop matrix: ${v::2} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "1f05504309640337",
+      "exit_code": 0,
+      "name": "varop matrix: ${v::2} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "f4248d793abb49ea",
+      "exit_code": 0,
+      "name": "varop matrix: ${v::2} (foo)",
+      "stderr": "",
+      "stdout": "[fo]\nrc=0\n"
+    },
+    {
+      "content_hash": "f8348c981aff44d7",
+      "exit_code": 0,
+      "name": "varop matrix: ${v::2} (foobar)",
+      "stderr": "",
+      "stdout": "[fo]\nrc=0\n"
+    },
+    {
+      "content_hash": "63ba2c810c935aa6",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#foo} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "c16dc8d99396113a",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#foo} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "74aef8b513a36472",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#foo} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "700f2cf68ff5bf9a",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#foo} (foobar)",
+      "stderr": "",
+      "stdout": "[bar]\nrc=0\n"
+    },
+    {
+      "content_hash": "995ef9d1b3b05be4",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#f*} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "4c80c201bcffcde5",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#f*} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "9c3c22cb12dc1e0d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#f*} (foo)",
+      "stderr": "",
+      "stdout": "[oo]\nrc=0\n"
+    },
+    {
+      "content_hash": "29b65f0ce7edef37",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#f*} (foobar)",
+      "stderr": "",
+      "stdout": "[oobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "bf608d76be23a2d9",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#bar} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "81a602079a751cc2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#bar} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "75f4f1790e78ad9b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#bar} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "3294b498bf6a7ed4",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#bar} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "62e77b7ad3af63c2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#*} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "e9bd2cacc9d54314",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#*} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "8445492401cde5c3",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#*} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "f6bb59d2bcdab7c7",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#*} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "dd4225bf0bee4503",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "576e8a8beea2805e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "fbcf2efde37c87ee",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "f93392f3ed895c1e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "542e51800103540b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##foo} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "f99de91a1a725d05",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##foo} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "69aa8230bcb16403",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##foo} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "d62c6804c0d2eecb",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##foo} (foobar)",
+      "stderr": "",
+      "stdout": "[bar]\nrc=0\n"
+    },
+    {
+      "content_hash": "ea6a49aca7b53e09",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##f*} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "8a20b059818bdb92",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##f*} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "2ca5dd5afa31d1e9",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##f*} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "5130505512b1ae7e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##f*} (foobar)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "1d18e6b47da9a645",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##bar} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "9257384da5d07bc8",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##bar} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "266ac2df9dcf6c76",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##bar} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "33f5fae9f63eac64",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##bar} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "60a4eb3a44877127",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##*} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "ceed23da8c8134c1",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##*} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "192605b629c4bbfc",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##*} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "f96e902573c3cda2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##*} (foobar)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "9eb461db2ea05053",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "aaa954dceb312f9b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "4f44b8606bcca06f",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "596e625f053a5f53",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "e3eb5cf3fba9d193",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%foo} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "08a0a0bf602db55d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%foo} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "9bffb3dcdf54c207",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%foo} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "9dfdc36b43168cf8",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%foo} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "e0021ce11921b46a",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%bar} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "3ea7e95bc4041f41",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%bar} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "c1446834edb63c86",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%bar} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "d38c168021f42eeb",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%bar} (foobar)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "c75095446bc39e5b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*r} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "403d21b8ab5c1045",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*r} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "25c2263a0e824900",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*r} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "f563eef5308d28a2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*r} (foobar)",
+      "stderr": "",
+      "stdout": "[fooba]\nrc=0\n"
+    },
+    {
+      "content_hash": "af0a5c6e7b6b581a",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "51512a3c8e12d3a4",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "0c5d3d1b5f397860",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "fc78f01b29234dc8",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "97881f640f8562d7",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "f845afef09007a85",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "476d748bc33abf87",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "f6815bddf75e23c0",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "a4e8bcb427847bcb",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%foo} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "c336b7e9401b962b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%foo} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a073c5c0f241bad1",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%foo} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "6d08f8d3cc4ed570",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%foo} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "d5e7779057e4261e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%bar} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "36e652f72cc58c9d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%bar} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "77e0dfa57d72c074",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%bar} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "f5f549f5b351a417",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%bar} (foobar)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "536e069896157e5f",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*r} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "20a12ce18bcb3188",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*r} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "29a45e03cf63151f",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*r} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "4146d4b069ac0b29",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*r} (foobar)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "980d92a33ea89e54",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "3b34b63c26e47fba",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "dac60e08169d4c47",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*} (foo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "07b0486257603985",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*} (foobar)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "57f06c3ad4567d17",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "090972ae3e64a2c8",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "8633f9823e056dca",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "3cb1270765bb9977",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%} (foobar)",
+      "stderr": "",
+      "stdout": "[foobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "fdf43c9cbed68636",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#f*} (foofoo)",
+      "stderr": "",
+      "stdout": "[oofoo]\nrc=0\n"
+    },
+    {
+      "content_hash": "fc2c01ac980b87ee",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##f*} (foofoo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a9be89ac6534a241",
+      "exit_code": 0,
+      "name": "varop matrix: ${v#foo*} (foofoo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "f565d373ff2da9b3",
+      "exit_code": 0,
+      "name": "varop matrix: ${v##foo*} (foofoo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "c20e188cc78504bc",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*o} (foofoo)",
+      "stderr": "",
+      "stdout": "[foofo]\nrc=0\n"
+    },
+    {
+      "content_hash": "8672db2368491e0c",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*o} (foofoo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "4f892e317b3d17ff",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%*foo} (foofoo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "dac343f001a55509",
+      "exit_code": 0,
+      "name": "varop matrix: ${v%%*foo} (foofoo)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "1bd22f65afb31156",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o/X} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "f712fdd5938fc1c7",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o/X} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "09a90cf48833b483",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o/X} (foo)",
+      "stderr": "",
+      "stdout": "[fXo]\nrc=0\n"
+    },
+    {
+      "content_hash": "3df9b0b451a367f3",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o/X} (foobar)",
+      "stderr": "",
+      "stdout": "[fXobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "8bbd1bcacc386d53",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o/} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "e763d78ac6ae5706",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o/} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "9b07c111c2c05c64",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o/} (foo)",
+      "stderr": "",
+      "stdout": "[fo]\nrc=0\n"
+    },
+    {
+      "content_hash": "242e7ee84a4bbfed",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o/} (foobar)",
+      "stderr": "",
+      "stdout": "[fobar]\nrc=0\n"
+    },
+    {
+      "content_hash": "0da2dcc84d5d3cc4",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/foo/X} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "25d508183918c3af",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/foo/X} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "dce20fadcfa98d9d",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/foo/X} (foo)",
+      "stderr": "",
+      "stdout": "[X]\nrc=0\n"
+    },
+    {
+      "content_hash": "6afeb9e958bf3a75",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/foo/X} (foobar)",
+      "stderr": "",
+      "stdout": "[Xbar]\nrc=0\n"
+    },
+    {
+      "content_hash": "c14686ec25540567",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/bar/X} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "7db1dd2908f62e36",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/bar/X} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "66edbcf0a2afe5ae",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/bar/X} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "1cd93358f73bd034",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/bar/X} (foobar)",
+      "stderr": "",
+      "stdout": "[fooX]\nrc=0\n"
+    },
+    {
+      "content_hash": "f25c8482fa6bba17",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o/X} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "85ce062c6905af8b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o/X} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "a47d5c2d18ba000c",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o/X} (foo)",
+      "stderr": "",
+      "stdout": "[fXX]\nrc=0\n"
+    },
+    {
+      "content_hash": "161832266f47db6b",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o/X} (foobar)",
+      "stderr": "",
+      "stdout": "[fXXbar]\nrc=0\n"
+    },
+    {
+      "content_hash": "41cf642d7764f0dd",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o/} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "21008468d8f6e610",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o/} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "10040d958c0c6d84",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o/} (foo)",
+      "stderr": "",
+      "stdout": "[f]\nrc=0\n"
+    },
+    {
+      "content_hash": "ef7ff9c5247aa96e",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o/} (foobar)",
+      "stderr": "",
+      "stdout": "[fbar]\nrc=0\n"
+    },
+    {
+      "content_hash": "f04ff74cd37ac1b7",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//foo/X} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "394e2baacc9ffa31",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//foo/X} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "87b0bdaa5dd987f2",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//foo/X} (foo)",
+      "stderr": "",
+      "stdout": "[X]\nrc=0\n"
+    },
+    {
+      "content_hash": "da50a048c1f8b6f6",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//foo/X} (foobar)",
+      "stderr": "",
+      "stdout": "[Xbar]\nrc=0\n"
+    },
+    {
+      "content_hash": "adc97f11c76318c4",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//bar/X} (unset)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "7ed0ed0e08486ee0",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//bar/X} (empty)",
+      "stderr": "",
+      "stdout": "[]\nrc=0\n"
+    },
+    {
+      "content_hash": "1a7111b5a8c48fc1",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//bar/X} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "621bfe00424f9b12",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//bar/X} (foobar)",
+      "stderr": "",
+      "stdout": "[fooX]\nrc=0\n"
+    },
+    {
+      "content_hash": "f4eabe602394edc8",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/foo/X} (foofoo)",
+      "stderr": "",
+      "stdout": "[Xfoo]\nrc=0\n"
+    },
+    {
+      "content_hash": "868ea60f372c7085",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//foo/X} (foofoo)",
+      "stderr": "",
+      "stdout": "[XX]\nrc=0\n"
+    },
+    {
+      "content_hash": "0c85894fe0b55ba1",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "16437e278cd1e4ef",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//} (foo)",
+      "stderr": "",
+      "stdout": "[foo]\nrc=0\n"
+    },
+    {
+      "content_hash": "c6c1d89eb92a54c1",
+      "exit_code": 0,
+      "name": "varop matrix: ${v/o} (foo)",
+      "stderr": "",
+      "stdout": "[fo]\nrc=0\n"
+    },
+    {
+      "content_hash": "9b2b75af31a88627",
+      "exit_code": 0,
+      "name": "varop matrix: ${v//o} (foo)",
+      "stderr": "",
+      "stdout": "[f]\nrc=0\n"
+    }
+  ],
+  "suite": "varop_matrix"
+}

--- a/test/mix/tasks/bash_fixtures_gen_test.exs
+++ b/test/mix/tasks/bash_fixtures_gen_test.exs
@@ -138,6 +138,96 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
     end
   end
 
+  describe "varop matrix" do
+    test "enumerates every ${var op word} form, not a sample" do
+      cases = Gen.cases_for("varop")
+      names = Enum.map(cases, & &1["name"])
+
+      assert length(cases) > 150
+
+      for op <- ["-", ":-", "=", ":=", "+", ":+", "?", ":?"] do
+        fragment = "${" <> "v#{op}"
+
+        assert Enum.any?(names, &String.contains?(&1, fragment)),
+               "missing word-op #{fragment}"
+      end
+
+      for op <- ["#", "##", "%", "%%"] do
+        fragment = "${" <> "v#{op}"
+
+        assert Enum.any?(names, &String.contains?(&1, fragment)),
+               "missing removal #{fragment}"
+      end
+
+      assert Enum.any?(names, &String.contains?(&1, ~S|${#v}|))
+      assert Enum.any?(names, &String.contains?(&1, ~S|${v:3}|))
+      assert Enum.any?(names, &String.contains?(&1, ~S|${v:1:3}|))
+      assert Enum.any?(names, &String.contains?(&1, ~S|${v/o/X}|))
+      assert Enum.any?(names, &String.contains?(&1, ~S|${v//o/X}|))
+    end
+
+    test "uses two or more bases so prefix/suffix and offset cannot hide" do
+      names = Gen.cases_for("varop") |> Enum.map(& &1["name"])
+
+      for fragment <- [
+            ~S|${v-word} (unset|,
+            ~S|${v-word} (empty|,
+            ~S|${v-word} (foo|,
+            ~S|${v-word} (foobar|,
+            ~S|${v-} (unset|,
+            ~S|${v:3} (foo)|,
+            ~S|${v:3} (foobar)|,
+            ~S|${v#f*} (foo)|,
+            ~S|${v#f*} (foobar)|,
+            ~S|${v##f*} (foofoo)|,
+            ~S|${v//foo/X} (foofoo)|
+          ] do
+        assert Enum.any?(names, &String.contains?(&1, fragment)),
+               "missing #{fragment}"
+      end
+    end
+
+    test "quotes expansions and is explicit about set +u vs unset" do
+      cases = Gen.cases_for("varop")
+
+      assert Enum.any?(cases, fn test_case ->
+               String.contains?(test_case["script"], ~S|"[${v-word}]"|) and
+                 String.contains?(test_case["script"], "set +u") and
+                 String.contains?(test_case["script"], "unset v")
+             end)
+
+      assert Enum.any?(cases, fn test_case ->
+               String.contains?(test_case["name"], ~S|set -u ${v-word}|) and
+                 String.contains?(test_case["script"], "set -u")
+             end)
+    end
+
+    test "every case hashes from its script, not its name or gap" do
+      cases = Gen.cases_for("varop")
+
+      Enum.each(cases, fn test_case ->
+        assert test_case["content_hash"] == JustBash.Fixtures.hash_case(test_case)
+      end)
+    end
+
+    test "known_gap lives in opts and does not change the digest" do
+      cases = Gen.cases_for("varop")
+      gapped = Enum.filter(cases, &get_in(&1, ["opts", "known_gap"]))
+
+      assert length(gapped) > 10
+      assert length(gapped) < length(cases)
+
+      Enum.each(gapped, fn test_case ->
+        reason = test_case["opts"]["known_gap"]
+        assert is_binary(reason)
+        assert String.length(reason) > 10
+
+        assert JustBash.Fixtures.hash_case(test_case) ==
+                 JustBash.Fixtures.hash_case(Map.delete(test_case, "opts"))
+      end)
+    end
+  end
+
   describe "run/1" do
     test "printf --dry-run reports a count and writes nothing" do
       output =
@@ -156,6 +246,16 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
         end)
 
       assert output =~ ~r/test_matrix: \d+ cases/
+      refute output =~ "wrote"
+    end
+
+    test "varop --dry-run reports a count and writes nothing" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Task.rerun("bash_fixtures.gen", ["varop", "--dry-run"])
+        end)
+
+      assert output =~ ~r/varop_matrix: \d+ cases/
       refute output =~ "wrote"
     end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #70 item 2 for **`${var op word}` parameter expansion only**: a generated `varop_matrix` suite in the same generate / record / test path as `date_matrix`, `printf_matrix`, and `test_matrix`.

This is not the item-3 filesystem-shape × command cube, Oils activation, or CI topology.

## What was enumerated

`mix bash_fixtures.gen varop` writes **270** cases. Suite name is `varop_matrix` (not `param_matrix`, to keep it distinct from the hand-written `parameter_expansion` suite).

- Word-taking operators: `-` `:-` `=` `:=` `+` `:+` `?` `:?` × unset / set-empty / `foo` / `foobar` × nonempty vs empty word
- `${v:-1}` next to `${v: -1}` so a parser cannot hide the colon/space distinction behind `word`
- Length `${#v}` at the same four states
- Substring `${v:offset}` / `${v:offset:len}` including `:3` (empty vs `bar`), `:1:3`, `: -N`, `::2`, `:0:-1`
- Prefix/suffix `#` `##` `%` `%%` × literal / glob / empty pattern, plus `foofoo` where shortest vs longest actually splits
- Replacement `/` `//` × first-vs-all (`o` occurs twice), match vs miss, delete, empty-pattern forms, and `foofoo` for first vs all of `foo`
- `set -u` cells so unset-safe word-ops stay recorded next to `${#v}` / substring / removal / replacement, which bash still treats as unbound
- Every expansion is double-quoted (`echo "[${v-word}]"`); `set +u` is explicit except the nounset cells

`mix bash_fixtures.gen varop --dry-run` reports `varop_matrix: 270 cases`. `mix bash_fixtures.gen` now generates date, printf, test, and varop.

## Recording

Docker was not available on the agent VM. Oracle output was recorded with the same `test/fixtures/runner.sh` the Docker task runs, under GNU bash 5.2.21 / Ubuntu 24.04 (uid `ubuntu`, not root), then pretty-printed through `Mix.Tasks.BashFixtures.write_json!/2`:

```bash
mix bash_fixtures.gen varop
bash test/fixtures/runner.sh < test/fixtures/bash_cases/varop_matrix.json > /tmp/varop_matrix_raw.json
# then Jason-pretty-print + Fixtures.validate, as `mix bash_fixtures` does
```

To re-record through Docker when it is available:

```bash
mix bash_fixtures varop_matrix
```

## Known gaps (18 of 270)

No cell was omitted. Divergences are `opts.known_gap` (excluded from the digest). The fixture runner still executes them with the assertion inverted.

| Count | Reason |
|------:|--------|
| 9 | `${v?}` / `${v:?}` returns empty and continues; bash writes a diagnostic and aborts |
| 4 | `set -u` on `${#v}` / `${v:0}` / `${v#x}` / `${v/x/y}` of unset: JustBash treats empty; bash errors unbound variable |
| 4 | Shortest `#*` / `%*` consumes one character; bash's shortest `*` match is empty so the value is unchanged |
| 1 | `${v:0:-1}` on empty is empty at exit 0; bash errors `substring expression < 0` |

Matching siblings are left unmarked (for example `${v?}` on a set value, `${v##*}`, `${v:0:-1}` on `foo`).

JustBash.exec/2 did not raise on any cell. No expansion implementation bugs were fixed in this PR — it is the enumeration + harness.

## Cheap follow-ups the matrix now makes un-skippable

- `${v?}` / `${v:?}` should write the diagnostic and abort
- `set -u` should error on `${#unset}` / `${unset:offset}` / `${unset#pat}` / `${unset/pat}`
- Shortest `#*` / `%*` should match the empty string
- Negative substring length on an empty value should be a diagnostic, not silent empty

Not in this PR: the item-3 FS-shape × command cube, Oils activation, CI topology changes.

## Tests

All local quality gates passed:

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict` (only the existing intentional `banned_fixture_apply` finding)
- `mix dialyzer` (zero new errors)
- `mix test` — 6622 tests, 0 failures
- `mix bash_fixtures.gen varop --dry-run` — `varop_matrix: 270 cases`

## Related Issues
Related to #70 (item 2, `${var op word}` only; not closing the issue)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Added new tests
- [x] All existing tests pass
- [x] Tested manually (`mix bash_fixtures.gen varop --dry-run`, local runner.sh recording, JustBash vs oracle classification)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md (for non-trivial changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3cb4d36-2c47-4c76-9d16-a033890e2435?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3cb4d36-2c47-4c76-9d16-a033890e2435&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

