### PR TITLE
Add set -o name alphabet matrix (`mix bash_fixtures.gen seto`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `mix bash_fixtures.gen test` enumerates a `test`/`[` operator × revealing-shape matrix (`test_matrix`) — #70 item 2
 * `mix bash_fixtures.gen varop` enumerates a `${var op word}` parameter-expansion matrix (`varop_matrix`) — #70 item 2
 * `mix bash_fixtures.gen flags` enumerates a Registry-wide unknown-flag probe (`flags_matrix`) — #70 item 2
+* `mix bash_fixtures.gen seto` enumerates the POSIX/bash `set -o`/`+o` name alphabet (`seto_matrix`) — #70 item 2
 
 ### Bug Fixes
 

--- a/lib/just_bash/commands/set.ex
+++ b/lib/just_bash/commands/set.ex
@@ -18,8 +18,17 @@ defmodule JustBash.Commands.Set do
 
   @behaviour JustBash.Commands.Command
 
+  # Names `set -o` / `+o` actually honour. The seto fixture matrix asserts
+  # completeness against this list — a new clause that is not listed here
+  # (or a listed name with no clause) fails generation.
+  @option_names ~w(errexit nounset pipefail)
+
   @impl true
   def names, do: ["set"]
+
+  @doc false
+  @spec option_names() :: [String.t()]
+  def option_names, do: @option_names
 
   @impl true
   def execute(bash, args, _stdin) do

--- a/lib/mix/tasks/bash_fixtures.gen.ex
+++ b/lib/mix/tasks/bash_fixtures.gen.ex
@@ -33,6 +33,10 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       mix bash_fixtures flags_matrix   # record what real bash does
       mix test --only suite:flags_matrix
 
+      mix bash_fixtures.gen seto       # write the matrix
+      mix bash_fixtures seto_matrix    # record what real bash does
+      mix test --only suite:seto_matrix
+
   Generated suites are named `<matrix>_matrix` and are safe to regenerate: the
   digest in `JustBash.Fixtures` is content-derived, so a case that did not change
   keeps its recording.
@@ -74,6 +78,14 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       `flags_matrix`. This is the registry-wide unknown-flag probe from #70
       item 2; `unknown_flags_test.exs` keeps the FlagParser unit tests from
       #68 rather than a second classification table.
+    * `seto` — every POSIX `set -o` name and every extra bash name `set -o`
+      lists, plus unknown names, each asked as `-o` and `+o`. Names
+      `JustBash.Commands.Set.option_names/0` implements are generated
+      unmarked; real names this shell rejects, and names bash itself
+      refuses, are still generated and named with a reason — never silently
+      omitted. Suite `seto_matrix`. This is the `set -o` name alphabet from
+      #70 item 2, not the short-option cluster (`-euo`) or `set -o` with no
+      name (that lists every option).
 
   A list of conversions and a list of flags are each easy to write down. The
   cross of the two is where the bugs live and is what nobody enumerates by hand:
@@ -89,6 +101,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
       mix bash_fixtures.gen test         # one matrix
       mix bash_fixtures.gen varop        # one matrix
       mix bash_fixtures.gen flags        # one matrix
+      mix bash_fixtures.gen seto         # one matrix
       mix bash_fixtures.gen --dry-run    # report counts, write nothing
   """
 
@@ -100,7 +113,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
 
   @shortdoc "Generate enumerated fixture matrices"
 
-  @matrices ["date", "printf", "test", "varop", "flags"]
+  @matrices ["date", "printf", "test", "varop", "flags", "seto"]
 
   @doc false
   def cases_for(name), do: build(name)
@@ -424,6 +437,7 @@ defmodule Mix.Tasks.BashFixtures.Gen do
   defp build("test"), do: test_cases()
   defp build("varop"), do: varop_cases()
   defp build("flags"), do: flags_cases()
+  defp build("seto"), do: seto_cases()
 
   defp date_cases do
     Enum.concat([
@@ -2174,6 +2188,133 @@ defmodule Mix.Tasks.BashFixtures.Gen do
 
   defp flags_gap(name, flag) do
     Map.get(@flags_gap_overrides, {name, flag}, Map.get(@flags_command_gaps, name))
+  end
+
+  # ---------------------------------------------------------------------------
+  # seto — POSIX/bash `set -o` / `+o` name alphabet
+  #
+  # The alphabet is every name POSIX documents for `set -o`, every extra name
+  # bash's `set -o` listing adds, and a handful of unknown names. Each is
+  # asked as `-o` and as `+o`. This is the name list, not the short-option
+  # cluster (`-euo`) and not `set -o` with no name (that dumps the listing).
+  #
+  # Completeness is `Set.option_names/0`: a name this shell implements must
+  # be in the POSIX/bash alphabet or generation fails, and every such name
+  # is generated. Unsupported real names and unknown names are still
+  # generated; the reason lives here so an omit cannot hide as a pass.
+  #
+  # Gaps are assigned after recording, never by omitting a cell. Marking a
+  # gap must not change the digest — the reason lives in opts.
+  # ---------------------------------------------------------------------------
+
+  # POSIX.1 `set -o` names. Enumerated rather than curated: which of these
+  # JustBash implements is exactly the fact nobody writes down.
+  @seto_posix ~w(
+    allexport
+    errexit
+    ignoreeof
+    monitor
+    noclobber
+    noglob
+    noexec
+    nolog
+    notify
+    nounset
+    verbose
+    vi
+    xtrace
+  )
+
+  # Bash extras that `set -o` lists and POSIX does not. `pipefail` lives
+  # here; it is implemented. The rest are still generated.
+  @seto_bash ~w(
+    braceexpand
+    emacs
+    errtrace
+    functrace
+    hashall
+    histexpand
+    history
+    interactive-comments
+    keyword
+    onecmd
+    physical
+    pipefail
+    posix
+    privileged
+  )
+
+  # Names bash itself refuses. Both engines error; the wording and exit
+  # code are the recorded difference. `ERREXIT` is the case trap — bash
+  # option names are lowercase.
+  @seto_unknown ~w(not-an-option jb-not-an-option ERREXIT)
+
+  @seto_signs ["-o", "+o"]
+
+  @unsupported_name_gap "JustBash rejects this set -o name; bash accepts it"
+  @unknown_name_gap "JustBash names the option in a different word order and exits 1; bash exits 2"
+
+  @doc false
+  def seto_posix, do: @seto_posix
+
+  @doc false
+  def seto_bash, do: @seto_bash
+
+  @doc false
+  def seto_unknown, do: @seto_unknown
+
+  @doc false
+  def seto_supported, do: JustBash.Commands.Set.option_names()
+
+  @doc false
+  def seto_names, do: @seto_posix ++ @seto_bash ++ @seto_unknown
+
+  defp seto_cases do
+    assert_seto_supported_in_alphabet!()
+
+    for name <- seto_names(), sign <- @seto_signs do
+      seto_case(sign, name)
+    end
+  end
+
+  defp assert_seto_supported_in_alphabet! do
+    supported = seto_supported()
+    alphabet = @seto_posix ++ @seto_bash
+    missing = supported -- alphabet
+    extra_posix_bash = alphabet -- Enum.uniq(alphabet)
+
+    unless extra_posix_bash == [] do
+      Mix.raise("seto matrix POSIX/bash alphabet has duplicates: #{inspect(extra_posix_bash)}")
+    end
+
+    unless missing == [] do
+      Mix.raise("""
+      seto matrix alphabet does not include names Set.option_names/0 implements:
+        missing: #{inspect(missing)}
+      """)
+    end
+  end
+
+  defp seto_case(sign, name) do
+    fixture_case(
+      "seto matrix: #{sign} #{name}",
+      seto_script(sign, name),
+      seto_gap(name)
+    )
+  end
+
+  # Quote the name so a future unknown with spaces or a leading dash stays
+  # data. Real names are [a-z-]+ and quoting does not change what bash sees.
+  defp seto_script(sign, name) do
+    "LC_ALL=C LANG=C set #{sign} #{sh_single(name)}; echo rc=$?"
+  end
+
+  defp seto_gap(name) do
+    cond do
+      name in seto_supported() -> nil
+      name in @seto_unknown -> @unknown_name_gap
+      true -> @unsupported_name_gap
+    end
   end
 
   defp fixture_case(name, script, known_gap) do

--- a/test/fixtures/bash_cases/seto_matrix.json
+++ b/test/fixtures/bash_cases/seto_matrix.json
@@ -1,0 +1,467 @@
+{
+  "cases": [
+    {
+      "content_hash": "3115ab7751270d15",
+      "name": "seto matrix: -o allexport",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'allexport'; echo rc=$?"
+    },
+    {
+      "content_hash": "e6b92512ffd42d65",
+      "name": "seto matrix: +o allexport",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'allexport'; echo rc=$?"
+    },
+    {
+      "content_hash": "a651c05393f294e2",
+      "name": "seto matrix: -o errexit",
+      "script": "LC_ALL=C LANG=C set -o 'errexit'; echo rc=$?"
+    },
+    {
+      "content_hash": "6f94bed1abbeebba",
+      "name": "seto matrix: +o errexit",
+      "script": "LC_ALL=C LANG=C set +o 'errexit'; echo rc=$?"
+    },
+    {
+      "content_hash": "a94c52c0b3a0f87e",
+      "name": "seto matrix: -o ignoreeof",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'ignoreeof'; echo rc=$?"
+    },
+    {
+      "content_hash": "e52c8da9481a6c06",
+      "name": "seto matrix: +o ignoreeof",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'ignoreeof'; echo rc=$?"
+    },
+    {
+      "content_hash": "e30828c00141c609",
+      "name": "seto matrix: -o monitor",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'monitor'; echo rc=$?"
+    },
+    {
+      "content_hash": "2ded897d750c9464",
+      "name": "seto matrix: +o monitor",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'monitor'; echo rc=$?"
+    },
+    {
+      "content_hash": "b934358f6044dd18",
+      "name": "seto matrix: -o noclobber",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'noclobber'; echo rc=$?"
+    },
+    {
+      "content_hash": "0f188f12d5047fb2",
+      "name": "seto matrix: +o noclobber",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'noclobber'; echo rc=$?"
+    },
+    {
+      "content_hash": "0b0fba31d13addf3",
+      "name": "seto matrix: -o noglob",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'noglob'; echo rc=$?"
+    },
+    {
+      "content_hash": "e7bb35d195bebbeb",
+      "name": "seto matrix: +o noglob",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'noglob'; echo rc=$?"
+    },
+    {
+      "content_hash": "70636fa283a652b9",
+      "name": "seto matrix: -o noexec",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'noexec'; echo rc=$?"
+    },
+    {
+      "content_hash": "5f478feeb3f1ed53",
+      "name": "seto matrix: +o noexec",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'noexec'; echo rc=$?"
+    },
+    {
+      "content_hash": "768ce60ebf8c09fd",
+      "name": "seto matrix: -o nolog",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'nolog'; echo rc=$?"
+    },
+    {
+      "content_hash": "190f605fd430995d",
+      "name": "seto matrix: +o nolog",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'nolog'; echo rc=$?"
+    },
+    {
+      "content_hash": "866399b14fc06b48",
+      "name": "seto matrix: -o notify",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'notify'; echo rc=$?"
+    },
+    {
+      "content_hash": "a31c8ed814b2a125",
+      "name": "seto matrix: +o notify",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'notify'; echo rc=$?"
+    },
+    {
+      "content_hash": "decaac3252c20aee",
+      "name": "seto matrix: -o nounset",
+      "script": "LC_ALL=C LANG=C set -o 'nounset'; echo rc=$?"
+    },
+    {
+      "content_hash": "df1f66125ca6247c",
+      "name": "seto matrix: +o nounset",
+      "script": "LC_ALL=C LANG=C set +o 'nounset'; echo rc=$?"
+    },
+    {
+      "content_hash": "05d0c4f82fbce7d7",
+      "name": "seto matrix: -o verbose",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'verbose'; echo rc=$?"
+    },
+    {
+      "content_hash": "0385b0f26f774708",
+      "name": "seto matrix: +o verbose",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'verbose'; echo rc=$?"
+    },
+    {
+      "content_hash": "c60921b8c771941b",
+      "name": "seto matrix: -o vi",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'vi'; echo rc=$?"
+    },
+    {
+      "content_hash": "d0d0c0a0d11dcc74",
+      "name": "seto matrix: +o vi",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'vi'; echo rc=$?"
+    },
+    {
+      "content_hash": "7690605827846e5a",
+      "name": "seto matrix: -o xtrace",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'xtrace'; echo rc=$?"
+    },
+    {
+      "content_hash": "b2ea5f8fa1786c19",
+      "name": "seto matrix: +o xtrace",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'xtrace'; echo rc=$?"
+    },
+    {
+      "content_hash": "f12aa522f427233d",
+      "name": "seto matrix: -o braceexpand",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'braceexpand'; echo rc=$?"
+    },
+    {
+      "content_hash": "79d4d26a1dd3ed60",
+      "name": "seto matrix: +o braceexpand",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'braceexpand'; echo rc=$?"
+    },
+    {
+      "content_hash": "e20852247f6ac779",
+      "name": "seto matrix: -o emacs",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'emacs'; echo rc=$?"
+    },
+    {
+      "content_hash": "8feed1c5085c0bc2",
+      "name": "seto matrix: +o emacs",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'emacs'; echo rc=$?"
+    },
+    {
+      "content_hash": "7384bd0b0df8c613",
+      "name": "seto matrix: -o errtrace",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'errtrace'; echo rc=$?"
+    },
+    {
+      "content_hash": "75ab80b807222856",
+      "name": "seto matrix: +o errtrace",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'errtrace'; echo rc=$?"
+    },
+    {
+      "content_hash": "a339abcc167e59de",
+      "name": "seto matrix: -o functrace",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'functrace'; echo rc=$?"
+    },
+    {
+      "content_hash": "fe242c7376302c2e",
+      "name": "seto matrix: +o functrace",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'functrace'; echo rc=$?"
+    },
+    {
+      "content_hash": "58585997fa5c326d",
+      "name": "seto matrix: -o hashall",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'hashall'; echo rc=$?"
+    },
+    {
+      "content_hash": "46fad353ef177ecf",
+      "name": "seto matrix: +o hashall",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'hashall'; echo rc=$?"
+    },
+    {
+      "content_hash": "1a7fef5be7042a75",
+      "name": "seto matrix: -o histexpand",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'histexpand'; echo rc=$?"
+    },
+    {
+      "content_hash": "9977c46021c44e57",
+      "name": "seto matrix: +o histexpand",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'histexpand'; echo rc=$?"
+    },
+    {
+      "content_hash": "a0312be545a218b7",
+      "name": "seto matrix: -o history",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'history'; echo rc=$?"
+    },
+    {
+      "content_hash": "75f6192f3e8fe94b",
+      "name": "seto matrix: +o history",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'history'; echo rc=$?"
+    },
+    {
+      "content_hash": "1c3ba1dc4c6191fd",
+      "name": "seto matrix: -o interactive-comments",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'interactive-comments'; echo rc=$?"
+    },
+    {
+      "content_hash": "747a71abf6eec55b",
+      "name": "seto matrix: +o interactive-comments",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'interactive-comments'; echo rc=$?"
+    },
+    {
+      "content_hash": "3a30e2613a9efd7f",
+      "name": "seto matrix: -o keyword",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'keyword'; echo rc=$?"
+    },
+    {
+      "content_hash": "ec822441cf746b10",
+      "name": "seto matrix: +o keyword",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'keyword'; echo rc=$?"
+    },
+    {
+      "content_hash": "ac4e2514e7816b22",
+      "name": "seto matrix: -o onecmd",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'onecmd'; echo rc=$?"
+    },
+    {
+      "content_hash": "de230f44ed5e917d",
+      "name": "seto matrix: +o onecmd",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'onecmd'; echo rc=$?"
+    },
+    {
+      "content_hash": "0b029ef160e8bc72",
+      "name": "seto matrix: -o physical",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'physical'; echo rc=$?"
+    },
+    {
+      "content_hash": "107d597ebdf99015",
+      "name": "seto matrix: +o physical",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'physical'; echo rc=$?"
+    },
+    {
+      "content_hash": "da2d04ae72e91102",
+      "name": "seto matrix: -o pipefail",
+      "script": "LC_ALL=C LANG=C set -o 'pipefail'; echo rc=$?"
+    },
+    {
+      "content_hash": "c8b051d26dbfcd38",
+      "name": "seto matrix: +o pipefail",
+      "script": "LC_ALL=C LANG=C set +o 'pipefail'; echo rc=$?"
+    },
+    {
+      "content_hash": "d8f5ab2539604db8",
+      "name": "seto matrix: -o posix",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'posix'; echo rc=$?"
+    },
+    {
+      "content_hash": "8a90b6d614943f90",
+      "name": "seto matrix: +o posix",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'posix'; echo rc=$?"
+    },
+    {
+      "content_hash": "4a3af3659e5cc1be",
+      "name": "seto matrix: -o privileged",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'privileged'; echo rc=$?"
+    },
+    {
+      "content_hash": "a7356f18ba29edac",
+      "name": "seto matrix: +o privileged",
+      "opts": {
+        "known_gap": "JustBash rejects this set -o name; bash accepts it"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'privileged'; echo rc=$?"
+    },
+    {
+      "content_hash": "a8fb795468e17f2b",
+      "name": "seto matrix: -o not-an-option",
+      "opts": {
+        "known_gap": "JustBash names the option in a different word order and exits 1; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'not-an-option'; echo rc=$?"
+    },
+    {
+      "content_hash": "a582042193a91446",
+      "name": "seto matrix: +o not-an-option",
+      "opts": {
+        "known_gap": "JustBash names the option in a different word order and exits 1; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'not-an-option'; echo rc=$?"
+    },
+    {
+      "content_hash": "53bd34daf635c8d5",
+      "name": "seto matrix: -o jb-not-an-option",
+      "opts": {
+        "known_gap": "JustBash names the option in a different word order and exits 1; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'jb-not-an-option'; echo rc=$?"
+    },
+    {
+      "content_hash": "2b26805af90b14c4",
+      "name": "seto matrix: +o jb-not-an-option",
+      "opts": {
+        "known_gap": "JustBash names the option in a different word order and exits 1; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'jb-not-an-option'; echo rc=$?"
+    },
+    {
+      "content_hash": "d5311a0d68adca60",
+      "name": "seto matrix: -o ERREXIT",
+      "opts": {
+        "known_gap": "JustBash names the option in a different word order and exits 1; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C set -o 'ERREXIT'; echo rc=$?"
+    },
+    {
+      "content_hash": "a8ced96d414218e4",
+      "name": "seto matrix: +o ERREXIT",
+      "opts": {
+        "known_gap": "JustBash names the option in a different word order and exits 1; bash exits 2"
+      },
+      "script": "LC_ALL=C LANG=C set +o 'ERREXIT'; echo rc=$?"
+    }
+  ],
+  "suite": "seto_matrix"
+}

--- a/test/fixtures/bash_expected/seto_matrix.json
+++ b/test/fixtures/bash_expected/seto_matrix.json
@@ -1,0 +1,425 @@
+{
+  "results": [
+    {
+      "content_hash": "3115ab7751270d15",
+      "exit_code": 0,
+      "name": "seto matrix: -o allexport",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e6b92512ffd42d65",
+      "exit_code": 0,
+      "name": "seto matrix: +o allexport",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a651c05393f294e2",
+      "exit_code": 0,
+      "name": "seto matrix: -o errexit",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "6f94bed1abbeebba",
+      "exit_code": 0,
+      "name": "seto matrix: +o errexit",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a94c52c0b3a0f87e",
+      "exit_code": 0,
+      "name": "seto matrix: -o ignoreeof",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e52c8da9481a6c06",
+      "exit_code": 0,
+      "name": "seto matrix: +o ignoreeof",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e30828c00141c609",
+      "exit_code": 0,
+      "name": "seto matrix: -o monitor",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "2ded897d750c9464",
+      "exit_code": 0,
+      "name": "seto matrix: +o monitor",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b934358f6044dd18",
+      "exit_code": 0,
+      "name": "seto matrix: -o noclobber",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "0f188f12d5047fb2",
+      "exit_code": 0,
+      "name": "seto matrix: +o noclobber",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "0b0fba31d13addf3",
+      "exit_code": 0,
+      "name": "seto matrix: -o noglob",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e7bb35d195bebbeb",
+      "exit_code": 0,
+      "name": "seto matrix: +o noglob",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "70636fa283a652b9",
+      "exit_code": 0,
+      "name": "seto matrix: -o noexec",
+      "stderr": "",
+      "stdout": ""
+    },
+    {
+      "content_hash": "5f478feeb3f1ed53",
+      "exit_code": 0,
+      "name": "seto matrix: +o noexec",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "768ce60ebf8c09fd",
+      "exit_code": 0,
+      "name": "seto matrix: -o nolog",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "190f605fd430995d",
+      "exit_code": 0,
+      "name": "seto matrix: +o nolog",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "866399b14fc06b48",
+      "exit_code": 0,
+      "name": "seto matrix: -o notify",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a31c8ed814b2a125",
+      "exit_code": 0,
+      "name": "seto matrix: +o notify",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "decaac3252c20aee",
+      "exit_code": 0,
+      "name": "seto matrix: -o nounset",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "df1f66125ca6247c",
+      "exit_code": 0,
+      "name": "seto matrix: +o nounset",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "05d0c4f82fbce7d7",
+      "exit_code": 0,
+      "name": "seto matrix: -o verbose",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "0385b0f26f774708",
+      "exit_code": 0,
+      "name": "seto matrix: +o verbose",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "c60921b8c771941b",
+      "exit_code": 0,
+      "name": "seto matrix: -o vi",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "d0d0c0a0d11dcc74",
+      "exit_code": 0,
+      "name": "seto matrix: +o vi",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "7690605827846e5a",
+      "exit_code": 0,
+      "name": "seto matrix: -o xtrace",
+      "stderr": "+ echo rc=0\n",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "b2ea5f8fa1786c19",
+      "exit_code": 0,
+      "name": "seto matrix: +o xtrace",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "f12aa522f427233d",
+      "exit_code": 0,
+      "name": "seto matrix: -o braceexpand",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "79d4d26a1dd3ed60",
+      "exit_code": 0,
+      "name": "seto matrix: +o braceexpand",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "e20852247f6ac779",
+      "exit_code": 0,
+      "name": "seto matrix: -o emacs",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "8feed1c5085c0bc2",
+      "exit_code": 0,
+      "name": "seto matrix: +o emacs",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "7384bd0b0df8c613",
+      "exit_code": 0,
+      "name": "seto matrix: -o errtrace",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "75ab80b807222856",
+      "exit_code": 0,
+      "name": "seto matrix: +o errtrace",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a339abcc167e59de",
+      "exit_code": 0,
+      "name": "seto matrix: -o functrace",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "fe242c7376302c2e",
+      "exit_code": 0,
+      "name": "seto matrix: +o functrace",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "58585997fa5c326d",
+      "exit_code": 0,
+      "name": "seto matrix: -o hashall",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "46fad353ef177ecf",
+      "exit_code": 0,
+      "name": "seto matrix: +o hashall",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "1a7fef5be7042a75",
+      "exit_code": 0,
+      "name": "seto matrix: -o histexpand",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "9977c46021c44e57",
+      "exit_code": 0,
+      "name": "seto matrix: +o histexpand",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a0312be545a218b7",
+      "exit_code": 0,
+      "name": "seto matrix: -o history",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "75f6192f3e8fe94b",
+      "exit_code": 0,
+      "name": "seto matrix: +o history",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "1c3ba1dc4c6191fd",
+      "exit_code": 0,
+      "name": "seto matrix: -o interactive-comments",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "747a71abf6eec55b",
+      "exit_code": 0,
+      "name": "seto matrix: +o interactive-comments",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "3a30e2613a9efd7f",
+      "exit_code": 0,
+      "name": "seto matrix: -o keyword",
+      "stderr": "",
+      "stdout": "\n"
+    },
+    {
+      "content_hash": "ec822441cf746b10",
+      "exit_code": 0,
+      "name": "seto matrix: +o keyword",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "ac4e2514e7816b22",
+      "exit_code": 0,
+      "name": "seto matrix: -o onecmd",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "de230f44ed5e917d",
+      "exit_code": 0,
+      "name": "seto matrix: +o onecmd",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "0b029ef160e8bc72",
+      "exit_code": 0,
+      "name": "seto matrix: -o physical",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "107d597ebdf99015",
+      "exit_code": 0,
+      "name": "seto matrix: +o physical",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "da2d04ae72e91102",
+      "exit_code": 0,
+      "name": "seto matrix: -o pipefail",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "c8b051d26dbfcd38",
+      "exit_code": 0,
+      "name": "seto matrix: +o pipefail",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "d8f5ab2539604db8",
+      "exit_code": 0,
+      "name": "seto matrix: -o posix",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "8a90b6d614943f90",
+      "exit_code": 0,
+      "name": "seto matrix: +o posix",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "4a3af3659e5cc1be",
+      "exit_code": 0,
+      "name": "seto matrix: -o privileged",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a7356f18ba29edac",
+      "exit_code": 0,
+      "name": "seto matrix: +o privileged",
+      "stderr": "",
+      "stdout": "rc=0\n"
+    },
+    {
+      "content_hash": "a8fb795468e17f2b",
+      "exit_code": 0,
+      "name": "seto matrix: -o not-an-option",
+      "stderr": "bash: line 1: set: not-an-option: invalid option name\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "a582042193a91446",
+      "exit_code": 0,
+      "name": "seto matrix: +o not-an-option",
+      "stderr": "bash: line 1: set: not-an-option: invalid option name\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "53bd34daf635c8d5",
+      "exit_code": 0,
+      "name": "seto matrix: -o jb-not-an-option",
+      "stderr": "bash: line 1: set: jb-not-an-option: invalid option name\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "2b26805af90b14c4",
+      "exit_code": 0,
+      "name": "seto matrix: +o jb-not-an-option",
+      "stderr": "bash: line 1: set: jb-not-an-option: invalid option name\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "d5311a0d68adca60",
+      "exit_code": 0,
+      "name": "seto matrix: -o ERREXIT",
+      "stderr": "bash: line 1: set: ERREXIT: invalid option name\n",
+      "stdout": "rc=2\n"
+    },
+    {
+      "content_hash": "a8ced96d414218e4",
+      "exit_code": 0,
+      "name": "seto matrix: +o ERREXIT",
+      "stderr": "bash: line 1: set: ERREXIT: invalid option name\n",
+      "stdout": "rc=2\n"
+    }
+  ],
+  "suite": "seto_matrix"
+}

--- a/test/mix/tasks/bash_fixtures_gen_test.exs
+++ b/test/mix/tasks/bash_fixtures_gen_test.exs
@@ -297,6 +297,99 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
     end
   end
 
+  describe "seto matrix" do
+    test "enumerates every POSIX and bash set -o name, not a sample" do
+      cases = Gen.cases_for("seto")
+      names = Enum.map(cases, & &1["name"])
+
+      posix = Gen.seto_posix()
+      bash_extra = Gen.seto_bash()
+      unknown = Gen.seto_unknown()
+
+      assert posix ++ bash_extra == Enum.uniq(posix ++ bash_extra)
+      assert length(posix) + length(bash_extra) == 27
+      assert length(cases) == (length(posix) + length(bash_extra) + length(unknown)) * 2
+
+      for opt <- posix ++ bash_extra ++ unknown, sign <- ["-o", "+o"] do
+        assert Enum.any?(names, &(&1 == "seto matrix: #{sign} #{opt}")),
+               "missing #{sign} #{opt}"
+      end
+    end
+
+    test "covers both -o and +o so enable vs disable cannot hide" do
+      names = Gen.cases_for("seto") |> Enum.map(& &1["name"])
+
+      assert Enum.any?(names, &(&1 == "seto matrix: -o errexit"))
+      assert Enum.any?(names, &(&1 == "seto matrix: +o errexit"))
+      assert Enum.any?(names, &(&1 == "seto matrix: -o pipefail"))
+      assert Enum.any?(names, &(&1 == "seto matrix: +o pipefail"))
+      assert Enum.any?(names, &(&1 == "seto matrix: -o noglob"))
+      assert Enum.any?(names, &(&1 == "seto matrix: +o noglob"))
+    end
+
+    test "every Set.option_names/0 name is in the alphabet and generated unmarked" do
+      alias JustBash.Commands.Set
+
+      supported = Set.option_names()
+      alphabet = Gen.seto_posix() ++ Gen.seto_bash()
+      cases = Gen.cases_for("seto")
+
+      assert Enum.sort(Gen.seto_supported()) == Enum.sort(supported)
+      assert supported -- alphabet == []
+      assert supported != []
+
+      Enum.each(supported, fn name ->
+        for sign <- ["-o", "+o"] do
+          test_case = Enum.find(cases, &(&1["name"] == "seto matrix: #{sign} #{name}"))
+          assert test_case, "missing #{sign} #{name}"
+          refute get_in(test_case, ["opts", "known_gap"]), "#{sign} #{name} was marked a gap"
+        end
+      end)
+    end
+
+    test "records unknown and unsupported names instead of omitting them" do
+      cases = Gen.cases_for("seto")
+      names = Enum.map(cases, & &1["name"])
+
+      assert Enum.any?(names, &(&1 == "seto matrix: -o not-an-option"))
+      assert Enum.any?(names, &(&1 == "seto matrix: +o jb-not-an-option"))
+      assert Enum.any?(names, &(&1 == "seto matrix: -o ERREXIT"))
+      assert Enum.any?(names, &(&1 == "seto matrix: -o noglob"))
+      assert Enum.any?(names, &(&1 == "seto matrix: -o posix"))
+
+      noglob = Enum.find(cases, &(&1["name"] == "seto matrix: -o noglob"))
+      assert noglob["opts"]["known_gap"] =~ "rejects this set -o name"
+
+      unknown = Enum.find(cases, &(&1["name"] == "seto matrix: -o not-an-option"))
+      assert unknown["opts"]["known_gap"] =~ "exits 1"
+    end
+
+    test "every case hashes from its script, not its name or gap" do
+      cases = Gen.cases_for("seto")
+
+      Enum.each(cases, fn test_case ->
+        assert test_case["content_hash"] == JustBash.Fixtures.hash_case(test_case)
+      end)
+    end
+
+    test "known_gap lives in opts and does not change the digest" do
+      cases = Gen.cases_for("seto")
+      gapped = Enum.filter(cases, &get_in(&1, ["opts", "known_gap"]))
+
+      assert length(gapped) > 10
+      assert length(gapped) < length(cases)
+
+      Enum.each(gapped, fn test_case ->
+        reason = test_case["opts"]["known_gap"]
+        assert is_binary(reason)
+        assert String.length(reason) > 10
+
+        assert JustBash.Fixtures.hash_case(test_case) ==
+                 JustBash.Fixtures.hash_case(Map.delete(test_case, "opts"))
+      end)
+    end
+  end
+
   describe "run/1" do
     test "printf --dry-run reports a count and writes nothing" do
       output =
@@ -335,6 +428,16 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
         end)
 
       assert output =~ ~r/flags_matrix: \d+ cases/
+      refute output =~ "wrote"
+    end
+
+    test "seto --dry-run reports a count and writes nothing" do
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          Mix.Task.rerun("bash_fixtures.gen", ["seto", "--dry-run"])
+        end)
+
+      assert output =~ ~r/seto_matrix: \d+ cases/
       refute output =~ "wrote"
     end
 

--- a/test/mix/tasks/bash_fixtures_gen_test.exs
+++ b/test/mix/tasks/bash_fixtures_gen_test.exs
@@ -336,7 +336,7 @@ defmodule Mix.Tasks.BashFixtures.GenTest do
 
       assert Enum.sort(Gen.seto_supported()) == Enum.sort(supported)
       assert supported -- alphabet == []
-      assert supported != []
+      assert "errexit" in supported
 
       Enum.each(supported, fn name ->
         for sign <- ["-o", "+o"] do


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #70 item 2 for the **`set -o` / `+o` name alphabet only**: a generated `seto_matrix` suite in the same generate / record / test path as `date_matrix`, `printf_matrix`, `test_matrix`, `varop_matrix`, and `flags_matrix`.

This is not the short-option cluster (`-euo`), `set -o` with no name (that lists every option), the item-3 filesystem-shape × command cube, Oils activation, or CI topology. It does not implement missing options.

## What was enumerated

`mix bash_fixtures.gen seto` writes **60** cases (13 POSIX names + 14 bash extras + 3 unknown names) × `{ -o, +o }`. Completeness is `JustBash.Commands.Set.option_names/0` (`errexit`, `nounset`, `pipefail`): a newly implemented name that is not in the POSIX/bash alphabet fails generation, and every such name is generated unmarked.

- POSIX: `allexport` `errexit` `ignoreeof` `monitor` `noclobber` `noglob` `noexec` `nolog` `notify` `nounset` `verbose` `vi` `xtrace`
- Bash extras: `braceexpand` `emacs` `errtrace` `functrace` `hashall` `histexpand` `history` `interactive-comments` `keyword` `onecmd` `physical` `pipefail` `posix` `privileged`
- Unknown (bash itself refuses): `not-an-option` `jb-not-an-option` `ERREXIT` (case trap)
- Scripts are `LC_ALL=C LANG=C set ±o 'name'; echo rc=$?` so a wrong exit code is a stdout difference too. Names are quoted so a future unknown stays data.

`mix bash_fixtures.gen seto --dry-run` reports `seto_matrix: 60 cases`. `mix bash_fixtures.gen` now generates date, printf, test, varop, flags, and seto.

## Recording

Docker was not available on the agent VM. Oracle output was recorded with the same `test/fixtures/runner.sh` the Docker task runs, under GNU bash 5.2.21 / Ubuntu 24.04 (uid `ubuntu`, not root), then pretty-printed through `Mix.Tasks.BashFixtures.write_json!/2`:

```bash
mix bash_fixtures.gen seto
bash test/fixtures/runner.sh < test/fixtures/bash_cases/seto_matrix.json > /tmp/seto_matrix_raw.json
# then Jason-pretty-print + Fixtures.validate, as `mix bash_fixtures` does
```

To re-record through Docker when it is available:

```bash
mix bash_fixtures seto_matrix
```

## Known gaps (54 of 60)

No cell was omitted. Divergences are `opts.known_gap` (excluded from the digest). The fixture runner still executes them with the assertion inverted.

6 cells match bash unmarked: `errexit`, `nounset`, `pipefail` (both `-o` and `+o`).

| Count | Reason |
|------:|--------|
| 48 | JustBash rejects a real POSIX/bash name; bash accepts it |
| 6 | Unknown name: JustBash wording/order differs and `rc=1`; bash exits 2 |

JustBash.exec/2 did not raise on any cell. No missing `set -o` options were implemented in this PR — it is the enumeration + harness.

## Cheap follow-ups the matrix now makes un-skippable

- Accept (or implement) the remaining POSIX names agents actually write: `noglob`, `noclobber`, `allexport`, `xtrace`/`verbose`
- Align unknown-name refusal with bash (`name: invalid option name`, exit 2)
- `set -o` / `+o` with no name still lists (or dumps `set` commands); out of this alphabet

Not in this PR: `sort -k` / `cut` / `od` / `xxd` alphabets, the item-3 FS-shape × command cube, Oils activation, CI topology changes.

## Tests

All local quality gates passed:

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict` (only the existing intentional `banned_fixture_apply` finding)
- `mix dialyzer` (zero new errors; 13 skipped, same as main)
- `mix test` — 2 doctests, 62 properties, 6877 tests, 0 failures
- `mix test --only suite:seto_matrix` — 60 tests, 0 failures
- `mix bash_fixtures.gen seto --dry-run` — `seto_matrix: 60 cases`
- `mix bash_fixtures.verify seto_matrix` — suite sound

## Related Issues
Related to #70 (item 2, `set -o` name alphabet only; not closing the issue)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Added new tests
- [x] All existing tests pass
- [x] Tested manually (`mix bash_fixtures.gen seto --dry-run`, local runner.sh recording, JustBash vs oracle classification)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have run `mix format`
- [x] I have run `mix credo` and addressed any issues
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG.md (for non-trivial changes)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92cf32dc-ba5f-4400-80d3-87c1b8cab460?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92cf32dc-ba5f-4400-80d3-87c1b8cab460&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

