### PR TITLE
Add Registry-wide unknown-flag probe (`mix bash_fixtures.gen flags`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `mix bash_fixtures.gen printf` enumerates a printf conversion × flag/width/precision matrix (`printf_matrix`) — #70 item 2
 * `mix bash_fixtures.gen test` enumerates a `test`/`[` operator × revealing-shape matrix (`test_matrix`) — #70 item 2
 * `mix bash_fixtures.gen varop` enumerates a `${var op word}` parameter-expansion matrix (`varop_matrix`) — #70 item 2
+* `mix bash_fixtures.gen flags` enumerates a Registry-wide unknown-flag probe (`flags_matrix`) — #70 item 2
 
 ### Bug Fixes
 

--- a/lib/mix/tasks/bash_fixtures.gen.ex
+++ b/lib/mix/tasks/bash_fixtures.gen.ex
@@ -29,6 +29,10 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       mix bash_fixtures varop_matrix   # record what real bash does
       mix test --only suite:varop_matrix
 
+      mix bash_fixtures.gen flags      # write the matrix
+      mix bash_fixtures flags_matrix   # record what real bash does
+      mix test --only suite:flags_matrix
+
   Generated suites are named `<matrix>_matrix` and are safe to regenerate: the
   digest in `JustBash.Fixtures` is content-derived, so a case that did not change
   keeps its recording.
@@ -61,6 +65,15 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       plus `foofoo` where shortest vs longest or first vs all would otherwise
       hide) so one value cannot hide the bug. Suite `varop_matrix`. See #70
       item 2.
+    * `flags` — `cmd --jb-not-a-flag` and `cmd -Z` for every name in
+      `Commands.Registry`. The default assertion is non-zero exit and
+      usage-bearing stderr (never exit 0). Commands that legitimately treat
+      the token as an operand (`echo`), accept GNU `-Z` (SELinux, `diff -Z`,
+      `grep -Z`, `curl -Z`), or have no GNU twin (`markdown`/`md`) are still
+      generated and named with a reason — never silently omitted. Suite
+      `flags_matrix`. This is the registry-wide unknown-flag probe from #70
+      item 2; `unknown_flags_test.exs` keeps the FlagParser unit tests from
+      #68 rather than a second classification table.
 
   A list of conversions and a list of flags are each easy to write down. The
   cross of the two is where the bugs live and is what nobody enumerates by hand:
@@ -75,17 +88,19 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       mix bash_fixtures.gen printf       # one matrix
       mix bash_fixtures.gen test         # one matrix
       mix bash_fixtures.gen varop        # one matrix
+      mix bash_fixtures.gen flags        # one matrix
       mix bash_fixtures.gen --dry-run    # report counts, write nothing
   """
 
   use Mix.Task
 
+  alias JustBash.Commands.Registry
   alias JustBash.Fixtures
   alias Mix.Tasks.BashFixtures
 
   @shortdoc "Generate enumerated fixture matrices"
 
-  @matrices ["date", "printf", "test", "varop"]
+  @matrices ["date", "printf", "test", "varop", "flags"]
 
   @doc false
   def cases_for(name), do: build(name)
@@ -408,6 +423,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
   defp build("printf"), do: printf_cases()
   defp build("test"), do: test_cases()
   defp build("varop"), do: varop_cases()
+  defp build("flags"), do: flags_cases()
 
   defp date_cases do
     Enum.concat([
@@ -1880,6 +1896,284 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       name in @shortest_star_names -> @shortest_star_gap
       true -> nil
     end
+  end
+
+  # ---------------------------------------------------------------------------
+  # flags — registry-wide unknown-flag probe
+  #
+  # The alphabet is every name in Commands.Registry × {--jb-not-a-flag, -Z}.
+  # A new Registry command must be classified below or `mix bash_fixtures.gen
+  # flags` fails — the same completeness rule as end_of_options_test.exs.
+  #
+  # The probe's default claim is "non-zero exit, usage-bearing stderr, never
+  # exit 0". Commands that legitimately treat the token as data, accept GNU
+  # `-Z`, or have no twin are still generated; the reason lives here so an
+  # omit cannot hide as a pass.
+  #
+  # Gaps are assigned after recording, never by omitting a cell. Marking a
+  # gap must not change the digest — the reason lives in opts.
+  # ---------------------------------------------------------------------------
+
+  @flags_probes ["--jb-not-a-flag", "-Z"]
+
+  # Every Registry name. The value is why this command is classified rather
+  # than omitted: a probe that bash refuses, an operand that both engines
+  # print, a GNU `-Z` that is a real flag, or a JustBash-only command.
+  @flags_classifications %{
+    "." => "bash source builtin: unknown flag is invalid option + usage",
+    ":" => "alias of true; ignores operands and exits 0",
+    "[" => "missing ] is a usage-bearing syntax error; not the operand form of test",
+    "arch" => "probe: coreutils refuse an unknown flag",
+    "awk" => "probe: gawk refuses an unknown flag",
+    "base64" => "probe: coreutils refuse an unknown flag",
+    "basename" => "probe: coreutils refuse an unknown flag",
+    "break" => "bash ignores the token and warns only meaningful in a loop at exit 0",
+    "cat" => "probe: coreutils refuse an unknown flag",
+    "cd" => "probe: bash builtin refuses an unknown flag + usage",
+    "chmod" => "probe: coreutils refuse an unknown flag",
+    "chown" => "probe: coreutils refuse an unknown flag",
+    "comm" => "probe: coreutils refuse an unknown flag",
+    "command" => "probe: bash builtin refuses an unknown flag + usage",
+    "continue" => "bash ignores the token and warns only meaningful in a loop at exit 0",
+    "cp" => "GNU -Z is SELinux context of the copy; --jb-not-a-flag is refused",
+    "curl" => "GNU -Z is --parallel; --jb-not-a-flag is unknown",
+    "cut" => "probe: coreutils refuse an unknown flag",
+    "date" => "probe: coreutils refuse an unknown flag",
+    "declare" => "probe: bash builtin refuses an unknown flag + usage",
+    "diff" => "GNU -Z ignores trailing whitespace; --jb-not-a-flag is refused",
+    "dirname" => "probe: coreutils refuse an unknown flag",
+    "du" => "probe: coreutils refuse an unknown flag",
+    "echo" => "operand: writes arguments; -Z and --jb-not-a-flag are data at exit 0",
+    "env" => "probe: coreutils refuse an unknown flag",
+    "eval" => "probe: bash builtin refuses an unknown flag + usage",
+    "exit" => "bash wants a numeric status; the token is not a flag",
+    "expand" => "probe: coreutils refuse an unknown flag",
+    "export" => "probe: bash builtin refuses an unknown flag + usage",
+    "false" => "ignores operands and exits 1 with no diagnostic",
+    "file" => "GNU -Z tries to uncompress; --jb-not-a-flag is refused",
+    "find" => "probe: GNU find reports an unknown predicate",
+    "fold" => "probe: coreutils refuse an unknown flag",
+    "getopts" => "probe: bash builtin refuses an unknown flag + usage",
+    "grep" => "GNU -Z is --null; --jb-not-a-flag is refused",
+    "head" => "probe: coreutils refuse an unknown flag",
+    "hostname" => "probe: hostname refuses an unknown flag + usage",
+    "id" => "GNU -Z is SELinux context; --jb-not-a-flag is refused",
+    "jq" => "probe: jq refuses an unknown flag",
+    "ln" => "probe: coreutils refuse an unknown flag",
+    "local" => "bash errors can only be used in a function before flag parsing",
+    "ls" => "GNU -Z prints SELinux context (empty dir so the listing is deterministic)",
+    "markdown" => "JustBash-only; bash has no markdown",
+    "md" => "alias of markdown; bash has no md",
+    "md5sum" => "probe: coreutils refuse an unknown flag",
+    "mkdir" => "GNU -Z is SELinux context of the directory; --jb-not-a-flag is refused",
+    "mktemp" => "probe: coreutils refuse an unknown flag",
+    "mv" => "GNU -Z is SELinux context of the rename; --jb-not-a-flag is refused",
+    "nl" => "probe: coreutils refuse an unknown flag",
+    "nproc" => "probe: coreutils refuse an unknown flag",
+    "od" => "probe: coreutils refuse an unknown flag",
+    "paste" => "probe: coreutils refuse an unknown flag",
+    "printenv" => "probe: coreutils refuse an unknown flag",
+    "printf" => "probe: bash builtin refuses an unknown flag + usage",
+    "pwd" => "probe: bash builtin refuses an unknown flag + usage",
+    "read" => "probe: bash builtin refuses an unknown flag + usage",
+    "readlink" => "probe: coreutils refuse an unknown flag",
+    "realpath" => "probe: coreutils refuse an unknown flag",
+    "return" => "bash wants a numeric status; the token is not a flag",
+    "rev" => "probe: util-linux refuse an unknown flag",
+    "rm" => "probe: coreutils refuse an unknown flag",
+    "sed" => "probe: GNU sed refuses an unknown flag + usage",
+    "seq" => "probe: coreutils refuse an unknown flag",
+    "set" => "probe: bash builtin refuses an unknown flag + usage",
+    "sha256sum" => "probe: coreutils refuse an unknown flag",
+    "shasum" => "probe: Perl shasum refuses an unknown flag",
+    "shift" => "bash wants a numeric count; the token is not a flag",
+    "sleep" => "probe: coreutils refuse an unknown flag",
+    "sort" => "probe: coreutils refuse an unknown flag",
+    "source" => "bash source builtin: unknown flag is invalid option + usage",
+    "stat" => "probe: coreutils refuse an unknown flag",
+    "tac" => "probe: coreutils refuse an unknown flag",
+    "tail" => "probe: coreutils refuse an unknown flag",
+    "tee" => "probe: coreutils refuse an unknown flag",
+    "test" => "operand: one-arg test is implicit -n; -Z and --jb-not-a-flag are nonempty",
+    "touch" => "probe: coreutils refuse an unknown flag",
+    "tr" => "probe: coreutils refuse an unknown flag",
+    "trap" => "probe: bash builtin refuses an unknown flag + usage",
+    "tree" => "probe: tree refuses an unknown flag + usage",
+    "true" => "ignores operands and exits 0",
+    "type" => "probe: bash builtin refuses an unknown flag + usage",
+    "typeset" => "probe: bash builtin refuses an unknown flag + usage",
+    "uname" => "probe: coreutils refuse an unknown flag",
+    "uniq" => "probe: coreutils refuse an unknown flag",
+    "unset" => "probe: bash builtin refuses an unknown flag + usage",
+    "wc" => "probe: coreutils refuse an unknown flag",
+    "wget" => "probe: wget refuses an unknown flag + usage",
+    "which" => "probe: which refuses an unknown flag + usage",
+    "whoami" => "probe: coreutils refuse an unknown flag",
+    "xargs" => "probe: findutils refuse an unknown flag",
+    "xxd" => "probe: xxd refuses an unknown flag + usage",
+    "yes" => "GNU yes refuses unknown flags; they are not the string to repeat"
+  }
+
+  # Assigned after recording. A cell that matches is left unmarked even
+  # when a sibling of the same command diverges — marking a match inverts
+  # a passing assertion. Per-flag overrides win over the per-command map.
+  @absorbed_gap "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+  @misblame_gap "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+  @wording_gap "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+  @selinux_z_gap "GNU -Z is a real flag (SELinux context); JustBash rejects -Z as unknown or mishandles it"
+  @gnu_z_gap "GNU -Z is a real flag; JustBash rejects -Z as unknown or mishandles it"
+  @no_gnu_gap "JustBash-only command; bash reports command not found"
+  @quiet_gap "JustBash exits non-zero with no diagnostic; bash writes usage or a required-argument error"
+  @loop_gap "JustBash does not emit bash's only meaningful in a loop warning"
+  @local_gap "JustBash local/declare parses flags outside a function; bash errors can only be used in a function or refuses the option"
+  @numeric_gap "JustBash does not diagnose a non-numeric status/count the way bash does"
+  @yes_gap "JustBash yes treats the flag as the string to repeat; GNU yes refuses unknown flags"
+  @bracket_gap "JustBash [ without a closing ] still evaluates the token; bash exits 2 and diagnoses missing ]"
+
+  # Per-command default, applied to both probes unless overridden.
+  # Filled after the first recording; matching cells stay nil.
+  @flags_command_gaps %{
+    "." => @misblame_gap,
+    "[" => @bracket_gap,
+    "arch" => @absorbed_gap,
+    "awk" => @absorbed_gap,
+    "base64" => @wording_gap,
+    "basename" => @absorbed_gap,
+    "break" => @loop_gap,
+    "cat" => @misblame_gap,
+    "cd" => @misblame_gap,
+    "chmod" => @misblame_gap,
+    "chown" => @misblame_gap,
+    "comm" => @wording_gap,
+    "command" => @misblame_gap,
+    "continue" => @loop_gap,
+    "cut" => @wording_gap,
+    "curl" => @misblame_gap,
+    "date" => @wording_gap,
+    "declare" => @local_gap,
+    "diff" => @wording_gap,
+    "dirname" => @absorbed_gap,
+    "du" => @wording_gap,
+    "env" => @wording_gap,
+    "eval" => @misblame_gap,
+    "expand" => @wording_gap,
+    "exit" => @numeric_gap,
+    "export" => @absorbed_gap,
+    "file" => @wording_gap,
+    "find" => @misblame_gap,
+    "fold" => @wording_gap,
+    "getopts" => @misblame_gap,
+    "hostname" => @absorbed_gap,
+    "id" => @absorbed_gap,
+    "jq" => @misblame_gap,
+    "ln" => @misblame_gap,
+    "local" => @local_gap,
+    "md5sum" => @wording_gap,
+    "markdown" => @no_gnu_gap,
+    "md" => @no_gnu_gap,
+    "mkdir" => @absorbed_gap,
+    "mktemp" => @absorbed_gap,
+    "mv" => @misblame_gap,
+    "nl" => @wording_gap,
+    "nproc" => @absorbed_gap,
+    "od" => @misblame_gap,
+    "paste" => @wording_gap,
+    "printenv" => @absorbed_gap,
+    "printf" => @absorbed_gap,
+    "pwd" => @absorbed_gap,
+    "read" => @quiet_gap,
+    "readlink" => @wording_gap,
+    "realpath" => @misblame_gap,
+    "return" => @numeric_gap,
+    "rev" => @absorbed_gap,
+    "rm" => @misblame_gap,
+    "sed" => @wording_gap,
+    "seq" => @misblame_gap,
+    "set" => @wording_gap,
+    "sha256sum" => @misblame_gap,
+    "shasum" => @misblame_gap,
+    "shift" => @numeric_gap,
+    "sleep" => @absorbed_gap,
+    "source" => @misblame_gap,
+    "stat" => @wording_gap,
+    "tac" => @absorbed_gap,
+    "touch" => @absorbed_gap,
+    "tee" => @wording_gap,
+    "trap" => @misblame_gap,
+    "tree" => @wording_gap,
+    "type" => @misblame_gap,
+    "typeset" => @local_gap,
+    "uname" => @absorbed_gap,
+    "unset" => @absorbed_gap,
+    "wc" => @misblame_gap,
+    "wget" => @misblame_gap,
+    "which" => @wording_gap,
+    "whoami" => @absorbed_gap,
+    "xargs" => @wording_gap,
+    "xxd" => @misblame_gap,
+    "yes" => @yes_gap
+  }
+
+  # Per-flag overrides. GNU `-Z` that is a real option is a different
+  # divergence from `--jb-not-a-flag` on the same command.
+  @flags_gap_overrides %{
+    {"cp", "-Z"} => @selinux_z_gap,
+    {"curl", "-Z"} => @gnu_z_gap,
+    {"diff", "-Z"} => @gnu_z_gap,
+    {"file", "-Z"} => @gnu_z_gap,
+    {"grep", "-Z"} => @gnu_z_gap,
+    {"id", "-Z"} => @selinux_z_gap,
+    {"ls", "-Z"} => @selinux_z_gap,
+    {"mkdir", "-Z"} => @selinux_z_gap,
+    {"mv", "-Z"} => @selinux_z_gap
+  }
+
+  @doc false
+  def flags_classifications, do: @flags_classifications
+
+  defp flags_cases do
+    assert_registry_classified!()
+
+    for name <- flags_names(), flag <- @flags_probes do
+      flags_case(name, flag)
+    end
+  end
+
+  defp flags_names, do: @flags_classifications |> Map.keys() |> Enum.sort()
+
+  defp assert_registry_classified! do
+    classified = flags_names()
+    registry = Registry.list() |> Enum.sort()
+
+    unless classified == registry do
+      Mix.raise("""
+      flags matrix classification does not match Commands.Registry:
+        missing: #{inspect(registry -- classified)}
+        extra: #{inspect(classified -- registry)}
+      """)
+    end
+  end
+
+  defp flags_case(name, flag) do
+    fixture_case(
+      "flags matrix: #{name} #{flag}",
+      flags_script(name, flag),
+      flags_gap(name, flag)
+    )
+  end
+
+  # `ls -Z` lists the current directory under GNU. Pin an empty workdir so
+  # the recording is not the workspace listing.
+  defp flags_script("ls", "-Z") do
+    ~S[D=/tmp/jb_flags_ls; mkdir -p "$D"; LC_ALL=C LANG=C ls -Z "$D"; echo rc=$?]
+  end
+
+  defp flags_script(name, flag) do
+    "LC_ALL=C LANG=C #{name} #{flag}; echo rc=$?"
+  end
+
+  defp flags_gap(name, flag) do
+    Map.get(@flags_gap_overrides, {name, flag}, Map.get(@flags_command_gaps, name))
   end
 
   defp fixture_case(name, script, known_gap) do

--- a/test/commands/unknown_flags_test.exs
+++ b/test/commands/unknown_flags_test.exs
@@ -8,8 +8,6 @@ defmodule JustBash.Commands.UnknownFlagsTest do
   """
   use ExUnit.Case, async: true
 
-  alias JustBash.Commands.Registry
-
   defp bash, do: JustBash.new(files: %{"/f.txt" => "a\nb\nc\n"})
 
   describe "commands sharing JustBash.FlagParser" do
@@ -398,194 +396,23 @@ defmodule JustBash.Commands.UnknownFlagsTest do
     end
   end
 
-  describe "the whole registry" do
-    @probe_flags ["--jb-not-a-flag", "-Z"]
+  # Registry-wide unknown-flag coverage lives in `flags_matrix`
+  # (`mix bash_fixtures.gen flags`). That suite lists every
+  # `Commands.Registry` name × {--jb-not-a-flag, -Z}, records real
+  # bash/coreutils stderr+rc, and fails if a new command is unclassified.
+  # This file keeps the FlagParser unit tests from #68 — exact wording,
+  # clusters, --help — rather than a second classification table.
 
-    # Every name in `Commands.Registry`, classified by what it does with a flag
-    # it does not implement. The table is compared to observed behaviour as a
-    # whole, so a new command cannot join the registry without being classified
-    # and a command cannot change category unnoticed.
-    #
-    #   :strict    - non-zero exit, nothing on stdout, and a diagnostic that
-    #                names the *option*. What every option-parsing command
-    #                should do, and the only category that certifies the fix:
-    #                a non-zero exit alone does not, because `ls -Z`, `head -Z`,
-    #                `tail -Z` and `cp -Z` all exited non-zero before this
-    #                change too - by demoting the flag and then failing to open
-    #                the file it named.
-    #   :misblamed - STILL WRONG. Non-zero exit, but the diagnostic is about a
-    #                file the flag was turned into rather than about the flag.
-    #                `cat -Z /f.txt` says `cat: -Z: No such file or directory`
-    #                and prints the file anyway; GNU says
-    #                `cat: invalid option -- 'Z'` and prints nothing.
-    #   :quiet     - non-zero exit with no diagnostic. These three parse no
-    #                options at all; bash is equally silent.
-    #   :operand   - exit 0 is correct: bash also treats the argument as data.
-    #                `echo -Z` prints `-Z`, `test -Z` is a non-empty string.
-    #   :absorbed  - STILL WRONG. Exits 0 with the flag ignored, exactly the way
-    #                `sort -Q` did. These are the hand-rolled `parse_args`
-    #                commands that issue #68 explicitly defers migrating onto
-    #                FlagParser (migrating first would have spread the bug, not
-    #                fixed it). Listed by name so the list can only shrink.
-    @classification %{
-      "." => :misblamed,
-      ":" => :operand,
-      "[" => :absorbed,
-      "arch" => :absorbed,
-      "awk" => :absorbed,
-      "base64" => :strict,
-      "basename" => :absorbed,
-      "break" => :absorbed,
-      "cat" => :misblamed,
-      "cd" => :misblamed,
-      "chmod" => :misblamed,
-      "chown" => :misblamed,
-      "comm" => :strict,
-      "command" => :misblamed,
-      "continue" => :absorbed,
-      "cp" => :strict,
-      "curl" => :misblamed,
-      "cut" => :strict,
-      "date" => :strict,
-      "declare" => :absorbed,
-      "diff" => :strict,
-      "dirname" => :absorbed,
-      "du" => :strict,
-      "echo" => :operand,
-      "env" => :strict,
-      "eval" => :misblamed,
-      "exit" => :quiet,
-      "expand" => :strict,
-      "export" => :absorbed,
-      "false" => :quiet,
-      "file" => :strict,
-      "find" => :misblamed,
-      "fold" => :strict,
-      "getopts" => :misblamed,
-      "grep" => :strict,
-      "head" => :strict,
-      "hostname" => :absorbed,
-      "id" => :absorbed,
-      "jq" => :misblamed,
-      "ln" => :misblamed,
-      "local" => :absorbed,
-      "ls" => :strict,
-      "markdown" => :misblamed,
-      "md" => :misblamed,
-      "md5sum" => :strict,
-      "mkdir" => :absorbed,
-      "mktemp" => :absorbed,
-      "mv" => :misblamed,
-      "nl" => :strict,
-      "nproc" => :absorbed,
-      "od" => :misblamed,
-      "paste" => :strict,
-      "printenv" => :absorbed,
-      "printf" => :absorbed,
-      "pwd" => :absorbed,
-      "read" => :quiet,
-      "readlink" => :strict,
-      "realpath" => :misblamed,
-      "return" => :absorbed,
-      "rev" => :absorbed,
-      "rm" => :misblamed,
-      "sed" => :strict,
-      "seq" => :misblamed,
-      "set" => :strict,
-      "sha256sum" => :misblamed,
-      "shasum" => :misblamed,
-      "shift" => :misblamed,
-      "sleep" => :absorbed,
-      "sort" => :strict,
-      "source" => :misblamed,
-      "stat" => :strict,
-      "tac" => :absorbed,
-      "tail" => :strict,
-      "tee" => :strict,
-      "test" => :operand,
-      "touch" => :absorbed,
-      "tr" => :strict,
-      "trap" => :misblamed,
-      "tree" => :strict,
-      "true" => :operand,
-      "type" => :misblamed,
-      "typeset" => :absorbed,
-      "uname" => :absorbed,
-      "uniq" => :strict,
-      "unset" => :absorbed,
-      "wc" => :misblamed,
-      "wget" => :misblamed,
-      "which" => :strict,
-      "whoami" => :absorbed,
-      "xargs" => :strict,
-      "xxd" => :misblamed,
-      "yes" => :operand
-    }
-
-    test "no command silently accepts a flag it does not implement" do
-      observed = Map.new(Registry.list(), fn name -> {name, classify(name)} end)
-      expected = Map.new(@classification, fn {name, kind} -> {name, observable(kind)} end)
-
-      assert observed == expected
-    end
-
-    # A diagnostic nobody can attribute is barely better than none, so a
-    # rejection has to name the program it came from.
-    test "a rejecting command names itself in the diagnostic" do
-      for {name, :strict} <- @classification, flag <- @probe_flags do
-        {result, _} = JustBash.exec(bash(), "#{name} #{flag}")
-        module = Registry.get(name)
-        canonical = hd(module.names())
-
-        assert String.starts_with?(result.stderr, ["bash: ", "#{name}: ", "#{canonical}: "]),
-               "#{name} #{flag} exited #{result.exit_code} with unattributable stderr " <>
-                 inspect(result.stderr)
-      end
-    end
-
-    # Every command the seven FlagParser callers cover has to be :strict, and
-    # naming them here means the matrix cannot certify the fix by accident:
-    # four of these exited non-zero before the fix as well.
-    test "every command on the shared flag parser rejects the flag itself" do
+  describe "the shared flag parser still rejects the flag itself" do
+    test "every FlagParser command is :strict on an unknown short flag" do
       for name <- ~w(cp grep head ls sort tail uniq tr) do
-        assert @classification[name] == :strict
+        {result, _} = JustBash.exec(bash(), "#{name} -Q")
+
+        assert result.exit_code != 0, "#{name} -Q exited 0"
+        assert result.stdout == ""
+        assert result.stderr =~ ~r/(invalid|unrecognized|illegal) option/
+        assert String.starts_with?(result.stderr, ["#{name}: ", "bash: "])
       end
-    end
-
-    # :operand and :absorbed are the same observation - the command exits 0 -
-    # and differ only in whether that is correct. The distinction is carried by
-    # the table above so that fixing an :absorbed command forces an edit here.
-    defp observable(:operand), do: :exit_zero
-    defp observable(:absorbed), do: :exit_zero
-    defp observable(other), do: other
-
-    defp classify(name) do
-      @probe_flags
-      |> Enum.map(&probe(name, &1))
-      |> Enum.uniq()
-      |> case do
-        [single] -> single
-        both -> both
-      end
-    end
-
-    # A non-zero exit is not evidence that the flag was rejected: demoting it to
-    # a filename and failing to open that file exits non-zero too, and leaves
-    # the command's real output on stdout. Only a command that says nothing on
-    # stdout and names the option in its diagnostic has actually rejected it.
-    defp probe(name, flag) do
-      {result, _} = JustBash.exec(bash(), "#{name} #{flag}")
-
-      cond do
-        result.exit_code == 0 -> :exit_zero
-        result.stderr == "" -> :quiet
-        rejected_the_option?(result) -> :strict
-        true -> :misblamed
-      end
-    end
-
-    defp rejected_the_option?(result) do
-      result.stdout == "" and result.stderr =~ ~r/(invalid|unrecognized|illegal) option/
     end
   end
 end

--- a/test/fixtures/bash_cases/flags_matrix.json
+++ b/test/fixtures/bash_cases/flags_matrix.json
@@ -1,0 +1,1408 @@
+{
+  "cases": [
+    {
+      "content_hash": "8c29f946339dab87",
+      "name": "flags matrix: . --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C . --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "9fdbbb9735809581",
+      "name": "flags matrix: . -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C . -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "b244dcddf9c07964",
+      "name": "flags matrix: : --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C : --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "8a21c7a9e82d063a",
+      "name": "flags matrix: : -Z",
+      "script": "LC_ALL=C LANG=C : -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "cce910e2b4329ff4",
+      "name": "flags matrix: [ --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash [ without a closing ] still evaluates the token; bash exits 2 and diagnoses missing ]"
+      },
+      "script": "LC_ALL=C LANG=C [ --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "f9a5bab5cbe88382",
+      "name": "flags matrix: [ -Z",
+      "opts": {
+        "known_gap": "JustBash [ without a closing ] still evaluates the token; bash exits 2 and diagnoses missing ]"
+      },
+      "script": "LC_ALL=C LANG=C [ -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "6522ab3a9bb3e4f7",
+      "name": "flags matrix: arch --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C arch --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "dc267e4c075a8ead",
+      "name": "flags matrix: arch -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C arch -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "9720e773eb1af481",
+      "name": "flags matrix: awk --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C awk --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "8cbda97754e29556",
+      "name": "flags matrix: awk -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C awk -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "0a2aeaa49ea11402",
+      "name": "flags matrix: base64 --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C base64 --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "ee596a90b2cdfae3",
+      "name": "flags matrix: base64 -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C base64 -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "f80afcdc01efa68a",
+      "name": "flags matrix: basename --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C basename --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "6c9a94316f6c7a5c",
+      "name": "flags matrix: basename -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C basename -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "8d61057f74c9766e",
+      "name": "flags matrix: break --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash does not emit bash's only meaningful in a loop warning"
+      },
+      "script": "LC_ALL=C LANG=C break --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "9bf2712cfeb3d99b",
+      "name": "flags matrix: break -Z",
+      "opts": {
+        "known_gap": "JustBash does not emit bash's only meaningful in a loop warning"
+      },
+      "script": "LC_ALL=C LANG=C break -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "8d27f8303d34d25e",
+      "name": "flags matrix: cat --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C cat --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "931c42f37877e610",
+      "name": "flags matrix: cat -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C cat -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "c806f5e88bb30f72",
+      "name": "flags matrix: cd --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C cd --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "ee52d1333815317d",
+      "name": "flags matrix: cd -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C cd -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "806d3235adf3eda2",
+      "name": "flags matrix: chmod --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C chmod --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "c3f4fa910fef9181",
+      "name": "flags matrix: chmod -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C chmod -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "62c4ed52201d44ea",
+      "name": "flags matrix: chown --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C chown --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "1342dcd3648926a5",
+      "name": "flags matrix: chown -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C chown -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "ff97de54b8215960",
+      "name": "flags matrix: comm --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C comm --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "8eb95ad97877a6e4",
+      "name": "flags matrix: comm -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C comm -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "a1d0bacd29760673",
+      "name": "flags matrix: command --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C command --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "712dde023c924136",
+      "name": "flags matrix: command -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C command -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "c359b9389fff025a",
+      "name": "flags matrix: continue --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash does not emit bash's only meaningful in a loop warning"
+      },
+      "script": "LC_ALL=C LANG=C continue --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "55c777dd61a929b8",
+      "name": "flags matrix: continue -Z",
+      "opts": {
+        "known_gap": "JustBash does not emit bash's only meaningful in a loop warning"
+      },
+      "script": "LC_ALL=C LANG=C continue -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "d75034e2b4d1850a",
+      "name": "flags matrix: cp --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C cp --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "36a451b7c9afcd8c",
+      "name": "flags matrix: cp -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag (SELinux context); JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "LC_ALL=C LANG=C cp -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "8264c85f8ffcd1fe",
+      "name": "flags matrix: curl --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C curl --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "7e3ea378d76be00b",
+      "name": "flags matrix: curl -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag; JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "LC_ALL=C LANG=C curl -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "48c81c23948cfdb1",
+      "name": "flags matrix: cut --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C cut --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "6bb3b13f1114f84e",
+      "name": "flags matrix: cut -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C cut -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "f0c09a8a8ecf5c75",
+      "name": "flags matrix: date --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C date --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "eda7c90ef168cd79",
+      "name": "flags matrix: date -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C date -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "c4592335e027ec93",
+      "name": "flags matrix: declare --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash local/declare parses flags outside a function; bash errors can only be used in a function or refuses the option"
+      },
+      "script": "LC_ALL=C LANG=C declare --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "aac8829e8e9a69ed",
+      "name": "flags matrix: declare -Z",
+      "opts": {
+        "known_gap": "JustBash local/declare parses flags outside a function; bash errors can only be used in a function or refuses the option"
+      },
+      "script": "LC_ALL=C LANG=C declare -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "f83f1e80925ccf29",
+      "name": "flags matrix: diff --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C diff --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "2273846e7228cf54",
+      "name": "flags matrix: diff -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag; JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "LC_ALL=C LANG=C diff -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "0d2dcd2254bfef14",
+      "name": "flags matrix: dirname --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C dirname --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "7fb21f0c98a15979",
+      "name": "flags matrix: dirname -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C dirname -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "4e3c5ec077432534",
+      "name": "flags matrix: du --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C du --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "dda5c66630e4a6cb",
+      "name": "flags matrix: du -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C du -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "738a5a1db2895671",
+      "name": "flags matrix: echo --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C echo --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "b3667c189b932d38",
+      "name": "flags matrix: echo -Z",
+      "script": "LC_ALL=C LANG=C echo -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "86cf314e0ebbccd8",
+      "name": "flags matrix: env --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C env --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "87c049a58961ec1d",
+      "name": "flags matrix: env -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C env -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "99dc084feeb41578",
+      "name": "flags matrix: eval --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C eval --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "0c346639ee4c367f",
+      "name": "flags matrix: eval -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C eval -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "9b30adf19c2828b7",
+      "name": "flags matrix: exit --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash does not diagnose a non-numeric status/count the way bash does"
+      },
+      "script": "LC_ALL=C LANG=C exit --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "aaa7cd9a1b722675",
+      "name": "flags matrix: exit -Z",
+      "opts": {
+        "known_gap": "JustBash does not diagnose a non-numeric status/count the way bash does"
+      },
+      "script": "LC_ALL=C LANG=C exit -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "3c2f567b5d0e67c0",
+      "name": "flags matrix: expand --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C expand --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "80d65f205aba6eb5",
+      "name": "flags matrix: expand -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C expand -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "8ab517d142f2a34d",
+      "name": "flags matrix: export --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C export --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "0c525111b96fb065",
+      "name": "flags matrix: export -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C export -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "f08a76e769f7b68b",
+      "name": "flags matrix: false --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C false --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "d1660d75ad465ad1",
+      "name": "flags matrix: false -Z",
+      "script": "LC_ALL=C LANG=C false -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "0786015a70def26a",
+      "name": "flags matrix: file --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C file --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "d39b6c6db0fc870d",
+      "name": "flags matrix: file -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag; JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "LC_ALL=C LANG=C file -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "91dda89cf619b042",
+      "name": "flags matrix: find --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C find --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "f7bb635ba111a5a7",
+      "name": "flags matrix: find -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C find -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "ab40733a4468a002",
+      "name": "flags matrix: fold --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C fold --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "4f59f1858e7a4b38",
+      "name": "flags matrix: fold -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C fold -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "5d56181846eea17e",
+      "name": "flags matrix: getopts --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C getopts --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "64c0dec6297fe61a",
+      "name": "flags matrix: getopts -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C getopts -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "a05fcb2b267719c2",
+      "name": "flags matrix: grep --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C grep --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "f6424691562fe7a0",
+      "name": "flags matrix: grep -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag; JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "LC_ALL=C LANG=C grep -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "3cb1edf1663242a3",
+      "name": "flags matrix: head --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C head --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "2d384ed256882204",
+      "name": "flags matrix: head -Z",
+      "script": "LC_ALL=C LANG=C head -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "e57d10a3e345416a",
+      "name": "flags matrix: hostname --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C hostname --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "bc6dff95de1e8a2e",
+      "name": "flags matrix: hostname -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C hostname -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "f244bbf3ded46b33",
+      "name": "flags matrix: id --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C id --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "00fbac6c1dd2a6b3",
+      "name": "flags matrix: id -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag (SELinux context); JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "LC_ALL=C LANG=C id -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "58bce440850c781d",
+      "name": "flags matrix: jq --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C jq --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "c5d1fd47ba075dc3",
+      "name": "flags matrix: jq -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C jq -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "99c75f5418539766",
+      "name": "flags matrix: ln --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C ln --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "28d0cbe45a1d5c93",
+      "name": "flags matrix: ln -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C ln -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "222b698d1b8688a4",
+      "name": "flags matrix: local --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash local/declare parses flags outside a function; bash errors can only be used in a function or refuses the option"
+      },
+      "script": "LC_ALL=C LANG=C local --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "c33f71709cb52044",
+      "name": "flags matrix: local -Z",
+      "opts": {
+        "known_gap": "JustBash local/declare parses flags outside a function; bash errors can only be used in a function or refuses the option"
+      },
+      "script": "LC_ALL=C LANG=C local -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "8f70e712ea44d0ad",
+      "name": "flags matrix: ls --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C ls --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "9de0b59f0522db84",
+      "name": "flags matrix: ls -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag (SELinux context); JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "D=/tmp/jb_flags_ls; mkdir -p \"$D\"; LC_ALL=C LANG=C ls -Z \"$D\"; echo rc=$?"
+    },
+    {
+      "content_hash": "77d2b5962f2cc2ba",
+      "name": "flags matrix: markdown --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash-only command; bash reports command not found"
+      },
+      "script": "LC_ALL=C LANG=C markdown --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "710190a48ded9de9",
+      "name": "flags matrix: markdown -Z",
+      "opts": {
+        "known_gap": "JustBash-only command; bash reports command not found"
+      },
+      "script": "LC_ALL=C LANG=C markdown -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "daa408d95ab87f8f",
+      "name": "flags matrix: md --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash-only command; bash reports command not found"
+      },
+      "script": "LC_ALL=C LANG=C md --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "a753e9fea918ee8f",
+      "name": "flags matrix: md -Z",
+      "opts": {
+        "known_gap": "JustBash-only command; bash reports command not found"
+      },
+      "script": "LC_ALL=C LANG=C md -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "2e2b716439071ea6",
+      "name": "flags matrix: md5sum --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C md5sum --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "8b85ad48b8a6e5c7",
+      "name": "flags matrix: md5sum -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C md5sum -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "04378694958b9c75",
+      "name": "flags matrix: mkdir --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C mkdir --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "e110a6668cd5da54",
+      "name": "flags matrix: mkdir -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag (SELinux context); JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "LC_ALL=C LANG=C mkdir -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "69c70479f4c18e85",
+      "name": "flags matrix: mktemp --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C mktemp --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "d6524d789517e7e2",
+      "name": "flags matrix: mktemp -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C mktemp -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "6eae29972d31ae11",
+      "name": "flags matrix: mv --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C mv --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "77b9e191488f731e",
+      "name": "flags matrix: mv -Z",
+      "opts": {
+        "known_gap": "GNU -Z is a real flag (SELinux context); JustBash rejects -Z as unknown or mishandles it"
+      },
+      "script": "LC_ALL=C LANG=C mv -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "dda020763eb774c8",
+      "name": "flags matrix: nl --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C nl --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "01e036b5867eb414",
+      "name": "flags matrix: nl -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C nl -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "22430f159dd9624e",
+      "name": "flags matrix: nproc --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C nproc --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "705b9cdc2593fe38",
+      "name": "flags matrix: nproc -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C nproc -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "5511a2a87fe6ecad",
+      "name": "flags matrix: od --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C od --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "0d7dbac466fdef72",
+      "name": "flags matrix: od -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C od -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "a13d8bba35d1aaa3",
+      "name": "flags matrix: paste --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C paste --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "ec804b28970e480c",
+      "name": "flags matrix: paste -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C paste -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "4eefe94b27c89243",
+      "name": "flags matrix: printenv --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C printenv --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "198cb53efc7badd9",
+      "name": "flags matrix: printenv -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C printenv -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "5c580a682bc167e7",
+      "name": "flags matrix: printf --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C printf --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "ad6e556cbba16d20",
+      "name": "flags matrix: printf -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C printf -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "0bed639817d884a1",
+      "name": "flags matrix: pwd --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C pwd --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "20684d4868679fa4",
+      "name": "flags matrix: pwd -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C pwd -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "6b061c1881b52ba2",
+      "name": "flags matrix: read --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash exits non-zero with no diagnostic; bash writes usage or a required-argument error"
+      },
+      "script": "LC_ALL=C LANG=C read --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "12db787b6b0d1b65",
+      "name": "flags matrix: read -Z",
+      "opts": {
+        "known_gap": "JustBash exits non-zero with no diagnostic; bash writes usage or a required-argument error"
+      },
+      "script": "LC_ALL=C LANG=C read -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "2a974559bf470f17",
+      "name": "flags matrix: readlink --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C readlink --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "acdf21f44a34c202",
+      "name": "flags matrix: readlink -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C readlink -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "7a0e0149c351d39a",
+      "name": "flags matrix: realpath --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C realpath --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "471ccaa47e71e625",
+      "name": "flags matrix: realpath -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C realpath -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "54542de9851c2103",
+      "name": "flags matrix: return --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash does not diagnose a non-numeric status/count the way bash does"
+      },
+      "script": "LC_ALL=C LANG=C return --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "582e5993a83624ca",
+      "name": "flags matrix: return -Z",
+      "opts": {
+        "known_gap": "JustBash does not diagnose a non-numeric status/count the way bash does"
+      },
+      "script": "LC_ALL=C LANG=C return -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "442ecfc430f3243b",
+      "name": "flags matrix: rev --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C rev --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "19bc9d32b17f3680",
+      "name": "flags matrix: rev -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C rev -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "a19bee7a093e43d9",
+      "name": "flags matrix: rm --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C rm --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "ade74dfc89d89a8a",
+      "name": "flags matrix: rm -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C rm -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "c4d0b19d788f7dca",
+      "name": "flags matrix: sed --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C sed --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "e38d79063bd7d4b7",
+      "name": "flags matrix: sed -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C sed -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "19bcb620821e1d34",
+      "name": "flags matrix: seq --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C seq --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "440b65f8e220b94b",
+      "name": "flags matrix: seq -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C seq -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "e04e58d0474a93a8",
+      "name": "flags matrix: set --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C set --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "35190c70718f7fd5",
+      "name": "flags matrix: set -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C set -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "fee204554f83df8f",
+      "name": "flags matrix: sha256sum --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C sha256sum --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "2c61859cc4e65514",
+      "name": "flags matrix: sha256sum -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C sha256sum -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "46168061a576619a",
+      "name": "flags matrix: shasum --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C shasum --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "a318c5216be49614",
+      "name": "flags matrix: shasum -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C shasum -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "b5dc1230c5ddc7c9",
+      "name": "flags matrix: shift --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash does not diagnose a non-numeric status/count the way bash does"
+      },
+      "script": "LC_ALL=C LANG=C shift --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "bb60b18cdf1ff66a",
+      "name": "flags matrix: shift -Z",
+      "opts": {
+        "known_gap": "JustBash does not diagnose a non-numeric status/count the way bash does"
+      },
+      "script": "LC_ALL=C LANG=C shift -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "578d253f43cd436c",
+      "name": "flags matrix: sleep --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C sleep --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "bac11ed0862d76db",
+      "name": "flags matrix: sleep -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C sleep -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "2207625afdf49a88",
+      "name": "flags matrix: sort --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C sort --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "bac9e8ca927c744b",
+      "name": "flags matrix: sort -Z",
+      "script": "LC_ALL=C LANG=C sort -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "976270b0db470582",
+      "name": "flags matrix: source --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C source --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "27b10b1f9cceee95",
+      "name": "flags matrix: source -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C source -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "209a4d0ca55f2bdd",
+      "name": "flags matrix: stat --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C stat --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "a6205cb88875c4d9",
+      "name": "flags matrix: stat -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C stat -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "5c49dab31fb465b7",
+      "name": "flags matrix: tac --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C tac --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "1857c78bef2652fc",
+      "name": "flags matrix: tac -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C tac -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "25f3c2f6336d8f2a",
+      "name": "flags matrix: tail --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C tail --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "a912c94bfccda44d",
+      "name": "flags matrix: tail -Z",
+      "script": "LC_ALL=C LANG=C tail -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "8c1198eeaf0ba285",
+      "name": "flags matrix: tee --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C tee --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "89dfa88b6963bdd8",
+      "name": "flags matrix: tee -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C tee -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "9f15eb67784953d7",
+      "name": "flags matrix: test --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C test --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "91c3454c66da01d5",
+      "name": "flags matrix: test -Z",
+      "script": "LC_ALL=C LANG=C test -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "991b407415c50094",
+      "name": "flags matrix: touch --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C touch --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "18613896b9b26eac",
+      "name": "flags matrix: touch -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C touch -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "7bd25c99fa6c25c4",
+      "name": "flags matrix: tr --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C tr --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "c5fb221920d91b35",
+      "name": "flags matrix: tr -Z",
+      "script": "LC_ALL=C LANG=C tr -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "9a8726a5ca235d0e",
+      "name": "flags matrix: trap --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C trap --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "4efa32321ce38cd3",
+      "name": "flags matrix: trap -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C trap -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "3594642b30758999",
+      "name": "flags matrix: tree --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C tree --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "b00efc56994f27aa",
+      "name": "flags matrix: tree -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C tree -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "98fee787fdd52229",
+      "name": "flags matrix: true --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C true --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "ba8e9b25b65bad17",
+      "name": "flags matrix: true -Z",
+      "script": "LC_ALL=C LANG=C true -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "f944bf079ab0dc51",
+      "name": "flags matrix: type --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C type --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "efbb88610f20f3c8",
+      "name": "flags matrix: type -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C type -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "a6410187d5603489",
+      "name": "flags matrix: typeset --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash local/declare parses flags outside a function; bash errors can only be used in a function or refuses the option"
+      },
+      "script": "LC_ALL=C LANG=C typeset --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "1e4a824817174dbb",
+      "name": "flags matrix: typeset -Z",
+      "opts": {
+        "known_gap": "JustBash local/declare parses flags outside a function; bash errors can only be used in a function or refuses the option"
+      },
+      "script": "LC_ALL=C LANG=C typeset -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "0096d73a7367cfb0",
+      "name": "flags matrix: uname --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C uname --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "5046c9612e0213c2",
+      "name": "flags matrix: uname -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C uname -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "0a4f167ecd414001",
+      "name": "flags matrix: uniq --jb-not-a-flag",
+      "script": "LC_ALL=C LANG=C uniq --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "c4227a716fcb48fb",
+      "name": "flags matrix: uniq -Z",
+      "script": "LC_ALL=C LANG=C uniq -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "52f98db617b39493",
+      "name": "flags matrix: unset --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C unset --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "3cbac757aec98e64",
+      "name": "flags matrix: unset -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C unset -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "823f2280ae6841a0",
+      "name": "flags matrix: wc --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C wc --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "0ad8a1fe795f3430",
+      "name": "flags matrix: wc -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C wc -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "49d92eafb7fe210f",
+      "name": "flags matrix: wget --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C wget --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "daffc614f64a9c27",
+      "name": "flags matrix: wget -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C wget -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "14edba23874bb151",
+      "name": "flags matrix: which --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C which --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "1f4e1d0b62b8b1f9",
+      "name": "flags matrix: which -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C which -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "4f6fad84e75d32af",
+      "name": "flags matrix: whoami --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C whoami --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "1d97c07337856f39",
+      "name": "flags matrix: whoami -Z",
+      "opts": {
+        "known_gap": "JustBash absorbs the flag as an operand or format and exits 0; bash refuses it"
+      },
+      "script": "LC_ALL=C LANG=C whoami -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "196240c39b7686d9",
+      "name": "flags matrix: xargs --jb-not-a-flag",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C xargs --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "86689a3c74ae8123",
+      "name": "flags matrix: xargs -Z",
+      "opts": {
+        "known_gap": "both refuse the flag; JustBash's diagnostic wording or exit code differs from bash/coreutils"
+      },
+      "script": "LC_ALL=C LANG=C xargs -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "f3d49b8ce55378c0",
+      "name": "flags matrix: xxd --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C xxd --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "2cfa811b48800d4f",
+      "name": "flags matrix: xxd -Z",
+      "opts": {
+        "known_gap": "JustBash treats the flag as a filename or other operand and exits non-zero; bash names the option"
+      },
+      "script": "LC_ALL=C LANG=C xxd -Z; echo rc=$?"
+    },
+    {
+      "content_hash": "87f1d5e751018b2b",
+      "name": "flags matrix: yes --jb-not-a-flag",
+      "opts": {
+        "known_gap": "JustBash yes treats the flag as the string to repeat; GNU yes refuses unknown flags"
+      },
+      "script": "LC_ALL=C LANG=C yes --jb-not-a-flag; echo rc=$?"
+    },
+    {
+      "content_hash": "6368d678d481610d",
+      "name": "flags matrix: yes -Z",
+      "opts": {
+        "known_gap": "JustBash yes treats the flag as the string to repeat; GNU yes refuses unknown flags"
+      },
+      "script": "LC_ALL=C LANG=C yes -Z; echo rc=$?"
+    }
+  ],
+  "suite": "flags_matrix"
+}

--- a/test/fixtures/bash_expected/flags_matrix.json
+++ b/test/fixtures/bash_expected/flags_matrix.json
@@ -1,0 +1,1293 @@
+{
+  "results": [
+    {
+      "content_hash": "8c29f946339dab87",
+      "exit_code": 0,
+      "name": "flags matrix: . --jb-not-a-flag",
+      "stderr": "bash: line 1: .: --: invalid option\n.: usage: . filename [arguments]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "9fdbbb9735809581",
+      "exit_code": 0,
+      "name": "flags matrix: . -Z",
+      "stderr": "bash: line 1: .: -Z: invalid option\n.: usage: . filename [arguments]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "b244dcddf9c07964",
+      "exit_code": 0,
+      "name": "flags matrix: : --jb-not-a-flag",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "8a21c7a9e82d063a",
+      "exit_code": 0,
+      "name": "flags matrix: : -Z",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "cce910e2b4329ff4",
+      "exit_code": 0,
+      "name": "flags matrix: [ --jb-not-a-flag",
+      "stderr": "bash: line 1: [: missing `]'\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "f9a5bab5cbe88382",
+      "exit_code": 0,
+      "name": "flags matrix: [ -Z",
+      "stderr": "bash: line 1: [: missing `]'\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "6522ab3a9bb3e4f7",
+      "exit_code": 0,
+      "name": "flags matrix: arch --jb-not-a-flag",
+      "stderr": "arch: unrecognized option '--jb-not-a-flag'\nTry 'arch --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "dc267e4c075a8ead",
+      "exit_code": 0,
+      "name": "flags matrix: arch -Z",
+      "stderr": "arch: invalid option -- 'Z'\nTry 'arch --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "9720e773eb1af481",
+      "exit_code": 0,
+      "name": "flags matrix: awk --jb-not-a-flag",
+      "stderr": "awk: not an option: --jb-not-a-flag\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "8cbda97754e29556",
+      "exit_code": 0,
+      "name": "flags matrix: awk -Z",
+      "stderr": "awk: not an option: -Z\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "0a2aeaa49ea11402",
+      "exit_code": 0,
+      "name": "flags matrix: base64 --jb-not-a-flag",
+      "stderr": "base64: unrecognized option '--jb-not-a-flag'\nTry 'base64 --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "ee596a90b2cdfae3",
+      "exit_code": 0,
+      "name": "flags matrix: base64 -Z",
+      "stderr": "base64: invalid option -- 'Z'\nTry 'base64 --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f80afcdc01efa68a",
+      "exit_code": 0,
+      "name": "flags matrix: basename --jb-not-a-flag",
+      "stderr": "basename: unrecognized option '--jb-not-a-flag'\nTry 'basename --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6c9a94316f6c7a5c",
+      "exit_code": 0,
+      "name": "flags matrix: basename -Z",
+      "stderr": "basename: invalid option -- 'Z'\nTry 'basename --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8d61057f74c9766e",
+      "exit_code": 0,
+      "name": "flags matrix: break --jb-not-a-flag",
+      "stderr": "bash: line 1: break: only meaningful in a `for', `while', or `until' loop\n",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "9bf2712cfeb3d99b",
+      "exit_code": 0,
+      "name": "flags matrix: break -Z",
+      "stderr": "bash: line 1: break: only meaningful in a `for', `while', or `until' loop\n",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "8d27f8303d34d25e",
+      "exit_code": 0,
+      "name": "flags matrix: cat --jb-not-a-flag",
+      "stderr": "cat: unrecognized option '--jb-not-a-flag'\nTry 'cat --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "931c42f37877e610",
+      "exit_code": 0,
+      "name": "flags matrix: cat -Z",
+      "stderr": "cat: invalid option -- 'Z'\nTry 'cat --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c806f5e88bb30f72",
+      "exit_code": 0,
+      "name": "flags matrix: cd --jb-not-a-flag",
+      "stderr": "bash: line 1: cd: --: invalid option\ncd: usage: cd [-L|[-P [-e]] [-@]] [dir]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "ee52d1333815317d",
+      "exit_code": 0,
+      "name": "flags matrix: cd -Z",
+      "stderr": "bash: line 1: cd: -Z: invalid option\ncd: usage: cd [-L|[-P [-e]] [-@]] [dir]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "806d3235adf3eda2",
+      "exit_code": 0,
+      "name": "flags matrix: chmod --jb-not-a-flag",
+      "stderr": "chmod: unrecognized option '--jb-not-a-flag'\nTry 'chmod --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c3f4fa910fef9181",
+      "exit_code": 0,
+      "name": "flags matrix: chmod -Z",
+      "stderr": "chmod: invalid option -- 'Z'\nTry 'chmod --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "62c4ed52201d44ea",
+      "exit_code": 0,
+      "name": "flags matrix: chown --jb-not-a-flag",
+      "stderr": "chown: unrecognized option '--jb-not-a-flag'\nTry 'chown --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "1342dcd3648926a5",
+      "exit_code": 0,
+      "name": "flags matrix: chown -Z",
+      "stderr": "chown: invalid option -- 'Z'\nTry 'chown --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "ff97de54b8215960",
+      "exit_code": 0,
+      "name": "flags matrix: comm --jb-not-a-flag",
+      "stderr": "comm: unrecognized option '--jb-not-a-flag'\nTry 'comm --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8eb95ad97877a6e4",
+      "exit_code": 0,
+      "name": "flags matrix: comm -Z",
+      "stderr": "comm: invalid option -- 'Z'\nTry 'comm --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a1d0bacd29760673",
+      "exit_code": 0,
+      "name": "flags matrix: command --jb-not-a-flag",
+      "stderr": "bash: line 1: command: --: invalid option\ncommand: usage: command [-pVv] command [arg ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "712dde023c924136",
+      "exit_code": 0,
+      "name": "flags matrix: command -Z",
+      "stderr": "bash: line 1: command: -Z: invalid option\ncommand: usage: command [-pVv] command [arg ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "c359b9389fff025a",
+      "exit_code": 0,
+      "name": "flags matrix: continue --jb-not-a-flag",
+      "stderr": "bash: line 1: continue: only meaningful in a `for', `while', or `until' loop\n",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "55c777dd61a929b8",
+      "exit_code": 0,
+      "name": "flags matrix: continue -Z",
+      "stderr": "bash: line 1: continue: only meaningful in a `for', `while', or `until' loop\n",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "d75034e2b4d1850a",
+      "exit_code": 0,
+      "name": "flags matrix: cp --jb-not-a-flag",
+      "stderr": "cp: unrecognized option '--jb-not-a-flag'\nTry 'cp --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "36a451b7c9afcd8c",
+      "exit_code": 0,
+      "name": "flags matrix: cp -Z",
+      "stderr": "cp: missing file operand\nTry 'cp --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8264c85f8ffcd1fe",
+      "exit_code": 0,
+      "name": "flags matrix: curl --jb-not-a-flag",
+      "stderr": "curl: option --jb-not-a-flag: is unknown\ncurl: try 'curl --help' or 'curl --manual' for more information\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "7e3ea378d76be00b",
+      "exit_code": 0,
+      "name": "flags matrix: curl -Z",
+      "stderr": "curl: (2) no URL specified\ncurl: try 'curl --help' or 'curl --manual' for more information\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "48c81c23948cfdb1",
+      "exit_code": 0,
+      "name": "flags matrix: cut --jb-not-a-flag",
+      "stderr": "cut: unrecognized option '--jb-not-a-flag'\nTry 'cut --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6bb3b13f1114f84e",
+      "exit_code": 0,
+      "name": "flags matrix: cut -Z",
+      "stderr": "cut: invalid option -- 'Z'\nTry 'cut --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f0c09a8a8ecf5c75",
+      "exit_code": 0,
+      "name": "flags matrix: date --jb-not-a-flag",
+      "stderr": "date: unrecognized option '--jb-not-a-flag'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "eda7c90ef168cd79",
+      "exit_code": 0,
+      "name": "flags matrix: date -Z",
+      "stderr": "date: invalid option -- 'Z'\nTry 'date --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c4592335e027ec93",
+      "exit_code": 0,
+      "name": "flags matrix: declare --jb-not-a-flag",
+      "stderr": "bash: line 1: declare: --: invalid option\ndeclare: usage: declare [-aAfFgiIlnrtux] [name[=value] ...] or declare -p [-aAfFilnrtux] [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "aac8829e8e9a69ed",
+      "exit_code": 0,
+      "name": "flags matrix: declare -Z",
+      "stderr": "bash: line 1: declare: -Z: invalid option\ndeclare: usage: declare [-aAfFgiIlnrtux] [name[=value] ...] or declare -p [-aAfFilnrtux] [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "f83f1e80925ccf29",
+      "exit_code": 0,
+      "name": "flags matrix: diff --jb-not-a-flag",
+      "stderr": "diff: unrecognized option '--jb-not-a-flag'\ndiff: Try 'diff --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "2273846e7228cf54",
+      "exit_code": 0,
+      "name": "flags matrix: diff -Z",
+      "stderr": "diff: missing operand after '-Z'\ndiff: Try 'diff --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "0d2dcd2254bfef14",
+      "exit_code": 0,
+      "name": "flags matrix: dirname --jb-not-a-flag",
+      "stderr": "dirname: unrecognized option '--jb-not-a-flag'\nTry 'dirname --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "7fb21f0c98a15979",
+      "exit_code": 0,
+      "name": "flags matrix: dirname -Z",
+      "stderr": "dirname: invalid option -- 'Z'\nTry 'dirname --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "4e3c5ec077432534",
+      "exit_code": 0,
+      "name": "flags matrix: du --jb-not-a-flag",
+      "stderr": "du: unrecognized option '--jb-not-a-flag'\nTry 'du --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "dda5c66630e4a6cb",
+      "exit_code": 0,
+      "name": "flags matrix: du -Z",
+      "stderr": "du: invalid option -- 'Z'\nTry 'du --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "738a5a1db2895671",
+      "exit_code": 0,
+      "name": "flags matrix: echo --jb-not-a-flag",
+      "stderr": "",
+      "stdout": "--jb-not-a-flag\nrc=0\n"
+    },
+    {
+      "content_hash": "b3667c189b932d38",
+      "exit_code": 0,
+      "name": "flags matrix: echo -Z",
+      "stderr": "",
+      "stdout": "-Z\nrc=0\n"
+    },
+    {
+      "content_hash": "86cf314e0ebbccd8",
+      "exit_code": 0,
+      "name": "flags matrix: env --jb-not-a-flag",
+      "stderr": "env: unrecognized option '--jb-not-a-flag'\nTry 'env --help' for more information.\n",
+      "stdout": "rc=125\n"
+    },
+    {
+      "content_hash": "87c049a58961ec1d",
+      "exit_code": 0,
+      "name": "flags matrix: env -Z",
+      "stderr": "env: invalid option -- 'Z'\nTry 'env --help' for more information.\n",
+      "stdout": "rc=125\n"
+    },
+    {
+      "content_hash": "99dc084feeb41578",
+      "exit_code": 0,
+      "name": "flags matrix: eval --jb-not-a-flag",
+      "stderr": "bash: line 1: eval: --: invalid option\neval: usage: eval [arg ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "0c346639ee4c367f",
+      "exit_code": 0,
+      "name": "flags matrix: eval -Z",
+      "stderr": "bash: line 1: eval: -Z: invalid option\neval: usage: eval [arg ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "9b30adf19c2828b7",
+      "exit_code": 2,
+      "name": "flags matrix: exit --jb-not-a-flag",
+      "stderr": "bash: line 1: exit: --jb-not-a-flag: numeric argument required\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "aaa7cd9a1b722675",
+      "exit_code": 2,
+      "name": "flags matrix: exit -Z",
+      "stderr": "bash: line 1: exit: -Z: numeric argument required\n",
+      "stdout": ""
+    },
+    {
+      "content_hash": "3c2f567b5d0e67c0",
+      "exit_code": 0,
+      "name": "flags matrix: expand --jb-not-a-flag",
+      "stderr": "expand: unrecognized option '--jb-not-a-flag'\nTry 'expand --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "80d65f205aba6eb5",
+      "exit_code": 0,
+      "name": "flags matrix: expand -Z",
+      "stderr": "expand: invalid option -- 'Z'\nTry 'expand --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8ab517d142f2a34d",
+      "exit_code": 0,
+      "name": "flags matrix: export --jb-not-a-flag",
+      "stderr": "bash: line 1: export: --: invalid option\nexport: usage: export [-fn] [name[=value] ...] or export -p\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "0c525111b96fb065",
+      "exit_code": 0,
+      "name": "flags matrix: export -Z",
+      "stderr": "bash: line 1: export: -Z: invalid option\nexport: usage: export [-fn] [name[=value] ...] or export -p\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "f08a76e769f7b68b",
+      "exit_code": 0,
+      "name": "flags matrix: false --jb-not-a-flag",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "d1660d75ad465ad1",
+      "exit_code": 0,
+      "name": "flags matrix: false -Z",
+      "stderr": "",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "0786015a70def26a",
+      "exit_code": 0,
+      "name": "flags matrix: file --jb-not-a-flag",
+      "stderr": "file: unrecognized option '--jb-not-a-flag'\nUsage: file [-bcCdEhikLlNnprsSvzZ0] [--apple] [--extension] [--mime-encoding]\n            [--mime-type] [-e <testname>] [-F <separator>]  [-f <namefile>]\n            [-m <magicfiles>] [-P <parameter=value>] [--exclude-quiet]\n            <file> ...\n       file -C [-m <magicfiles>]\n       file [--help]\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "d39b6c6db0fc870d",
+      "exit_code": 0,
+      "name": "flags matrix: file -Z",
+      "stderr": "Usage: file [-bcCdEhikLlNnprsSvzZ0] [--apple] [--extension] [--mime-encoding]\n            [--mime-type] [-e <testname>] [-F <separator>]  [-f <namefile>]\n            [-m <magicfiles>] [-P <parameter=value>] [--exclude-quiet]\n            <file> ...\n       file -C [-m <magicfiles>]\n       file [--help]\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "91dda89cf619b042",
+      "exit_code": 0,
+      "name": "flags matrix: find --jb-not-a-flag",
+      "stderr": "find: unknown predicate `--jb-not-a-flag'\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f7bb635ba111a5a7",
+      "exit_code": 0,
+      "name": "flags matrix: find -Z",
+      "stderr": "find: unknown predicate `-Z'\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "ab40733a4468a002",
+      "exit_code": 0,
+      "name": "flags matrix: fold --jb-not-a-flag",
+      "stderr": "fold: unrecognized option '--jb-not-a-flag'\nTry 'fold --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "4f59f1858e7a4b38",
+      "exit_code": 0,
+      "name": "flags matrix: fold -Z",
+      "stderr": "fold: invalid option -- 'Z'\nTry 'fold --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "5d56181846eea17e",
+      "exit_code": 0,
+      "name": "flags matrix: getopts --jb-not-a-flag",
+      "stderr": "bash: line 1: getopts: --: invalid option\ngetopts: usage: getopts optstring name [arg ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "64c0dec6297fe61a",
+      "exit_code": 0,
+      "name": "flags matrix: getopts -Z",
+      "stderr": "bash: line 1: getopts: -Z: invalid option\ngetopts: usage: getopts optstring name [arg ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "a05fcb2b267719c2",
+      "exit_code": 0,
+      "name": "flags matrix: grep --jb-not-a-flag",
+      "stderr": "grep: unrecognized option '--jb-not-a-flag'\nUsage: grep [OPTION]... PATTERNS [FILE]...\nTry 'grep --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "f6424691562fe7a0",
+      "exit_code": 0,
+      "name": "flags matrix: grep -Z",
+      "stderr": "Usage: grep [OPTION]... PATTERNS [FILE]...\nTry 'grep --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "3cb1edf1663242a3",
+      "exit_code": 0,
+      "name": "flags matrix: head --jb-not-a-flag",
+      "stderr": "head: unrecognized option '--jb-not-a-flag'\nTry 'head --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "2d384ed256882204",
+      "exit_code": 0,
+      "name": "flags matrix: head -Z",
+      "stderr": "head: invalid option -- 'Z'\nTry 'head --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e57d10a3e345416a",
+      "exit_code": 0,
+      "name": "flags matrix: hostname --jb-not-a-flag",
+      "stderr": "hostname: unrecognized option '--jb-not-a-flag'\n",
+      "stdout": "Usage: hostname [-b] {hostname|-F file}         set host name (from file)\n       hostname [-a|-A|-d|-f|-i|-I|-s|-y]       display formatted name\n       hostname                                 display host name\n\n       {yp,nis,}domainname {nisdomain|-F file}  set NIS domain name (from file)\n       {yp,nis,}domainname                      display NIS domain name\n\n       dnsdomainname                            display dns domain name\n\n       hostname -V|--version|-h|--help          print info and exit\n\nProgram name:\n       {yp,nis,}domainname=hostname -y\n       dnsdomainname=hostname -d\n\nProgram options:\n    -a, --alias            alias names\n    -A, --all-fqdns        all long host names (FQDNs)\n    -b, --boot             set default hostname if none available\n    -d, --domain           DNS domain name\n    -f, --fqdn, --long     long host name (FQDN)\n    -F, --file             read host name or NIS domain name from given file\n    -i, --ip-address       addresses for the host name\n    -I, --all-ip-addresses all addresses for the host\n    -s, --short            short host name\n    -y, --yp, --nis        NIS/YP domain name\n\nDescription:\n   This command can get or set the host name or the NIS domain name. You can\n   also get the DNS domain or the FQDN (fully qualified domain name).\n   Unless you are using bind or NIS for host lookups you can change the\n   FQDN (Fully Qualified Domain Name) and the DNS domain name (which is\n   part of the FQDN) in the /etc/hosts file.\nrc=255\n"
+    },
+    {
+      "content_hash": "bc6dff95de1e8a2e",
+      "exit_code": 0,
+      "name": "flags matrix: hostname -Z",
+      "stderr": "hostname: invalid option -- 'Z'\n",
+      "stdout": "Usage: hostname [-b] {hostname|-F file}         set host name (from file)\n       hostname [-a|-A|-d|-f|-i|-I|-s|-y]       display formatted name\n       hostname                                 display host name\n\n       {yp,nis,}domainname {nisdomain|-F file}  set NIS domain name (from file)\n       {yp,nis,}domainname                      display NIS domain name\n\n       dnsdomainname                            display dns domain name\n\n       hostname -V|--version|-h|--help          print info and exit\n\nProgram name:\n       {yp,nis,}domainname=hostname -y\n       dnsdomainname=hostname -d\n\nProgram options:\n    -a, --alias            alias names\n    -A, --all-fqdns        all long host names (FQDNs)\n    -b, --boot             set default hostname if none available\n    -d, --domain           DNS domain name\n    -f, --fqdn, --long     long host name (FQDN)\n    -F, --file             read host name or NIS domain name from given file\n    -i, --ip-address       addresses for the host name\n    -I, --all-ip-addresses all addresses for the host\n    -s, --short            short host name\n    -y, --yp, --nis        NIS/YP domain name\n\nDescription:\n   This command can get or set the host name or the NIS domain name. You can\n   also get the DNS domain or the FQDN (fully qualified domain name).\n   Unless you are using bind or NIS for host lookups you can change the\n   FQDN (Fully Qualified Domain Name) and the DNS domain name (which is\n   part of the FQDN) in the /etc/hosts file.\nrc=255\n"
+    },
+    {
+      "content_hash": "f244bbf3ded46b33",
+      "exit_code": 0,
+      "name": "flags matrix: id --jb-not-a-flag",
+      "stderr": "id: unrecognized option '--jb-not-a-flag'\nTry 'id --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "00fbac6c1dd2a6b3",
+      "exit_code": 0,
+      "name": "flags matrix: id -Z",
+      "stderr": "id: --context (-Z) works only on an SELinux-enabled kernel\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "58bce440850c781d",
+      "exit_code": 0,
+      "name": "flags matrix: jq --jb-not-a-flag",
+      "stderr": "jq: Unknown option --jb-not-a-flag\nUse jq --help for help with command-line options,\nor see the jq manpage, or online docs  at https://jqlang.github.io/jq\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "c5d1fd47ba075dc3",
+      "exit_code": 0,
+      "name": "flags matrix: jq -Z",
+      "stderr": "jq: Unknown option -Z\nUse jq --help for help with command-line options,\nor see the jq manpage, or online docs  at https://jqlang.github.io/jq\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "99c75f5418539766",
+      "exit_code": 0,
+      "name": "flags matrix: ln --jb-not-a-flag",
+      "stderr": "ln: unrecognized option '--jb-not-a-flag'\nTry 'ln --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "28d0cbe45a1d5c93",
+      "exit_code": 0,
+      "name": "flags matrix: ln -Z",
+      "stderr": "ln: invalid option -- 'Z'\nTry 'ln --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "222b698d1b8688a4",
+      "exit_code": 0,
+      "name": "flags matrix: local --jb-not-a-flag",
+      "stderr": "bash: line 1: local: can only be used in a function\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c33f71709cb52044",
+      "exit_code": 0,
+      "name": "flags matrix: local -Z",
+      "stderr": "bash: line 1: local: can only be used in a function\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8f70e712ea44d0ad",
+      "exit_code": 0,
+      "name": "flags matrix: ls --jb-not-a-flag",
+      "stderr": "ls: unrecognized option '--jb-not-a-flag'\nTry 'ls --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "9de0b59f0522db84",
+      "exit_code": 0,
+      "name": "flags matrix: ls -Z",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "77d2b5962f2cc2ba",
+      "exit_code": 0,
+      "name": "flags matrix: markdown --jb-not-a-flag",
+      "stderr": "bash: line 1: markdown: command not found\n",
+      "stdout": "rc=127\n"
+    },
+    {
+      "content_hash": "710190a48ded9de9",
+      "exit_code": 0,
+      "name": "flags matrix: markdown -Z",
+      "stderr": "bash: line 1: markdown: command not found\n",
+      "stdout": "rc=127\n"
+    },
+    {
+      "content_hash": "daa408d95ab87f8f",
+      "exit_code": 0,
+      "name": "flags matrix: md --jb-not-a-flag",
+      "stderr": "bash: line 1: md: command not found\n",
+      "stdout": "rc=127\n"
+    },
+    {
+      "content_hash": "a753e9fea918ee8f",
+      "exit_code": 0,
+      "name": "flags matrix: md -Z",
+      "stderr": "bash: line 1: md: command not found\n",
+      "stdout": "rc=127\n"
+    },
+    {
+      "content_hash": "2e2b716439071ea6",
+      "exit_code": 0,
+      "name": "flags matrix: md5sum --jb-not-a-flag",
+      "stderr": "md5sum: unrecognized option '--jb-not-a-flag'\nTry 'md5sum --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8b85ad48b8a6e5c7",
+      "exit_code": 0,
+      "name": "flags matrix: md5sum -Z",
+      "stderr": "md5sum: invalid option -- 'Z'\nTry 'md5sum --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "04378694958b9c75",
+      "exit_code": 0,
+      "name": "flags matrix: mkdir --jb-not-a-flag",
+      "stderr": "mkdir: unrecognized option '--jb-not-a-flag'\nTry 'mkdir --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e110a6668cd5da54",
+      "exit_code": 0,
+      "name": "flags matrix: mkdir -Z",
+      "stderr": "mkdir: missing operand\nTry 'mkdir --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "69c70479f4c18e85",
+      "exit_code": 0,
+      "name": "flags matrix: mktemp --jb-not-a-flag",
+      "stderr": "mktemp: unrecognized option '--jb-not-a-flag'\nTry 'mktemp --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "d6524d789517e7e2",
+      "exit_code": 0,
+      "name": "flags matrix: mktemp -Z",
+      "stderr": "mktemp: invalid option -- 'Z'\nTry 'mktemp --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6eae29972d31ae11",
+      "exit_code": 0,
+      "name": "flags matrix: mv --jb-not-a-flag",
+      "stderr": "mv: unrecognized option '--jb-not-a-flag'\nTry 'mv --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "77b9e191488f731e",
+      "exit_code": 0,
+      "name": "flags matrix: mv -Z",
+      "stderr": "mv: missing file operand\nTry 'mv --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "dda020763eb774c8",
+      "exit_code": 0,
+      "name": "flags matrix: nl --jb-not-a-flag",
+      "stderr": "nl: unrecognized option '--jb-not-a-flag'\nTry 'nl --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "01e036b5867eb414",
+      "exit_code": 0,
+      "name": "flags matrix: nl -Z",
+      "stderr": "nl: invalid option -- 'Z'\nTry 'nl --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "22430f159dd9624e",
+      "exit_code": 0,
+      "name": "flags matrix: nproc --jb-not-a-flag",
+      "stderr": "nproc: unrecognized option '--jb-not-a-flag'\nTry 'nproc --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "705b9cdc2593fe38",
+      "exit_code": 0,
+      "name": "flags matrix: nproc -Z",
+      "stderr": "nproc: invalid option -- 'Z'\nTry 'nproc --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "5511a2a87fe6ecad",
+      "exit_code": 0,
+      "name": "flags matrix: od --jb-not-a-flag",
+      "stderr": "od: unrecognized option '--jb-not-a-flag'\nTry 'od --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "0d7dbac466fdef72",
+      "exit_code": 0,
+      "name": "flags matrix: od -Z",
+      "stderr": "od: invalid option -- 'Z'\nTry 'od --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a13d8bba35d1aaa3",
+      "exit_code": 0,
+      "name": "flags matrix: paste --jb-not-a-flag",
+      "stderr": "paste: unrecognized option '--jb-not-a-flag'\nTry 'paste --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "ec804b28970e480c",
+      "exit_code": 0,
+      "name": "flags matrix: paste -Z",
+      "stderr": "paste: invalid option -- 'Z'\nTry 'paste --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "4eefe94b27c89243",
+      "exit_code": 0,
+      "name": "flags matrix: printenv --jb-not-a-flag",
+      "stderr": "printenv: unrecognized option '--jb-not-a-flag'\nTry 'printenv --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "198cb53efc7badd9",
+      "exit_code": 0,
+      "name": "flags matrix: printenv -Z",
+      "stderr": "printenv: invalid option -- 'Z'\nTry 'printenv --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "5c580a682bc167e7",
+      "exit_code": 0,
+      "name": "flags matrix: printf --jb-not-a-flag",
+      "stderr": "bash: line 1: printf: --: invalid option\nprintf: usage: printf [-v var] format [arguments]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "ad6e556cbba16d20",
+      "exit_code": 0,
+      "name": "flags matrix: printf -Z",
+      "stderr": "bash: line 1: printf: -Z: invalid option\nprintf: usage: printf [-v var] format [arguments]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "0bed639817d884a1",
+      "exit_code": 0,
+      "name": "flags matrix: pwd --jb-not-a-flag",
+      "stderr": "bash: line 1: pwd: --: invalid option\npwd: usage: pwd [-LP]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "20684d4868679fa4",
+      "exit_code": 0,
+      "name": "flags matrix: pwd -Z",
+      "stderr": "bash: line 1: pwd: -Z: invalid option\npwd: usage: pwd [-LP]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "6b061c1881b52ba2",
+      "exit_code": 0,
+      "name": "flags matrix: read --jb-not-a-flag",
+      "stderr": "bash: line 1: read: --: invalid option\nread: usage: read [-ers] [-a array] [-d delim] [-i text] [-n nchars] [-N nchars] [-p prompt] [-t timeout] [-u fd] [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "12db787b6b0d1b65",
+      "exit_code": 0,
+      "name": "flags matrix: read -Z",
+      "stderr": "bash: line 1: read: -Z: invalid option\nread: usage: read [-ers] [-a array] [-d delim] [-i text] [-n nchars] [-N nchars] [-p prompt] [-t timeout] [-u fd] [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "2a974559bf470f17",
+      "exit_code": 0,
+      "name": "flags matrix: readlink --jb-not-a-flag",
+      "stderr": "readlink: unrecognized option '--jb-not-a-flag'\nTry 'readlink --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "acdf21f44a34c202",
+      "exit_code": 0,
+      "name": "flags matrix: readlink -Z",
+      "stderr": "readlink: invalid option -- 'Z'\nTry 'readlink --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "7a0e0149c351d39a",
+      "exit_code": 0,
+      "name": "flags matrix: realpath --jb-not-a-flag",
+      "stderr": "realpath: unrecognized option '--jb-not-a-flag'\nTry 'realpath --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "471ccaa47e71e625",
+      "exit_code": 0,
+      "name": "flags matrix: realpath -Z",
+      "stderr": "realpath: invalid option -- 'Z'\nTry 'realpath --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "54542de9851c2103",
+      "exit_code": 0,
+      "name": "flags matrix: return --jb-not-a-flag",
+      "stderr": "bash: line 1: return: --jb-not-a-flag: numeric argument required\nbash: line 1: return: can only `return' from a function or sourced script\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "582e5993a83624ca",
+      "exit_code": 0,
+      "name": "flags matrix: return -Z",
+      "stderr": "bash: line 1: return: -Z: numeric argument required\nbash: line 1: return: can only `return' from a function or sourced script\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "442ecfc430f3243b",
+      "exit_code": 0,
+      "name": "flags matrix: rev --jb-not-a-flag",
+      "stderr": "rev: unrecognized option '--jb-not-a-flag'\nTry 'rev --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "19bc9d32b17f3680",
+      "exit_code": 0,
+      "name": "flags matrix: rev -Z",
+      "stderr": "rev: invalid option -- 'Z'\nTry 'rev --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a19bee7a093e43d9",
+      "exit_code": 0,
+      "name": "flags matrix: rm --jb-not-a-flag",
+      "stderr": "rm: unrecognized option '--jb-not-a-flag'\nTry 'rm --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "ade74dfc89d89a8a",
+      "exit_code": 0,
+      "name": "flags matrix: rm -Z",
+      "stderr": "rm: invalid option -- 'Z'\nTry 'rm --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c4d0b19d788f7dca",
+      "exit_code": 0,
+      "name": "flags matrix: sed --jb-not-a-flag",
+      "stderr": "sed: unrecognized option '--jb-not-a-flag'\nUsage: sed [OPTION]... {script-only-if-no-other-script} [input-file]...\n\n  -n, --quiet, --silent\n                 suppress automatic printing of pattern space\n      --debug\n                 annotate program execution\n  -e script, --expression=script\n                 add the script to the commands to be executed\n  -f script-file, --file=script-file\n                 add the contents of script-file to the commands to be executed\n  --follow-symlinks\n                 follow symlinks when processing in place\n  -i[SUFFIX], --in-place[=SUFFIX]\n                 edit files in place (makes backup if SUFFIX supplied)\n  -l N, --line-length=N\n                 specify the desired line-wrap length for the `l' command\n  --posix\n                 disable all GNU extensions.\n  -E, -r, --regexp-extended\n                 use extended regular expressions in the script\n                 (for portability use POSIX -E).\n  -s, --separate\n                 consider files as separate rather than as a single,\n                 continuous long stream.\n      --sandbox\n                 operate in sandbox mode (disable e/r/w commands).\n  -u, --unbuffered\n                 load minimal amounts of data from the input files and flush\n                 the output buffers more often\n  -z, --null-data\n                 separate lines by NUL characters\n      --help     display this help and exit\n      --version  output version information and exit\n\nIf no -e, --expression, -f, or --file option is given, then the first\nnon-option argument is taken as the sed script to interpret.  All\nremaining arguments are names of input files; if no input files are\nspecified, then the standard input is read.\n\nGNU sed home page: <https://www.gnu.org/software/sed/>.\nGeneral help using GNU software: <https://www.gnu.org/gethelp/>.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e38d79063bd7d4b7",
+      "exit_code": 0,
+      "name": "flags matrix: sed -Z",
+      "stderr": "sed: invalid option -- 'Z'\nUsage: sed [OPTION]... {script-only-if-no-other-script} [input-file]...\n\n  -n, --quiet, --silent\n                 suppress automatic printing of pattern space\n      --debug\n                 annotate program execution\n  -e script, --expression=script\n                 add the script to the commands to be executed\n  -f script-file, --file=script-file\n                 add the contents of script-file to the commands to be executed\n  --follow-symlinks\n                 follow symlinks when processing in place\n  -i[SUFFIX], --in-place[=SUFFIX]\n                 edit files in place (makes backup if SUFFIX supplied)\n  -l N, --line-length=N\n                 specify the desired line-wrap length for the `l' command\n  --posix\n                 disable all GNU extensions.\n  -E, -r, --regexp-extended\n                 use extended regular expressions in the script\n                 (for portability use POSIX -E).\n  -s, --separate\n                 consider files as separate rather than as a single,\n                 continuous long stream.\n      --sandbox\n                 operate in sandbox mode (disable e/r/w commands).\n  -u, --unbuffered\n                 load minimal amounts of data from the input files and flush\n                 the output buffers more often\n  -z, --null-data\n                 separate lines by NUL characters\n      --help     display this help and exit\n      --version  output version information and exit\n\nIf no -e, --expression, -f, or --file option is given, then the first\nnon-option argument is taken as the sed script to interpret.  All\nremaining arguments are names of input files; if no input files are\nspecified, then the standard input is read.\n\nGNU sed home page: <https://www.gnu.org/software/sed/>.\nGeneral help using GNU software: <https://www.gnu.org/gethelp/>.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "19bcb620821e1d34",
+      "exit_code": 0,
+      "name": "flags matrix: seq --jb-not-a-flag",
+      "stderr": "seq: unrecognized option '--jb-not-a-flag'\nTry 'seq --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "440b65f8e220b94b",
+      "exit_code": 0,
+      "name": "flags matrix: seq -Z",
+      "stderr": "seq: invalid option -- 'Z'\nTry 'seq --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "e04e58d0474a93a8",
+      "exit_code": 0,
+      "name": "flags matrix: set --jb-not-a-flag",
+      "stderr": "bash: line 1: set: --: invalid option\nset: usage: set [-abefhkmnptuvxBCEHPT] [-o option-name] [--] [-] [arg ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "35190c70718f7fd5",
+      "exit_code": 0,
+      "name": "flags matrix: set -Z",
+      "stderr": "bash: line 1: set: -Z: invalid option\nset: usage: set [-abefhkmnptuvxBCEHPT] [-o option-name] [--] [-] [arg ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "fee204554f83df8f",
+      "exit_code": 0,
+      "name": "flags matrix: sha256sum --jb-not-a-flag",
+      "stderr": "sha256sum: unrecognized option '--jb-not-a-flag'\nTry 'sha256sum --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "2c61859cc4e65514",
+      "exit_code": 0,
+      "name": "flags matrix: sha256sum -Z",
+      "stderr": "sha256sum: invalid option -- 'Z'\nTry 'sha256sum --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "46168061a576619a",
+      "exit_code": 0,
+      "name": "flags matrix: shasum --jb-not-a-flag",
+      "stderr": "Unknown option: jb-not-a-flag\nType shasum -h for help\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a318c5216be49614",
+      "exit_code": 0,
+      "name": "flags matrix: shasum -Z",
+      "stderr": "Unknown option: Z\nType shasum -h for help\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b5dc1230c5ddc7c9",
+      "exit_code": 0,
+      "name": "flags matrix: shift --jb-not-a-flag",
+      "stderr": "bash: line 1: shift: --jb-not-a-flag: numeric argument required\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "bb60b18cdf1ff66a",
+      "exit_code": 0,
+      "name": "flags matrix: shift -Z",
+      "stderr": "bash: line 1: shift: -Z: numeric argument required\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "578d253f43cd436c",
+      "exit_code": 0,
+      "name": "flags matrix: sleep --jb-not-a-flag",
+      "stderr": "sleep: unrecognized option '--jb-not-a-flag'\nTry 'sleep --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "bac11ed0862d76db",
+      "exit_code": 0,
+      "name": "flags matrix: sleep -Z",
+      "stderr": "sleep: invalid option -- 'Z'\nTry 'sleep --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "2207625afdf49a88",
+      "exit_code": 0,
+      "name": "flags matrix: sort --jb-not-a-flag",
+      "stderr": "sort: unrecognized option '--jb-not-a-flag'\nTry 'sort --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "bac9e8ca927c744b",
+      "exit_code": 0,
+      "name": "flags matrix: sort -Z",
+      "stderr": "sort: invalid option -- 'Z'\nTry 'sort --help' for more information.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "976270b0db470582",
+      "exit_code": 0,
+      "name": "flags matrix: source --jb-not-a-flag",
+      "stderr": "bash: line 1: source: --: invalid option\nsource: usage: source filename [arguments]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "27b10b1f9cceee95",
+      "exit_code": 0,
+      "name": "flags matrix: source -Z",
+      "stderr": "bash: line 1: source: -Z: invalid option\nsource: usage: source filename [arguments]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "209a4d0ca55f2bdd",
+      "exit_code": 0,
+      "name": "flags matrix: stat --jb-not-a-flag",
+      "stderr": "stat: unrecognized option '--jb-not-a-flag'\nTry 'stat --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a6205cb88875c4d9",
+      "exit_code": 0,
+      "name": "flags matrix: stat -Z",
+      "stderr": "stat: invalid option -- 'Z'\nTry 'stat --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "5c49dab31fb465b7",
+      "exit_code": 0,
+      "name": "flags matrix: tac --jb-not-a-flag",
+      "stderr": "tac: unrecognized option '--jb-not-a-flag'\nTry 'tac --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "1857c78bef2652fc",
+      "exit_code": 0,
+      "name": "flags matrix: tac -Z",
+      "stderr": "tac: invalid option -- 'Z'\nTry 'tac --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "25f3c2f6336d8f2a",
+      "exit_code": 0,
+      "name": "flags matrix: tail --jb-not-a-flag",
+      "stderr": "tail: unrecognized option '--jb-not-a-flag'\nTry 'tail --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "a912c94bfccda44d",
+      "exit_code": 0,
+      "name": "flags matrix: tail -Z",
+      "stderr": "tail: invalid option -- 'Z'\nTry 'tail --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "8c1198eeaf0ba285",
+      "exit_code": 0,
+      "name": "flags matrix: tee --jb-not-a-flag",
+      "stderr": "tee: unrecognized option '--jb-not-a-flag'\nTry 'tee --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "89dfa88b6963bdd8",
+      "exit_code": 0,
+      "name": "flags matrix: tee -Z",
+      "stderr": "tee: invalid option -- 'Z'\nTry 'tee --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "9f15eb67784953d7",
+      "exit_code": 0,
+      "name": "flags matrix: test --jb-not-a-flag",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "91c3454c66da01d5",
+      "exit_code": 0,
+      "name": "flags matrix: test -Z",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "991b407415c50094",
+      "exit_code": 0,
+      "name": "flags matrix: touch --jb-not-a-flag",
+      "stderr": "touch: unrecognized option '--jb-not-a-flag'\nTry 'touch --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "18613896b9b26eac",
+      "exit_code": 0,
+      "name": "flags matrix: touch -Z",
+      "stderr": "touch: invalid option -- 'Z'\nTry 'touch --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "7bd25c99fa6c25c4",
+      "exit_code": 0,
+      "name": "flags matrix: tr --jb-not-a-flag",
+      "stderr": "tr: unrecognized option '--jb-not-a-flag'\nTry 'tr --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c5fb221920d91b35",
+      "exit_code": 0,
+      "name": "flags matrix: tr -Z",
+      "stderr": "tr: invalid option -- 'Z'\nTry 'tr --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "9a8726a5ca235d0e",
+      "exit_code": 0,
+      "name": "flags matrix: trap --jb-not-a-flag",
+      "stderr": "bash: line 1: trap: --: invalid option\ntrap: usage: trap [-lp] [[arg] signal_spec ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "4efa32321ce38cd3",
+      "exit_code": 0,
+      "name": "flags matrix: trap -Z",
+      "stderr": "bash: line 1: trap: -Z: invalid option\ntrap: usage: trap [-lp] [[arg] signal_spec ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "3594642b30758999",
+      "exit_code": 0,
+      "name": "flags matrix: tree --jb-not-a-flag",
+      "stderr": "tree: Invalid argument `--jb-not-a-flag'.\nusage: tree [-acdfghilnpqrstuvxACDFJQNSUX] [-L level [-R]] [-H  baseHREF]\n\t[-T title] [-o filename] [-P pattern] [-I pattern] [--gitignore]\n\t[--gitfile[=]file] [--matchdirs] [--metafirst] [--ignore-case]\n\t[--nolinks] [--hintro[=]file] [--houtro[=]file] [--inodes] [--device]\n\t[--sort[=]<name>] [--dirsfirst] [--filesfirst] [--filelimit #] [--si]\n\t[--du] [--prune] [--charset[=]X] [--timefmt[=]format] [--fromfile]\n\t[--fromtabfile] [--fflinks] [--info] [--infofile[=]file] [--noreport]\n\t[--version] [--help] [--] [directory ...]\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "b00efc56994f27aa",
+      "exit_code": 0,
+      "name": "flags matrix: tree -Z",
+      "stderr": "tree: Invalid argument -`Z'.\nusage: tree [-acdfghilnpqrstuvxACDFJQNSUX] [-L level [-R]] [-H  baseHREF]\n\t[-T title] [-o filename] [-P pattern] [-I pattern] [--gitignore]\n\t[--gitfile[=]file] [--matchdirs] [--metafirst] [--ignore-case]\n\t[--nolinks] [--hintro[=]file] [--houtro[=]file] [--inodes] [--device]\n\t[--sort[=]<name>] [--dirsfirst] [--filesfirst] [--filelimit #] [--si]\n\t[--du] [--prune] [--charset[=]X] [--timefmt[=]format] [--fromfile]\n\t[--fromtabfile] [--fflinks] [--info] [--infofile[=]file] [--noreport]\n\t[--version] [--help] [--] [directory ...]\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "98fee787fdd52229",
+      "exit_code": 0,
+      "name": "flags matrix: true --jb-not-a-flag",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ba8e9b25b65bad17",
+      "exit_code": 0,
+      "name": "flags matrix: true -Z",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f944bf079ab0dc51",
+      "exit_code": 0,
+      "name": "flags matrix: type --jb-not-a-flag",
+      "stderr": "bash: line 1: type: --: invalid option\ntype: usage: type [-afptP] name [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "efbb88610f20f3c8",
+      "exit_code": 0,
+      "name": "flags matrix: type -Z",
+      "stderr": "bash: line 1: type: -Z: invalid option\ntype: usage: type [-afptP] name [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "a6410187d5603489",
+      "exit_code": 0,
+      "name": "flags matrix: typeset --jb-not-a-flag",
+      "stderr": "bash: line 1: typeset: --: invalid option\ntypeset: usage: typeset [-aAfFgiIlnrtux] name[=value] ... or typeset -p [-aAfFilnrtux] [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "1e4a824817174dbb",
+      "exit_code": 0,
+      "name": "flags matrix: typeset -Z",
+      "stderr": "bash: line 1: typeset: -Z: invalid option\ntypeset: usage: typeset [-aAfFgiIlnrtux] name[=value] ... or typeset -p [-aAfFilnrtux] [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "0096d73a7367cfb0",
+      "exit_code": 0,
+      "name": "flags matrix: uname --jb-not-a-flag",
+      "stderr": "uname: unrecognized option '--jb-not-a-flag'\nTry 'uname --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "5046c9612e0213c2",
+      "exit_code": 0,
+      "name": "flags matrix: uname -Z",
+      "stderr": "uname: invalid option -- 'Z'\nTry 'uname --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "0a4f167ecd414001",
+      "exit_code": 0,
+      "name": "flags matrix: uniq --jb-not-a-flag",
+      "stderr": "uniq: unrecognized option '--jb-not-a-flag'\nTry 'uniq --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "c4227a716fcb48fb",
+      "exit_code": 0,
+      "name": "flags matrix: uniq -Z",
+      "stderr": "uniq: invalid option -- 'Z'\nTry 'uniq --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "52f98db617b39493",
+      "exit_code": 0,
+      "name": "flags matrix: unset --jb-not-a-flag",
+      "stderr": "bash: line 1: unset: --: invalid option\nunset: usage: unset [-f] [-v] [-n] [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "3cbac757aec98e64",
+      "exit_code": 0,
+      "name": "flags matrix: unset -Z",
+      "stderr": "bash: line 1: unset: -Z: invalid option\nunset: usage: unset [-f] [-v] [-n] [name ...]\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "823f2280ae6841a0",
+      "exit_code": 0,
+      "name": "flags matrix: wc --jb-not-a-flag",
+      "stderr": "wc: unrecognized option '--jb-not-a-flag'\nTry 'wc --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "0ad8a1fe795f3430",
+      "exit_code": 0,
+      "name": "flags matrix: wc -Z",
+      "stderr": "wc: invalid option -- 'Z'\nTry 'wc --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "49d92eafb7fe210f",
+      "exit_code": 0,
+      "name": "flags matrix: wget --jb-not-a-flag",
+      "stderr": "wget: unrecognized option '--jb-not-a-flag'\nUsage: wget [OPTION]... [URL]...\n\nTry `wget --help' for more options.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "daffc614f64a9c27",
+      "exit_code": 0,
+      "name": "flags matrix: wget -Z",
+      "stderr": "wget: invalid option -- 'Z'\nUsage: wget [OPTION]... [URL]...\n\nTry `wget --help' for more options.\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "14edba23874bb151",
+      "exit_code": 0,
+      "name": "flags matrix: which --jb-not-a-flag",
+      "stderr": "Illegal option --\n",
+      "stdout": "Usage: /usr/bin/which [-as] args\nrc=2\n"
+    },
+    {
+      "content_hash": "1f4e1d0b62b8b1f9",
+      "exit_code": 0,
+      "name": "flags matrix: which -Z",
+      "stderr": "Illegal option -Z\n",
+      "stdout": "Usage: /usr/bin/which [-as] args\nrc=2\n"
+    },
+    {
+      "content_hash": "4f6fad84e75d32af",
+      "exit_code": 0,
+      "name": "flags matrix: whoami --jb-not-a-flag",
+      "stderr": "whoami: unrecognized option '--jb-not-a-flag'\nTry 'whoami --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "1d97c07337856f39",
+      "exit_code": 0,
+      "name": "flags matrix: whoami -Z",
+      "stderr": "whoami: invalid option -- 'Z'\nTry 'whoami --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "196240c39b7686d9",
+      "exit_code": 0,
+      "name": "flags matrix: xargs --jb-not-a-flag",
+      "stderr": "xargs: unrecognized option '--jb-not-a-flag'\nTry 'xargs --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "86689a3c74ae8123",
+      "exit_code": 0,
+      "name": "flags matrix: xargs -Z",
+      "stderr": "xargs: invalid option -- 'Z'\nTry 'xargs --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "f3d49b8ce55378c0",
+      "exit_code": 0,
+      "name": "flags matrix: xxd --jb-not-a-flag",
+      "stderr": "Usage:\n       xxd [options] [infile [outfile]]\n    or\n       xxd -r [-s [-]offset] [-c cols] [-ps] [infile [outfile]]\nOptions:\n    -a          toggle autoskip: A single '*' replaces nul-lines. Default off.\n    -b          binary digit dump (incompatible with -ps,-i). Default hex.\n    -C          capitalize variable names in C include file style (-i).\n    -c cols     format <cols> octets per line. Default 16 (-i: 12, -ps: 30).\n    -E          show characters in EBCDIC. Default ASCII.\n    -e          little-endian dump (incompatible with -ps,-i,-r).\n    -g bytes    number of octets per group in normal output. Default 2 (-e: 4).\n    -h          print this summary.\n    -i          output in C include file style.\n    -l len      stop after <len> octets.\n    -n name     set the variable name used in C include output (-i).\n    -o off      add <off> to the displayed file position.\n    -ps         output in postscript plain hexdump style.\n    -r          reverse operation: convert (or patch) hexdump into binary.\n    -r -s off   revert with <off> added to file positions found in hexdump.\n    -d          show offset in decimal instead of hex.\n    -s [+][-]seek  start at <seek> bytes abs. (or +: rel.) infile offset.\n    -u          use upper case hex letters.\n    -R when     colorize the output; <when> can be 'always', 'auto' or 'never'. Default: 'auto'.\n    -v          show version: \"xxd 2023-10-25 by Juergen Weigert et al.\".\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "2cfa811b48800d4f",
+      "exit_code": 0,
+      "name": "flags matrix: xxd -Z",
+      "stderr": "Usage:\n       xxd [options] [infile [outfile]]\n    or\n       xxd -r [-s [-]offset] [-c cols] [-ps] [infile [outfile]]\nOptions:\n    -a          toggle autoskip: A single '*' replaces nul-lines. Default off.\n    -b          binary digit dump (incompatible with -ps,-i). Default hex.\n    -C          capitalize variable names in C include file style (-i).\n    -c cols     format <cols> octets per line. Default 16 (-i: 12, -ps: 30).\n    -E          show characters in EBCDIC. Default ASCII.\n    -e          little-endian dump (incompatible with -ps,-i,-r).\n    -g bytes    number of octets per group in normal output. Default 2 (-e: 4).\n    -h          print this summary.\n    -i          output in C include file style.\n    -l len      stop after <len> octets.\n    -n name     set the variable name used in C include output (-i).\n    -o off      add <off> to the displayed file position.\n    -ps         output in postscript plain hexdump style.\n    -r          reverse operation: convert (or patch) hexdump into binary.\n    -r -s off   revert with <off> added to file positions found in hexdump.\n    -d          show offset in decimal instead of hex.\n    -s [+][-]seek  start at <seek> bytes abs. (or +: rel.) infile offset.\n    -u          use upper case hex letters.\n    -R when     colorize the output; <when> can be 'always', 'auto' or 'never'. Default: 'auto'.\n    -v          show version: \"xxd 2023-10-25 by Juergen Weigert et al.\".\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "87f1d5e751018b2b",
+      "exit_code": 0,
+      "name": "flags matrix: yes --jb-not-a-flag",
+      "stderr": "yes: unrecognized option '--jb-not-a-flag'\nTry 'yes --help' for more information.\n",
+      "stdout": "rc=1\n"
+    },
+    {
+      "content_hash": "6368d678d481610d",
+      "exit_code": 0,
+      "name": "flags matrix: yes -Z",
+      "stderr": "yes: invalid option -- 'Z'\nTry 'yes --help' for more information.\n",
+      "stdout": "rc=1\n"
+    }
+  ],
+  "suite": "flags_matrix"
+}

--- a/test/mix/tasks/bash_fixtures_gen_test.exs
+++ b/test/mix/tasks/bash_fixtures_gen_test.exs
@@ -228,6 +228,75 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
     end
   end
 
+  describe "flags matrix" do
+    test "probes every Registry command with both flags" do
+      alias JustBash.Commands.Registry
+
+      cases = Gen.cases_for("flags")
+      names = Enum.map(cases, & &1["name"])
+
+      assert length(cases) == length(Registry.list()) * 2
+
+      for cmd <- Registry.list(), flag <- ["--jb-not-a-flag", "-Z"] do
+        assert Enum.any?(names, &(&1 == "flags matrix: #{cmd} #{flag}")),
+               "missing #{cmd} #{flag}"
+      end
+    end
+
+    test "classifies every Registry name with a reason, never a silent omit" do
+      alias JustBash.Commands.Registry
+
+      classified = Gen.flags_classifications()
+
+      assert Map.keys(classified) |> Enum.sort() == Enum.sort(Registry.list())
+
+      Enum.each(classified, fn {name, reason} ->
+        assert is_binary(reason), "#{name} has no reason"
+        assert String.length(reason) > 10, "#{name} reason is too short: #{inspect(reason)}"
+      end)
+    end
+
+    test "records operand and GNU -Z exceptions instead of omitting them" do
+      names = Gen.cases_for("flags") |> Enum.map(& &1["name"])
+      cases = Gen.cases_for("flags")
+
+      assert Enum.any?(names, &(&1 == "flags matrix: echo -Z"))
+      assert Enum.any?(names, &(&1 == "flags matrix: echo --jb-not-a-flag"))
+      assert Enum.any?(names, &(&1 == "flags matrix: test -Z"))
+      assert Enum.any?(names, &(&1 == "flags matrix: ls -Z"))
+      assert Enum.any?(names, &(&1 == "flags matrix: markdown --jb-not-a-flag"))
+
+      ls_z = Enum.find(cases, &(&1["name"] == "flags matrix: ls -Z"))
+      assert ls_z["script"] =~ "ls -Z"
+      assert ls_z["script"] =~ "/tmp/jb_flags_ls"
+    end
+
+    test "every case hashes from its script, not its name or gap" do
+      cases = Gen.cases_for("flags")
+
+      Enum.each(cases, fn test_case ->
+        assert test_case["content_hash"] == JustBash.Fixtures.hash_case(test_case)
+      end)
+    end
+
+    test "known_gap lives in opts and does not change the digest" do
+      cases = Gen.cases_for("flags")
+      gapped = Enum.filter(cases, &get_in(&1, ["opts", "known_gap"]))
+
+      assert length(gapped) > 10
+      assert length(gapped) < length(cases)
+
+      Enum.each(gapped, fn test_case ->
+        reason = test_case["opts"]["known_gap"]
+        assert is_binary(reason)
+        assert String.length(reason) > 10
+
+        assert JustBash.Fixtures.hash_case(test_case) ==
+                 JustBash.Fixtures.hash_case(Map.delete(test_case, "opts"))
+      end)
+    end
+  end
+
   describe "run/1" do
     test "printf --dry-run reports a count and writes nothing" do
       output =
@@ -256,6 +325,16 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
         end)
 
       assert output =~ ~r/varop_matrix: \d+ cases/
+      refute output =~ "wrote"
+    end
+
+    test "flags --dry-run reports a count and writes nothing" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Task.rerun("bash_fixtures.gen", ["flags", "--dry-run"])
+        end)
+
+      assert output =~ ~r/flags_matrix: \d+ cases/
       refute output =~ "wrote"
     end
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #70 item 2 for the **Registry-wide unknown-flag probe** only: a generated `flags_matrix` suite in the same generate / record / test path as `date_matrix`, `printf_matrix`, `test_matrix`, and `varop_matrix`.

This is not the item-3 filesystem-shape × command cube, Oils activation, or CI topology.

`unknown_flags_test.exs` from #68 keeps the FlagParser unit tests (exact GNU wording, clusters, `--help`). The registry-wide classification table moves here so there is one source of truth.

## What was enumerated

`mix bash_fixtures.gen flags` writes **184** cases (92 `Commands.Registry` names × `{--jb-not-a-flag, -Z}`). A new Registry command fails generation and the gen test until it is classified with a reason — the same completeness rule as `end_of_options_test.exs`.

- Every name is generated. Operand commands (`echo`, `test`, `true`, `:`, `false`), GNU `-Z` acceptors (`ls`/`cp`/`mkdir`/`mv`/`id` SELinux, `diff -Z`, `grep -Z`, `curl -Z`, `file -Z`), loop/numeric builtins, and JustBash-only `markdown`/`md` are **not omitted**.
- `ls -Z` is recorded against an empty workdir so the listing is not the workspace.
- Scripts end in `echo rc=$?` so a wrong exit code is a stdout difference too.

`mix bash_fixtures.gen flags --dry-run` reports `flags_matrix: 184 cases`. `mix bash_fixtures.gen` now generates date, printf, test, varop, and flags.

## Recording

Docker was not available on the agent VM. Oracle output was recorded with the same `test/fixtures/runner.sh` the Docker task runs, under GNU bash 5.2.21 / Ubuntu 24.04 (uid `ubuntu`, not root), then pretty-printed through `Mix.Tasks.BashFixtures.write_json!/2`:

```bash
mix bash_fixtures.gen flags
bash test/fixtures/runner.sh < test/fixtures/bash_cases/flags_matrix.json > /tmp/flags_matrix_raw.json
# then Jason-pretty-print + Fixtures.validate, as `mix bash_fixtures` does
```

Host extras used for twins the Docker runner image does not ship: `tree` 2.1.1 and `xxd` (vim 9.1). To re-record through Docker when it is available (those two will become `command not found` unless the image grows them):

```bash
mix bash_fixtures flags_matrix
```

## Known gaps (161 of 184)

No cell was omitted. Divergences are `opts.known_gap` (excluded from the digest). The fixture runner still executes them with the assertion inverted.

23 cells match bash unmarked: `:`, `echo`, `false`, `test`, `true` (both flags); FlagParser exact GNU wording on `sort`/`head`/`tail`/`tr`/`uniq` (both), `cp`/`grep`/`ls` (`--jb-not-a-flag` only).

| Count | Reason |
|------:|--------|
| 48 | Misblamed as a filename or other operand; bash names the option |
| 40 | Both refuse; wording or exit code differs (`Try --help`, `bash: line 1:`, env 125 vs 1) |
| 38 | Absorbed as operand/format at exit 0; bash refuses |
| 6 | Non-numeric status/count (`exit`/`return`/`shift`) not diagnosed the way bash does |
| 6 | `local`/`declare`/`typeset` parse flags outside a function |
| 5 | GNU `-Z` is SELinux context (`ls`/`cp`/`mkdir`/`mv`/`id`) |
| 4 | GNU `-Z` is a real flag (`diff`/`grep`/`curl`/`file`) |
| 4 | `break`/`continue` omit bash's "only meaningful in a loop" warning |
| 4 | `markdown`/`md` are JustBash-only; bash reports command not found |
| 2 | `[` without `]` still evaluates; bash exits 2 |
| 2 | `read` is quiet; bash writes usage |
| 2 | `yes` repeats the flag; GNU yes refuses unknown flags |

JustBash.exec/2 did not raise on any cell. No remaining unknown-flag implementation bugs were fixed in this PR — it is the enumeration + harness.

## Cheap follow-ups the matrix now makes un-skippable

- Migrate absorbed `parse_args` commands onto FlagParser (#68)
- Name the option instead of a filename on misblamed commands (`cat`, `rm`, `wc`, …)
- Align refusal wording with GNU (`unrecognized option`, `Try 'cmd --help'`)
- `yes` should refuse unknown flags instead of repeating them
- `[` without `]` should exit 2

Not in this PR: the item-3 FS-shape × command cube, Oils activation, CI topology changes.

## Tests

All local quality gates passed:

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict` (only the existing intentional `banned_fixture_apply` finding)
- `mix dialyzer` (zero new errors; 13 skipped, same as main)
- `mix test` — 2 doctests, 62 properties, 6810 tests, 0 failures
- `mix test --only suite:flags_matrix` — 184 tests, 0 failures
- `mix bash_fixtures.gen flags --dry-run` — `flags_matrix: 184 cases`

## Related Issues
Related to #70 (item 2, Registry-wide unknown-flag probe only; not closing the issue)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Added new tests
- [x] All existing tests pass
- [x] Tested manually (`mix bash_fixtures.gen flags --dry-run`, local runner.sh recording, JustBash vs oracle classification)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md (for non-trivial changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eaefbabe-ed23-4f77-a74d-e4b7da4d3ce2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaefbabe-ed23-4f77-a74d-e4b7da4d3ce2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

